### PR TITLE
fix: time format

### DIFF
--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -167,7 +167,7 @@ class Consoler(sys.stdout.__class__, LeverCtl):
                 message = str(self.__sum) + " " + FONT.clear(message)
             else:
                 message = FONT.clear(message)
-        # 如果是一个不带换行的字符串，需要判断一下前一个message是否带有换行
+        # 如果是一个头尾不带换行的字符串，需要判断一下前一个message是否带有换行
         else:
             if self.__previous_message.endswith("\n"):
                 self.__sum += 1

--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -157,16 +157,35 @@ class Consoler(sys.stdout.__class__, LeverCtl):
             self.__sum += 1
             message = str(self.__sum) + " " + FONT.clear(message)
             self.__previous_message = ""
-        # 如果直接就是换行，什么都不做
+        # 如果直接就是换行
         elif message == "\n":
-            pass
-        # 如果以换行符结尾，那么是一个正常的 print 打印，正常处理和输出，单独占一行
-        elif message.endswith("\n"):
+            # 上一个消息也是以 \n 结尾
             if self.__previous_message.endswith("\n"):
                 self.__sum += 1
-                message = str(self.__sum) + " " + FONT.clear(message)
-            else:
-                message = FONT.clear(message)
+                message = str(self.__sum) + " \n"
+        # 如果在字符串含有 \n
+        elif "\n" in message:
+            # 通过 \n 切割字符串
+            messages = FONT.clear(message).split("\n")
+            for index, msg in enumerate(messages):
+                # 两种情况不需要处理
+                # 为第一个子串，且上一条消息不是以换行结尾，那么不需要添加行号
+                # 为最后一个子串，且该子串为空，那么不需要添加行号
+                if (index == 0 and not self.__previous_message.endswith("\n")) or (
+                    index == len(messages) - 1 and msg == ""
+                ):
+                    pass
+                # 该字串需要单独一行展示，则添加行号
+                else:
+                    self.__sum += 1
+                    msg = str(self.__sum) + " " + msg
+                # 如果最后为空，说明原串以 \n 结尾，略过
+                if index == len(messages) - 1 and msg == "":
+                    pass
+                else:
+                    self.console.write(msg + "\n")
+            self.__previous_message = FONT.clear(message)
+            return self.console.flush()
         # 如果是一个头尾不带换行的字符串，需要判断一下前一个message是否带有换行
         else:
             if self.__previous_message.endswith("\n"):

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -389,7 +389,8 @@ def get_recent_logs(experiment_id):
     # # current_page = total
     for index, f in enumerate(consoles, start=1):
         with open(os.path.join(console_path, f), mode="r", encoding="utf-8") as log:
-            logs.extend(log.read().split("\n"))
+            # logs.extend(log.read().split("\n"))
+            logs = log.read().split("\n") + logs
             # 如果当前收集到的数据超过限制，退出循环
             if len(logs) >= MAX_NUM:
                 # current_page = index
@@ -398,7 +399,7 @@ def get_recent_logs(experiment_id):
     if logs[0] == "":
         return NOT_FOUND_404("No Logs Found")
 
