### PR TITLE
Feat/swanlab.config

### DIFF
--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -3,6 +3,7 @@ from .data import (
     init,
     log,
     finish,
+    config,
 )
 from .utils import get_package_version
 

--- a/swanlab/data/__init__.py
+++ b/swanlab/data/__init__.py
@@ -14,4 +14,5 @@ from .sdk import (
     init,
     log,
     finish,
+    config,
 )

--- a/swanlab/data/run/__init__.py
+++ b/swanlab/data/run/__init__.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     在此处导出SwanLabRun类，一次实验运行应该只有一个SwanLabRun实例
 """
-from .main import SwanLabRun, SwanConfig
+from .main import SwanLabRun, SwanLabConfig
 
 
 def register(*args, **kwargs) -> SwanLabRun:

--- a/swanlab/data/run/__init__.py
+++ b/swanlab/data/run/__init__.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     在此处导出SwanLabRun类，一次实验运行应该只有一个SwanLabRun实例
 """
-from .main import SwanLabRun
+from .main import SwanLabRun, SwanConfig
 
 
 def register(*args, **kwargs) -> SwanLabRun:

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -73,24 +73,24 @@ class SwanConfig(Mapping):
         self.__config[name] = value
         self.__save()
 
-    def get(self, name):
+    def get(self, name: str):
         try:
             return self.__config[name]
         except KeyError:
-            raise AttributeError(f"You have not set {name} in the config of the current experiment")
+            raise AttributeError(f"You have not set '{name}' in the config of the current experiment")
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         # 如果类被外部点号调用
         try:
             return self.__config[name]
         except KeyError:
-            raise AttributeError(f"You have not set {name} in the config of the current experiment")
+            raise AttributeError(f"You have not set '{name}' in the config of the current experiment")
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str):
         try:
             return self.__config[name]
         except KeyError:
-            raise AttributeError(f"You have not set {name} in the config of the current experiment")
+            raise AttributeError(f"You have not set '{name}' in the config of the current experiment")
 
     def __save(self):
         """

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -305,6 +305,9 @@ class SwanLabConfig(Mapping):
         """
         return len(self.__config)
 
+    def __str__(self):
+        return str(self.__config)
+
 
 class SwanLabRun:
     """

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -46,7 +46,10 @@ class SwanConfig(Mapping):
         self.__save()
 
     def __check_config(self, config: dict) -> dict:
-        """检查实验配置是否合法"""
+        """
+        检查配置是否合法，确保它可以被 JSON 序列化。
+        如果传入的是 argparse.Namespace 类型，会先转换为字典。
+        """
         if config is None:
             return {}
         # config必须可以被json序列化
@@ -60,26 +63,41 @@ class SwanConfig(Mapping):
         return config
 
     def __setattr__(self, name: str, value: Any) -> None:
+        """
+        自定义属性设置方法。如果属性名不是私有属性，则同时更新配置字典并保存。
+        """
         self.__dict__[name] = value
         if not name.startswith("_" + self.__class__.__name__ + "__"):
             self.__config[name] = value
             self.__save()
 
     def __setitem__(self, name: str, value: Any) -> None:
+        """
+        以字典方式设置配置项的值，并保存。
+        """
         self.__config[name] = value
         self.__save()
 
     def set(self, name: str, value: Any) -> None:
+        """
+        显式设置配置项的值，并保存。
+        """
         self.__config[name] = value
         self.__save()
 
     def get(self, name: str):
+        """
+        获取配置项的值。如果配置项不存在，抛出 AttributeError。
+        """
         try:
             return self.__config[name]
         except KeyError:
             raise AttributeError(f"You have not set '{name}' in the config of the current experiment")
 
     def __getattr__(self, name: str):
+        """
+        如果以点号方式访问属性且属性不存在于类中，尝试从配置字典中获取。
+        """
         # 如果类被外部点号调用
         try:
             return self.__config[name]
@@ -87,6 +105,9 @@ class SwanConfig(Mapping):
             raise AttributeError(f"You have not set '{name}' in the config of the current experiment")
 
     def __getitem__(self, name: str):
+        """
+        以字典方式获取配置项的值。
+        """
         try:
             return self.__config[name]
         except KeyError:
@@ -103,9 +124,15 @@ class SwanConfig(Mapping):
             yaml.dump(config, f)
 
     def __iter__(self):
+        """
+        返回配置字典的迭代器。
+        """
         return iter(self.__config)
 
     def __len__(self):
+        """
+        返回配置项的数量。
+        """
         return len(self.__config)
 
 

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -36,7 +36,7 @@ def need_inited(func):
     """装饰器，用于检查是否已经初始化"""
 
     def wrapper(self, *args, **kwargs):
-        if self._inited is None:
+        if not self._inited:
             raise RuntimeError("You must call swanlab.init() before using swanlab.log")
         return func(self, *args, **kwargs)
 

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -9,7 +9,7 @@ r"""
 """
 import atexit, sys, traceback, os
 from datetime import datetime
-from .run import SwanLabRun, SwanConfig, register
+from .run import SwanLabRun, SwanLabConfig, register
 from typing import Optional, Any
 from ..log import swanlog
 from .modules import DataType
@@ -21,7 +21,7 @@ from ..db import Project, connect
 
 run: Optional["SwanLabRun"] = None
 inited: bool = False
-run_config: Optional["SwanConfig"] = None
+config = SwanLabConfig(None)
 
 
 def init(
@@ -57,7 +57,7 @@ def init(
         If this parameter is not provided, no suffix will be added.
         At present, only 'timestamp' or None is allowed, and other values will be ignored as 'timestamp'.
     """
