### PR TITLE
Feat/better loggings

### DIFF
--- a/swanlab/data/run/exp.py
+++ b/swanlab/data/run/exp.py
@@ -95,8 +95,6 @@ class SwanLabExp:
             return swanlog.warning(f"Chart {tag} has been marked as error, ignored.")
         # 添加tag信息
         step = tag_obj.add(data, step)
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        swanlog.log(f"{timestamp}  step:{step}  tag:{tag}  value:{str(data)}")
 
 
 class SwanLabTag:

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -439,7 +439,7 @@ class SwanLabRun:
             loggings_json[key] = d
 
         # 将loggings_json的内容以"{key1}:{value1}, {key2}:{value2}, ..."的形式记录到loggings_formatted中
-        # 如果value是数值类型，则保留4位有效数字
+        # 如果value是数值类型，则保留4位小数
         loggings_formatted = ", ".join(
             [
                 "{}:{}".format(key, "{:.4f}".format(value) if isinstance(value, (int, float)) else str(value))

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -427,12 +427,28 @@ class SwanLabRun:
                 )
             )
             step = None
+
+        loggings_json = dict()
         # 遍历data，记录data
         for key in data:
             # 遍历字典的key，记录到本地文件中
             d = data[key]
             # 数据类型的检查将在创建chart配置的时候完成，因为数据类型错误并不会影响实验进行
             self.__exp.add(key=key, data=d, step=step)
+            # 将key, data, step记录到loggings_json中
+            loggings_json[key] = d
+
+        # 将loggings_json的内容以"{key1}:{value1}, {key2}:{value2}, ..."的形式记录到loggings_formatted中
+        # 如果value是数值类型，则保留4位有效数字
+        loggings_formatted = ", ".join(
+            [
+                "{}:{}".format(key, "{:.4f}".format(value) if isinstance(value, (int, float)) else str(value))
+                for key, value in loggings_json.items()
+            ]
+        )
+        # 设置时间戳
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        swanlog.log(f"{loggings_formatted}, time:{timestamp}", header=False)
 
     def success(self):
         """标记实验成功"""

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -124,7 +124,7 @@ def init(
     return run
 
 
-def log(data: Dict[str, DataType], step: int = None, loggings: Optional(bool, list) = None):
+def log(data: Dict[str, DataType], step: int = None, loggings: Optional(bool, dict) = None):
     """
     Log a row of data to the current run.
 
@@ -142,6 +142,12 @@ def log(data: Dict[str, DataType], step: int = None, loggings: Optional(bool, li
         raise RuntimeError("You must call swanlab.data.init() before using log()")
     if inited and run is None:
         return swanlog.error("After calling finish(), you can no longer log data to the current experiment")
+
+    loggings_dict = {
+        "open": None,
+        "prefix": False,
+        "file": False,
+    }
 
     if isinstance(loggings, bool):
         swanlog.set_temporary_logging(loggings)

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -124,7 +124,7 @@ def init(
     return run
 
 
-def log(data: Dict[str, DataType], step: int = None, loggings: bool = None):
+def log(data: Dict[str, DataType], step: int = None, loggings: Optional(bool, list) = None):
     """
     Log a row of data to the current run.
 
@@ -143,7 +143,8 @@ def log(data: Dict[str, DataType], step: int = None, loggings: bool = None):
     if inited and run is None:
         return swanlog.error("After calling finish(), you can no longer log data to the current experiment")
 
-    swanlog.set_temporary_logging(loggings)
+    if isinstance(loggings, bool):
+        swanlog.set_temporary_logging(loggings)
     l = run.log(data, step)
     swanlog.reset_temporary_logging()
     return l

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -330,9 +330,9 @@ class SwanLog(Logsys):
     def __concat_messages(func):
         """装饰器，当传递打印信息有多个时，拼接为一个"""
 
-        def wrapper(self, *args):
+        def wrapper(self, *args, **kwargs):
             message = " ".join(args)
-            return func(self, message)
+            return func(self, message, **kwargs)
 
         return wrapper
 
@@ -362,7 +362,7 @@ class SwanLog(Logsys):
         self.logger.critical(message)
 
     @__concat_messages
-    def log(self, message):
+    def log(self, message, header=True):
         """全局自定义信息打印，级别最高
         临时打印，为 None 的时候无效
         1. 临时凭证为 true，通过
@@ -379,6 +379,8 @@ class SwanLog(Logsys):
             # 别的情况都返回
             return
 
+        if not header:
+            return print(message)
         self.logger.log(self.__LOG_LEVEL["value"], message)
 
     def reset_console(self):


### PR DESCRIPTION
## Description

Close: #308 

修改内容包括：
1. 修改默认打印内容
2. swanlab.log的loggings参数改为logger
3. logger参数可以直接为bool，也可以为dict，dict支持open, subfix, perfix, time这四个配置项

测试代码：
```python
import swanlab
import time
import random
import numpy as np

epochs = 100
lr = 0.01
offset = random.random() / 5

swanlab.init(
    log_level="info",
    config={
        "epochs": epochs,
        "learning_rate": lr,
        "test": 1,
        "verbose": 1,
    },
    logggings=True,
)

for epoch in range(2, epochs):
    acc = 1 - 2**-epoch - random.random() / epoch - offset
    loss = 2**-epoch + random.random() / epoch + offset
    loss2 = 3**-epoch + random.random() / epoch + offset * 3
    swanlab.log(
        {"accuracy": acc * 0.001, "loss": loss, "loss2": loss2},
        logger={
            "prefix": f"[{epoch}/{epochs}] ",
            "subfix": "Hello Word!",
            "time": True,
        },
    )
    time.sleep(0.2)
```
