### PR TITLE
feat: change experiment's visibility

### DIFF
--- a/swanlab/db/models/experiments.py
+++ b/swanlab/db/models/experiments.py
@@ -85,7 +85,7 @@ class Experiment(SwanModel):
     def __dict__(self):
         return {
             "id": self.id,
-            "project_id": self.project_id,
+            "project_id": self.project_id.__dict__(),
             "run_id": self.run_id,
             "name": self.name,
             "description": self.description,

--- a/swanlab/server/controller/experiment.py
+++ b/swanlab/server/controller/experiment.py
@@ -579,3 +579,33 @@ def get_experiment_requirements(experiment_id: int):
         requirements = f.read()
 
     return SUCCESS_200({"requirements": requirements.split("\n")})
+
+
+# 修改实验是否可见
+def change_experiment_visibility(experiment_id: int, show: bool):
+    """修改实验是否可见
+
+    Parameters
+    ----------
+    experiment_id : int
+        实验id
+    show : bool
+        在多实验对比图表中，该实验是否可见，true -> 1 , false -> 0
+
+    Returns
+    -------
+    experiment : dict
+        当前实验信息
+    """
+
+    try:
+        experiment = Experiment.get_by_id(experiment_id)
+    except NotExistedError:
+        return NOT_FOUND_404("Experiment with id {} does not exist.".format(experiment_id))
+
+    if show:
+        experiment.show = 1
+    else:
+        experiment.show = 0
+    experiment.save()
+    return SUCCESS_200({"experiment": experiment.__dict__()})

--- a/swanlab/server/router/experiment.py
+++ b/swanlab/server/router/experiment.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from ..module.resp import PARAMS_ERROR_422
 
 from ..controller.experiment import (
     # 获取实验信息
@@ -21,6 +22,8 @@ from ..controller.experiment import (
     stop_experiment,
     # 获取实验依赖
     get_experiment_requirements,
+    # 修改实验可见性
+    change_experiment_visibility,
 )
 from fastapi import Request
 from urllib.parse import quote
@@ -192,3 +195,27 @@ def _(experiment_id: int):
     """
 
     return get_experiment_requirements(experiment_id)
+
+
+# 修改实验可见性
+@router.patch("/{experiment_id}/show")
+async def _(experiment_id: int, request: Request):
+    """修改实验是否可见
+
+    Parameters
+    ----------
+    experiment_id : int
+        实验id
+    request : Request
+        请求体，包含 show 字段
+
+    Returns
+    -------
+    experiment : dict
+        当前实验信息
+    """
+
+    show = (await request.json()).get("show")
+    if show is None:
+        return PARAMS_ERROR_422("Request parameter 'show'")
+    return change_experiment_visibility(experiment_id, show)


### PR DESCRIPTION
## Description

![img_v3_027q_82dff606-306f-407c-ab38-b2e26f0cfe8g](https://github.com/SwanHubX/SwanLab/assets/74649535/0d537632-12af-4b85-b044-156d2355225a)

Click to change the visibility of the target experiment in mutiple experiments charts.