-    global run, inited, run_config
+    global run, inited
 
     if inited:
         swanlog.warning("You have already initialized a run, the init function will be ignored")
@@ -105,9 +105,6 @@ def init(
     swanlog.info("Run data will be saved locally in " + formate_abs_path(run.settings.run_dir))
     swanlog.info("Experiment_name: " + run.settings.exp_name)
     swanlog.info("Run `swanlab watch` to view SwanLab Experiment Dashboard")
-    inited = True
-    # 同步run.config
-    run_config = run.config
     return run
 
 
@@ -192,66 +189,66 @@ def __except_handler(tp, val, tb):
     raise tp(val)
 
 
-class __Config:
-    """用于swanlab.config能够与run.config同步的类"""
+# class __Config:
+#     """用于swanlab.config能够与run.config同步的类"""
 
-    global run_config
+#     global run_config
 
-    def __check_init__(self):
-        """
-        检查 swanlab.init()是否已经完成。
-        如果没有完成，抛出 RuntimeError 异常。
-        如果完成但 run 为 None，打印error日志。
-        """
-        if not inited:
-            raise RuntimeError("You must call swanlab.data.init() before using swanlab.config")
-        if inited and run is None:
-            return swanlog.error("After calling finish(), you can no longer fetch config to the current experiment")
+#     def __check_init__(self):
+#         """
+#         检查 swanlab.init()是否已经完成。
+#         如果没有完成，抛出 RuntimeError 异常。
+#         如果完成但 run 为 None，打印error日志。
+#         """
+#         if not inited:
+#             raise RuntimeError("You must call swanlab.data.init() before using swanlab.config")
+#         if inited and run is None:
+#             return swanlog.error("After calling finish(), you can no longer fetch config to the current experiment")
 
-    def __setattr__(self, name: str, value: Any) -> None:
-        """
-        自定义属性设置方法。在设置属性之前进行初始化检查。
-        如果属性名称不是以类私有命名开始的，则同步更新 run_config。
-        """
-        self.__check_init__()
-        self.__dict__[name] = value
-        if not name.startswith("_" + self.__class__.__name__ + "__"):
-            run_config.set(name, value)
+#     def __setattr__(self, name: str, value: Any) -> None:
+#         """
+#         自定义属性设置方法。在设置属性之前进行初始化检查。
+#         如果属性名称不是以类私有命名开始的，则同步更新 run_config。
+#         """
+#         self.__check_init__()
+#         self.__dict__[name] = value
+#         if not name.startswith("_" + self.__class__.__name__ + "__"):
+#             run_config.set(name, value)
 
-    def __setitem__(self, name: str, value: Any) -> None:
-        """
-        以字典方式设置config的值。
-        """
-        self.__check_init__()
-        run_config.set(name, value)
+#     def __setitem__(self, name: str, value: Any) -> None:
+#         """
+#         以字典方式设置config的值。
+#         """
+#         self.__check_init__()
+#         run_config.set(name, value)
 
-    def set(self, name: str, value: Any) -> None:
-        """
-        显式设置config的值
-        """
-        self.__check_init__()
-        run_config.set(name, value)
+#     def set(self, name: str, value: Any) -> None:
+#         """
+#         显式设置config的值
+#         """
+#         self.__check_init__()
+#         run_config.set(name, value)
 
-    def get(self, name: str):
-        """
-        获取config对应name的值
-        """
-        self.__check_init__()
-        return run_config.get(name)
+#     def get(self, name: str):
+#         """
+#         获取config对应name的值
+#         """
+#         self.__check_init__()
+#         return run_config.get(name)
 
-    def __getattr__(self, name: str):
-        """
-        以点号方式获取config对应name的值
-        """
-        self.__check_init__()
-        return run_config.get(name)
+#     def __getattr__(self, name: str):
+#         """
+#         以点号方式获取config对应name的值
+#         """
+#         self.__check_init__()
+#         return run_config.get(name)
 
-    def __getitem__(self, name: str):
-        """
-        显式获取config对应name的值
-        """
-        self.__check_init__()
-        return run_config.get(name)
+#     def __getitem__(self, name: str):
+#         """
+#         显式获取config对应name的值
+#         """
+#         self.__check_init__()
+#         return run_config.get(name)
 
 
-config = __Config()
+# config = __Config()

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -198,34 +198,58 @@ class __Config:
     global run_config
 
     def __check_init__(self):
+        """
+        检查 swanlab.init()是否已经完成。
+        如果没有完成，抛出 RuntimeError 异常。
+        如果完成但 run 为 None，打印error日志。
+        """
         if not inited:
             raise RuntimeError("You must call swanlab.data.init() before using swanlab.config")
         if inited and run is None:
             return swanlog.error("After calling finish(), you can no longer fetch config to the current experiment")
 
     def __setattr__(self, name: str, value: Any) -> None:
+        """
+        自定义属性设置方法。在设置属性之前进行初始化检查。
+        如果属性名称不是以类私有命名开始的，则同步更新 run_config。
+        """
         self.__check_init__()
         self.__dict__[name] = value
         if not name.startswith("_" + self.__class__.__name__ + "__"):
             run_config.set(name, value)
 
     def __setitem__(self, name: str, value: Any) -> None:
+        """
+        以字典方式设置config的值。
+        """
         self.__check_init__()
         run_config.set(name, value)
 
     def set(self, name: str, value: Any) -> None:
+        """
+        显式设置config的值
+        """
         self.__check_init__()
         run_config.set(name, value)
 
     def get(self, name: str):
+        """
+        获取config对应name的值
+        """
         self.__check_init__()
         return run_config.get(name)
 
     def __getattr__(self, name: str):
+        """
+        以点号方式获取config对应name的值
+        """
         self.__check_init__()
         return run_config.get(name)
 
     def __getitem__(self, name: str):
+        """
+        显式获取config对应name的值
+        """
         self.__check_init__()
         return run_config.get(name)
 

--- a/swanlab/data/settings.py
+++ b/swanlab/data/settings.py
@@ -93,6 +93,8 @@ class SwanDataSettings:
     @property
     def files_dir(self) -> str:
         """实验配置信息路径"""
+        path = os.path.join(self.run_dir, "files")
+        os.makedirs(path, exist_ok=True)
         return os.path.join(self.run_dir, "files")
 
     @property


### PR DESCRIPTION
Add new features: swanlab.config, support the following use cases:

```python
import swanlab

# 初始化测试, swanlab.config不应早于swanlab.init
# [swanlab.config.lr](http://swanlab.config.lr/) = 1

run = swanlab.init(config={"lr": 1})

# 同步性check
print("同步性check: ")
print(type(run.config))
print(type(swanlab.config))

# 读数据（三种方式）
print("读数据（三种方式）: ")
print([swanlab.config.lr](http://swanlab.config.lr/))
print(swanlab.config["lr"])
print(swanlab.config.get("lr"))

# 读数据（同步性
print("读数据（同步性）: ")
print([run.config.lr](http://run.config.lr/))
print([swanlab.config.lr](http://swanlab.config.lr/))

# 写数据 & 同步性验证（三种方式）
print("写数据 & 同步性验证（三种方式）: ")
[run.config.lr](http://run.config.lr/) = 2
swanlab.config.set("epoch", 20)
run.config["acc"] = 100
print([swanlab.config.lr](http://swanlab.config.lr/))
print(run.config.epoch)
print(swanlab.config.acc)
```
