### PR TITLE
Feature/update-default-exp-suffix

### DIFF
--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -496,29 +496,33 @@ class SwanLabRun:
         experiment_name = "exp" if experiment_name is None else experiment_name
         # 校验实验名称
         experiment_name_checked = check_exp_name_format(experiment_name)
+        # 如果实验名称太长的tip
+        tip = "The experiment name you provided is too long, it has been truncated automatically."
+
         # 如果前后长度不一样，说明实验名称被截断了，提醒
-        if len(experiment_name_checked) != len(experiment_name):
-            swanlog.warning("The experiment name you provided is not valid, it has been truncated automatically.")
+        if len(experiment_name_checked) != len(experiment_name) and suffix is None:
+            swanlog.warning(tip)
 
         # 如果suffix为None, 则不添加后缀，直接返回
         if suffix is None:
             return experiment_name_checked, experiment_name
 
-        # 校验实验名后缀
-        suffix_checked = check_exp_suffix_format(suffix, experiment_name_checked)
-        # 如果前后长度不一样，说明实验名称被截断了，提醒
-        if len(suffix_checked) != len(suffix):
-            swanlog.warning(
-                "The suffix of experiment name you provided is not valid, it has been truncated automatically."
-            )
+        # suffix必须是字符串
+        if not isinstance(suffix, str):
+            raise TypeError("The suffix must be a string, but got {}".format(type(suffix)))
 
         # 如果suffix_checked为default，则设置为默认后缀
-        if suffix_checked.lower().strip() == "default":
+        if suffix.lower().strip() == "default":
             # 添加默认后缀
             default_suffix = "{}_{}".format(datetime.now().strftime("%b%d_%H-%M-%S"), socket.gethostname())
             exp_name = "{}_{}".format(experiment_name_checked, default_suffix)
         else:
-            exp_name = "{}_{}".format(experiment_name_checked, suffix_checked)
+            exp_name = "{}_{}".format(experiment_name_checked, suffix)
+
+        # 校验实验名称，如果实验名称过长，截断
+        experiment_name_checked = check_exp_name_format(exp_name)
+        if len(experiment_name_checked) != len(exp_name):
+            swanlog.warning(tip)
 
         return experiment_name_checked, exp_name
 

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -505,7 +505,7 @@ class SwanLabRun:
             return experiment_name_checked, experiment_name
 
         # 校验实验名后缀