-    logs = logs[:100]
+    logs = logs[:MAX_NUM]
     end = (logs[-1] if not logs[-1] == "" else logs[-2]).split(" ")[0]
     data = {
         "recent": [logs[0].split(" ")[0], end],

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -374,9 +374,12 @@ def get_recent_logs(experiment_id):
             error = f.read().split("\n")
         # 在consoles里删除error.log
         consoles.remove("error.log")
-    # 没有日志
-    if len(consoles) == 0:
+    # 没有日志，也没有错误日志
+    if len(consoles) == 0 and error is None:
         return NOT_FOUND_404("No Logs Found")
+    # 如果只有错误日志，直接返回
+    elif len(consoles) == 0 and error is None:
+        return SUCCESS_200({"error": error})
 
     total: int = len(consoles)
     # # 如果 total 大于 1, 按照时间排序
@@ -395,7 +398,7 @@ def get_recent_logs(experiment_id):
     if logs[0] == "":
         return NOT_FOUND_404("No Logs Found")
 
-    logs = logs[:MAX_NUM]
+    logs = logs[:100]
     end = (logs[-1] if not logs[-1] == "" else logs[-2]).split(" ")[0]
     data = {
         "recent": [logs[0].split(" ")[0], end],

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -11,7 +11,7 @@ r"""
 import os
 import ujson
 import shutil
-import datetime
+from datetime import datetime
 from ..module.resp import SUCCESS_200, DATA_ERROR_500, CONFLICT_409, NOT_FOUND_404
 from fastapi import Request
 from urllib.parse import quote

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -381,7 +381,7 @@ def get_recent_logs(experiment_id):
     if len(consoles) == 0 and error is None:
         return NOT_FOUND_404("No Logs Found")
     # 如果只有错误日志，直接返回
-    elif len(consoles) == 0 and error is None:
+    elif len(consoles) == 0 and error:
         return SUCCESS_200({"error": error})
 
     total: int = len(consoles)

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -366,6 +366,9 @@ def get_recent_logs(experiment_id):
     """
 
     console_path: str = __get_console_dir_by_id(experiment_id)
+    # 是否存在
+    if not os.path.exists(console_path):
+        return NOT_FOUND_404("Log Folder not Found")
     consoles: list = [f for f in os.listdir(console_path)]
     # 含有error.log，在返回值中带上其中的错误信息
     error = None

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -389,7 +389,6 @@ def get_recent_logs(experiment_id):
     # # current_page = total
     for index, f in enumerate(consoles, start=1):
         with open(os.path.join(console_path, f), mode="r", encoding="utf-8") as log:
-            # logs.extend(log.read().split("\n"))
             logs = log.read().split("\n") + logs
             # 如果当前收集到的数据超过限制，退出循环
             if len(logs) >= MAX_NUM:

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -391,6 +391,10 @@ def get_recent_logs(experiment_id):
             if len(logs) >= MAX_NUM:
                 # current_page = index
                 break
+    # 如果 logs 内容为空
+    if logs[0] == "":
+        return NOT_FOUND_404("No Logs Found")
+
     logs = logs[:MAX_NUM]
     end = (logs[-1] if not logs[-1] == "" else logs[-2]).split(" ")[0]
     data = {

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -374,6 +374,10 @@ def get_recent_logs(experiment_id):
             error = f.read().split("\n")
         # 在consoles里删除error.log
         consoles.remove("error.log")
+    # 没有日志
+    if len(consoles) == 0:
+        return NOT_FOUND_404("No Logs Found")
+
     total: int = len(consoles)
     # # 如果 total 大于 1, 按照时间排序
     if total > 1:

--- a/test/_server.py
+++ b/test/_server.py
@@ -1,3 +1,7 @@
+# from swanlab.env import ROOT
+# import os
+
+# os.environ[ROOT] = "/Users/likang/Code/swanhub-dev/swanlab/test/experiments"
 from swanlab.db import connect
 from swanlab.server.app import app
 

--- a/vue/src/layouts/ExperimentLayout.vue
+++ b/vue/src/layouts/ExperimentLayout.vue
@@ -128,7 +128,7 @@ const navs = [
   }
 }
 .experiment-description {
-  @apply mt-3.5 w-full break-words text-sm text-dimmer;
+  @apply mt-3 w-full break-words text-sm text-dimmer;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   overflow: hidden;
@@ -136,7 +136,7 @@ const navs = [
 }
 
 .experiment-navs {
-  @apply flex items-center gap-8 mt-6 w-full overflow-x-auto overflow-y-visible;
+  @apply flex items-center gap-8 mt-3 w-full overflow-x-auto overflow-y-visible;
   // 隐藏滚动条
   &::-webkit-scrollbar {
     display: none;

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -31,7 +31,7 @@
         <!-- 错误日志 -->
         <div class="log-line text-negative-default" v-for="(line, index) in errorLogs" :key="line">
           <!-- 行数 -->
-          <span class="w-8 text-right flex-shrink-0 select-none">{{ lines.length + index + 1 }}</span>
+          <span class="w-8 text-right flex-shrink-0 select-none">{{ lastLineIndex + index + 1 }}</span>
           <!-- 日志内容 -->
           <span>{{ line }}</span>
         </div>
@@ -77,18 +77,26 @@ const logs = ref()
 
 // 分开行号和内容之后的日志
 const lines = computed(() => {
-  return logs.value.map((line) => {
+  return logs.value?.map((line) => {
     const noIndex = isNaN(line.substring(0, line.indexOf(' ')))
     const index = noIndex ? null : line.substring(0, line.indexOf(' '))
     const content = noIndex ? line : line.substring(line.indexOf(' ')).trimStart()
     const isTarget = searchValue.value !== '' && content.toLowerCase().includes(searchValue.value)
-
     return {
       isTarget,
       index,
       value: isTarget ? splitStringBySearch(content, searchValue.value) : content
     }
   })
+})
+
+// 正常内容最后一行的行号
+const lastLineIndex = computed(() => {
+  const maxIndex = lines.value?.reduce((max, line) => {
+    if (!line.index) return max
+    return Number(line.index) > Number(max) ? line.index : max
+  }, -Infinity)
+  return Number(maxIndex)
 })
 
 function splitStringBySearch(target, substring) {

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -3,7 +3,7 @@
     <FuncBar
       class="pb-6"
       @input="search"
-      :content="logs?.join('\n')"
+      :content="download"
       :placeholder="$t('experiment.func-bar.placeholder.log')"
       :filename="filename"
       v-if="logs"
@@ -100,6 +100,15 @@ const lastLineIndex = computed(() => {
     return Number(line.index) > Number(max) ? line.index : max
   }, 0)
   return Number(maxIndex)
+})
+
+const download = computed(() => {
+  const log_list = logs.value?.map((log) => {
+    const noIndex = isNaN(log.substring(0, log.indexOf(' ')))
+    return noIndex ? log : log.substring(log.indexOf(' ')).trimStart()
+  })
+
+  return log_list?.join('\n') + errorLogs.value.join('\n')
 })
 
 function splitStringBySearch(target, substring) {

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -36,7 +36,10 @@
           <span>{{ line }}</span>
         </div>
         <!-- 没有日志 -->
-        <div class="w-full py-10 flex flex-col items-center text-lg font-semibold" v-if="logs.length === 0">
+        <div
+          class="w-full py-10 flex flex-col items-center text-lg font-semibold"
+          v-if="logs.length === 0 && errorLogs.length === 0"
+        >
           <SLIcon class="magnifier" icon="search"></SLIcon>
           <span>No Logs</span>
         </div>
@@ -95,7 +98,7 @@ const lastLineIndex = computed(() => {
   const maxIndex = lines.value?.reduce((max, line) => {
     if (!line.index) return max
     return Number(line.index) > Number(max) ? line.index : max
-  }, -Infinity)
+  }, 0)
   return Number(maxIndex)
 })
 
@@ -123,7 +126,7 @@ const errorLogs = ref([])
     return
   })
   // 设置日志
-  logs.value = data.logs
+  logs.value = data.logs || []
   if (data.error) errorLogs.value = data.error
   addTaskToBrowserMainThread(() => {
     // 滚动到底部

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -35,6 +35,11 @@
           <!-- 日志内容 -->
           <span>{{ line }}</span>
         </div>
+        <!-- 没有日志 -->
+        <div class="w-full py-10 flex flex-col items-center text-lg font-semibold">
+          <SLIcon class="magnifier" icon="search"></SLIcon>
+          <span>No Logs</span>
+        </div>
       </div>
       <div class="flex h-full items-center justify-center" v-else>
         <SLLoding />
@@ -100,7 +105,14 @@ function splitStringBySearch(target, substring) {
 const errorLogs = ref([])
 ;(async function () {
   // 获取日志
-  const { data } = await http.get(`/experiment/${id}/recent_log`)
+  const { data } = await http.get(`/experiment/${id}/recent_log`).catch((error) => {
+    if (error.data.code === 3404) {
+      logs.value = []
+    } else {
+      console.error(error)
+    }
+    return
+  })
   // 设置日志
   logs.value = data.logs
   if (data.error) errorLogs.value = data.error
@@ -141,6 +153,31 @@ const filename = 'print.log'
 
   .log-line {
     @apply flex gap-2 whitespace-pre-wrap;
+  }
+}
+
+$duration: 3s;
+
+.magnifier {
+  @apply w-10 h-10;
+  animation: animloader $duration infinite;
+}
+
+@keyframes animloader {
+  0% {
+    transform: translate(-5px, -5px);
+  }
+  25% {
+    transform: translate(-5px, 5px);
+  }
+  50% {
+    transform: translate(5px, 5px);
+  }
+  75% {
+    transform: translate(5px, -5px);
+  }
+  100% {
+    transform: translate(-5px, -5px);
   }
 }
 </style>

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -36,7 +36,7 @@
           <span>{{ line }}</span>
         </div>
         <!-- 没有日志 -->
-        <div class="w-full py-10 flex flex-col items-center text-lg font-semibold">
+        <div class="w-full py-10 flex flex-col items-center text-lg font-semibold" v-if="logs.length === 0">
           <SLIcon class="magnifier" icon="search"></SLIcon>
           <span>No Logs</span>
         </div>

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -137,10 +137,10 @@ const errorLogs = ref([])
   // 设置日志
   logs.value = data.logs || []
   if (data.error) errorLogs.value = data.error
-  addTaskToBrowserMainThread(() => {
-    // 滚动到底部
-    logAreaRef.value.scrollTop = logAreaRef.value.scrollHeight
-  })
+  // addTaskToBrowserMainThread(() => {
+  //   // 滚动到底部
+  //   logAreaRef.value.scrollTop = logAreaRef.value.scrollHeight
+  // })
 })()
 
 // ---------------------------------- 搜索 ----------------------------------

--- a/vue/src/views/experiment/pages/log/LogPage.vue
+++ b/vue/src/views/experiment/pages/log/LogPage.vue
@@ -22,7 +22,7 @@
             <span
               v-for="substring in line.value"
               :key="substring"
-              :class="substring.toLowerCase() === searchValue ? ' bg-warning-dimmest' : ''"
+              :class="{ 'bg-warning-dimmest': substring.toLowerCase() === searchValue }"
             >
               {{ substring }}
             </span>
@@ -31,7 +31,7 @@
         <!-- 错误日志 -->
         <div class="log-line text-negative-default" v-for="(line, index) in errorLogs" :key="line">
           <!-- 行数 -->
-          <span class="w-8 text-right flex-shrink-0 select-none">{{ logs.length + index }}</span>
+          <span class="w-8 text-right flex-shrink-0 select-none">{{ lines.length + index + 1 }}</span>
           <!-- 日志内容 -->
           <span>{{ line }}</span>
         </div>
@@ -78,8 +78,9 @@ const logs = ref()
 // 分开行号和内容之后的日志
 const lines = computed(() => {
   return logs.value.map((line) => {
-    const index = line.substring(0, line.indexOf(' '))
-    const content = line.substring(line.indexOf(' '))
+    const noIndex = isNaN(line.substring(0, line.indexOf(' ')))
+    const index = noIndex ? null : line.substring(0, line.indexOf(' '))
+    const content = noIndex ? line : line.substring(line.indexOf(' ')).trimStart()
     const isTarget = searchValue.value !== '' && content.toLowerCase().includes(searchValue.value)
 
     return {

--- a/vue/src/views/home/HomeView.vue
+++ b/vue/src/views/home/HomeView.vue
@@ -32,7 +32,7 @@
         @update:checked="onlySummary = $event"
         @update:searchText="searchText = $event"
       />
-      <div class="w-full pb-10 flex flex-col overflow-scroll flex-grow basis-0" v-if="tags">
+      <div class="w-full pb-10 flex flex-col overflow-scroll flex-grow basis-0" v-if="tags && init">
         <!-- 实验表格 -->
         <ExprTable sticky-header class="dashboard-table" :column="tableHead" :data="tableBody" last-row-gradient>
           <template v-slot:name="{ row }">
@@ -49,7 +49,12 @@
           </template>
         </ExprTable>
       </div>
-      <EmptyTable v-else-if="experiments.length === 0" />
+      <EmptyTable v-else-if="experiments.length === 0 && init" />
+      <div v-else>
+        <div class="w-full flex" v-for="index in 3" :key="index">
+          <div v-for="i in 5" :key="i" class="skeleton w-full py-3 m-2"></div>
+        </div>
+      </div>
     </div>
   </HomeLayout>
 </template>
@@ -62,7 +67,7 @@
  **/
 import { useProjectStore } from '@swanlab-vue/store'
 import { formatTime } from '@swanlab-vue/utils/time'
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted } from 'vue'
 import SLStatusLabel from '@swanlab-vue/components/SLStatusLabel.vue'
 import ExperimentName from './components/ExperimentName.vue'
 import { transTime, convertUtcToLocal } from '@swanlab-vue/utils/time'
@@ -80,6 +85,15 @@ const experiments = computed(() => {
     return []
   }
   return projectStore.experiments
+})
+
+// ---------------------------------- 图表延迟 ----------------------------------
+
+const init = ref(false)
+onMounted(() => {
+  setTimeout(() => {
+    init.value = true
+  }, 500)
 })
 
 // ---------------------------------- 在此处处理项目创建时间、运行时间和总实验数量 ----------------------------------
@@ -227,5 +241,43 @@ const tableBody = computed(() => {
 }
 .grow {
   @apply text-dimmest;
+}
+
+@-webkit-keyframes skeleton-ani {
+  0% {
+    left: 0;
+  }
+
+  to {
+    left: 100%;
+  }
+}
+
+@keyframes skeleton-ani {
+  0% {
+    left: 0;
+  }
+
+  to {
+    left: 100%;
+  }
+}
+
+.skeleton {
+  background-image: linear-gradient(-45deg, #f5f5f5 40%, #fff 55%, #f5f5f5 63%);
+  list-style: none;
+  background-size: 400% 100%;
+  background-position: 100% 50%;
+  animation: skeleton-animation 2s ease infinite;
+}
+
+@keyframes skeleton-animation {
+  0% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0 50%;
+  }
 }
 </style>


### PR DESCRIPTION
## Description

![image](https://github.com/SwanHubX/SwanLab/assets/74649535/39e83448-a497-4364-ac1e-abbd6806885b)

To get the latest 6000 pieces of data, log files must be sorted by time using `datetime.strptime`.
The point is we should import `datetime` as `from datetime import datetime` instead of `import datetime`.

Closes: #293
