### PR TITLE
feat: automatic release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,9 +1,9 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '*'
 
 jobs:
   publish:
@@ -39,3 +39,12 @@ jobs:
           npm run build.release
           python -m build
           python -m twine upload dist/*
+
+      - run: cp dist/*.whl .
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body: ${{ github.event.head_commit.message }}
+          files: |
+            *.whl

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish to PyPI
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 jobs:
   publish:


### PR DESCRIPTION
修改 Action 在推送标签后即发布版本到 PyPI，并发布到 Release，然后再手动编辑完善内容。发布后的 Release 如下所示：

<img width="1131" alt="截屏2024-01-14 13 45 58" src="https://github.com/SwanHubX/SwanLab/assets/55043165/b68abb72-d344-49d1-a7cf-77b82eb7369f">

> https://github.com/swpfY/SwanLab/releases/tag/v0.0.12

Closes: #174 