-        suffix_checked = check_exp_suffix_format(suffix)
+        suffix_checked = check_exp_suffix_format(suffix, experiment_name_checked)
         # 如果前后长度不一样，说明实验名称被截断了，提醒
         if len(suffix_checked) != len(suffix):
             swanlog.warning(

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -500,7 +500,7 @@ class SwanLabRun:
         if len(experiment_name_checked) != len(experiment_name):
             swanlog.warning("The experiment name you provided is not valid, it has been truncated automatically.")
 
-        # 如果suffix为None, 则不添加后缀
+        # 如果suffix为None, 则不添加后缀，直接返回
         if suffix is None:
             return experiment_name_checked, experiment_name
 
@@ -540,14 +540,12 @@ class SwanLabRun:
                 exp = Experiment.create(name=exp_name, run_id=self.__run_id, description=description)
                 break
             except ExistedError:
-                if suffix is None:
-                    raise ExistedError(f"Experiment {exp_name} has existed, please try another name.")
                 # 如果suffix名为default，说明是自动生成的后缀，需要重新生成后缀
                 if suffix.lower().strip() == "default":
                     swanlog.debug(f"Experiment {exp_name} has existed, try another name...")
                     time.sleep(0.5)
                     continue
-                # 如果suffix名是其他名称，说明是用户自定义的后缀，则报错
+                # 其他情况下，说明是用户自定义的后缀，需要报错
                 else:
                     raise ExistedError(f"Experiment {exp_name} has existed, please try another name.")
 

--- a/swanlab/data/run/utils.py
+++ b/swanlab/data/run/utils.py
@@ -12,7 +12,6 @@ from ...utils.file import (
     get_a_lock,
     check_exp_name_format,
     check_desc_format,
-    check_exp_suffix_format,
 )
 from ...utils import get_package_version, create_time, generate_color
 import datetime

--- a/swanlab/data/run/utils.py
+++ b/swanlab/data/run/utils.py
@@ -7,7 +7,13 @@ r"""
 @Description:
     运行时工具函数
 """
-from ...utils.file import check_tag_format, get_a_lock, check_exp_name_format, check_desc_format
+from ...utils.file import (
+    check_tag_format,
+    get_a_lock,
+    check_exp_name_format,
+    check_desc_format,
+    check_exp_suffix_format,
+)
 from ...utils import get_package_version, create_time, generate_color
 import datetime
 

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -41,7 +41,7 @@ def init(
     description: str = None,
     config: dict = None,
     logdir: str = None,
-    suffix: str = "timestamp",
+    suffix: str = "default",
     log_level: str = None,
     logggings: bool = False,
 ) -> SwanLabRun:
@@ -66,9 +66,12 @@ def init(
         The directory where the log file is stored, the default is current working directory.
         You can also specify a directory to store the log file, whether using an absolute path or a relative path, but you must ensure that the directory exists.
     suffix : str, optional
-        The suffix of the experiment name, used to distinguish experiments with the same name, the format is yyyy-mm-dd_HH-MM-SS.
-        If this parameter is not provided, no suffix will be added.
-        At present, only 'timestamp' or None is allowed, and other values will be ignored as 'timestamp'.
+        The suffix of the experiment name, the default is 'default'.
+        If this parameter is 'default', suffix will be '%b%d-%h-%m-%s_<hostname>'(example:'Feb03_14-45-37_windowsX'), which represents the current time.
+        example: experiment_name = 'example', suffix = 'default' -> 'example_Feb03_14-45-37_windowsX';
+        If this parameter is None, no suffix will be added.
+        If this paramter is a string, the suffix will be the string you provided.
+        Attention: experiment_name + suffix must be unique, otherwise the experiment will not be created.
     """
     global run, inited
 

--- a/swanlab/utils/file.py
+++ b/swanlab/utils/file.py
@@ -131,7 +131,7 @@ def check_exp_name_format(name: str, auto_cut: bool = True) -> str:
 
 
 def check_exp_suffix_format(suffix: str, auto_cut: bool = True) -> str:
-    """检查实验名格式，必须是0-9a-zA-Z和连字符(_-)，并且不能以连字符(_-)开头或结尾
+    """检查实验名后缀，必须是0-9a-zA-Z和连字符(_-)，并且不能以连字符(_-)开头或结尾
     最大长度为100个字符，一个中文字符算一个字符
 
     Parameters

--- a/swanlab/utils/file.py
+++ b/swanlab/utils/file.py
@@ -130,7 +130,7 @@ def check_exp_name_format(name: str, auto_cut: bool = True) -> str:
     return name
 
 
-def check_exp_suffix_format(suffix: str, auto_cut: bool = True) -> str:
+def check_exp_suffix_format(suffix: str, experiment_name_checked: str, auto_cut: bool = True) -> str:
     """检查实验名后缀，必须是0-9a-zA-Z和连字符(_-)，并且不能以连字符(_-)开头或结尾
     最大长度为100个字符，一个中文字符算一个字符
 
@@ -167,9 +167,9 @@ def check_exp_suffix_format(suffix: str, auto_cut: bool = True) -> str:
             f"suffix: {suffix} is not a valid string, which must be composed of 0-9a-zA-Z _- and / or Chinese characters, and the first character must be 0-9a-zA-Z or Chinese characters"
         )
     # 检查长度
-    if auto_cut and len(suffix) > max_len:
+    if auto_cut and len(experiment_name_checked + "_" + suffix) > max_len:
         suffix = suffix[:max_len]
-    elif not auto_cut and len(suffix) > max_len:
+    elif not auto_cut and len(experiment_name_checked + "_" + suffix) > max_len:
         raise IndexError(f"suffix: {suffix} is too long, which must be less than {max_len} characters")
     return suffix
 

--- a/swanlab/utils/file.py
+++ b/swanlab/utils/file.py
@@ -130,6 +130,50 @@ def check_exp_name_format(name: str, auto_cut: bool = True) -> str:
     return name
 
 
+def check_exp_suffix_format(suffix: str, auto_cut: bool = True) -> str:
+    """检查实验名格式，必须是0-9a-zA-Z和连字符(_-)，并且不能以连字符(_-)开头或结尾
+    最大长度为100个字符，一个中文字符算一个字符
+
+    Parameters
+    ----------
+    name : str
+        待检查的字符串
+    auto_cut : bool, optional
+        如果超出长度，是否自动截断，默认为True
+        如果为False，则超出长度会抛出异常
+
+    Returns
+    -------
+    str
+        检查后的字符串
+
+    Raises
+    ------
+    TypeError
+        name不是字符串，或者name为空字符串
+    ValueError
+        name不符合规定格式
+    IndexError
+        name超出长度
+    """
+    max_len = 100
+    if not isinstance(suffix, str) or suffix == "":
+        raise TypeError(f"suffix: {suffix} is not a string")
+    # 定义正则表达式
+    pattern = re.compile(r"^[0-9a-zA-Z][0-9a-zA-Z_-]*[0-9a-zA-Z]$")
+    # 检查 name 是否符合规定格式
+    if not pattern.match(suffix):
+        raise ValueError(
+            f"suffix: {suffix} is not a valid string, which must be composed of 0-9a-zA-Z _- and / or Chinese characters, and the first character must be 0-9a-zA-Z or Chinese characters"
+        )
+    # 检查长度
+    if auto_cut and len(suffix) > max_len:
+        suffix = suffix[:max_len]
+    elif not auto_cut and len(suffix) > max_len:
+        raise IndexError(f"suffix: {suffix} is too long, which must be less than {max_len} characters")
+    return suffix
+
+
 def check_desc_format(description: str, auto_cut: bool = True):
     """检查实验描述
     不能超过255个字符，可以包含任何字符

--- a/swanlab/utils/file.py
+++ b/swanlab/utils/file.py
@@ -130,50 +130,6 @@ def check_exp_name_format(name: str, auto_cut: bool = True) -> str:
     return name
 
 
-def check_exp_suffix_format(suffix: str, experiment_name_checked: str, auto_cut: bool = True) -> str:
-    """检查实验名后缀，必须是0-9a-zA-Z和连字符(_-)，并且不能以连字符(_-)开头或结尾
-    最大长度为100个字符，一个中文字符算一个字符
-
-    Parameters
-    ----------
-    name : str
-        待检查的字符串
-    auto_cut : bool, optional
-        如果超出长度，是否自动截断，默认为True
-        如果为False，则超出长度会抛出异常
-
-    Returns
-    -------
-    str
-        检查后的字符串
-
-    Raises
-    ------
-    TypeError
-        name不是字符串，或者name为空字符串
-    ValueError
-        name不符合规定格式
-    IndexError
-        name超出长度
-    """
-    max_len = 100
-    if not isinstance(suffix, str) or suffix == "":
-        raise TypeError(f"suffix: {suffix} is not a string")
-    # 定义正则表达式
-    pattern = re.compile(r"^[0-9a-zA-Z][0-9a-zA-Z_-]*[0-9a-zA-Z]$")
-    # 检查 name 是否符合规定格式
-    if not pattern.match(suffix):
-        raise ValueError(
-            f"suffix: {suffix} is not a valid string, which must be composed of 0-9a-zA-Z _- and / or Chinese characters, and the first character must be 0-9a-zA-Z or Chinese characters"
-        )
-    # 检查长度
-    if auto_cut and len(experiment_name_checked + "_" + suffix) > max_len:
-        suffix = suffix[:max_len]
-    elif not auto_cut and len(experiment_name_checked + "_" + suffix) > max_len:
-        raise IndexError(f"suffix: {suffix} is too long, which must be less than {max_len} characters")
-    return suffix
-
-
 def check_desc_format(description: str, auto_cut: bool = True):
     """检查实验描述
     不能超过255个字符，可以包含任何字符


### PR DESCRIPTION
## Description

Close: #219

test code1:
```python
import swanlab

swanlab.init(
    experiment_name="swanlab",
    suffix="default",
)
```

test code2:
```python
swanlab.init(
    experiment_name="swanlab",
    suffix="XDU101",
)
```

test code3:
```python
swanlab.init(
    experiment_name="swanlab",
    suffix=None,
)
```
