### PR TITLE
bugfix/caption

### DIFF
--- a/swanlab/data/modules/audio.py
+++ b/swanlab/data/modules/audio.py
@@ -54,11 +54,7 @@ class Audio(BaseType):
             else get_file_hash_path(self.audio_data)[:16]
         )
         save_dir = os.path.join(self.settings.static_dir, self.tag)
-        save_name = (
-            f"{self.caption}-step{self.step}-{hash_name}.wav"
-            if self.caption is not None
-            else f"audio-step{self.step}-{hash_name}.wav"
-        )
+        save_name = f"audio-step{self.step}-{hash_name}.wav"
         if not os.path.exists(save_dir):
             os.mkdir(save_dir)
         save_path = os.path.join(save_dir, save_name)
@@ -83,7 +79,7 @@ class Audio(BaseType):
             caption = None
         else:
             raise TypeError("caption must be a string, int or float.")
-        return caption
+        return caption.strip() if caption else None
 
     def __preprocess(self, data_or_path):
         """

--- a/swanlab/data/modules/image.py
+++ b/swanlab/data/modules/image.py
@@ -84,11 +84,7 @@ class Image(BaseType):
         hash_name = get_file_hash_pil(self.image_data)[:16]
         # 设置保存路径, 保存文件名
         save_dir = os.path.join(self.settings.static_dir, self.tag)
-        save_name = (
-            f"{self.caption}-step{self.step}-{hash_name}.{self.format}"
-            if self.caption is not None
-            else f"image-step{self.step}-{hash_name}.{self.format}"
-        )
+        save_name = f"image-step{self.step}-{hash_name}.{self.format}"
         # 如果不存在目录则创建
         if os.path.exists(save_dir) is False:
             os.makedirs(save_dir)
@@ -113,7 +109,7 @@ class Image(BaseType):
             caption = None
         else:
             raise TypeError("caption must be a string, int or float.")
-        return caption
+        return caption.strip() if caption else None
 
     def __convert_boxes(self, boxes):
         """将boxes转换为Dict[str, BoundingBoxes]类型对象, 并返回该对象和总标签"""

--- a/swanlab/data/modules/object_3d.py
+++ b/swanlab/data/modules/object_3d.py
@@ -70,11 +70,7 @@ class Object3D(BaseType):
         )
 
         save_dir = os.path.join(self.settings.static_dir, self.tag)
-        save_name = (
-            f"{self.caption}-step{self.step}-{hash_name}.{self.extension}"
-            if self.caption is not None
-            else f"object3d-step{self.step}-{hash_name}.{self.extension}"
-        )
+        save_name = save_name = f"obj3d-step{self.step}-{hash_name}.{self.format}"
         # 如果不存在目录则创建
         if os.path.exists(save_dir) is False:
             os.makedirs(save_dir)
@@ -135,7 +131,7 @@ class Object3D(BaseType):
             caption = None
         else:
             raise TypeError("caption must be a string, int or float.")
-        return caption
+        return caption.strip() if caption else None
 
     def __save_numpy(self, save_path):
         """保存 numpy.array 格式的 3D点云资源文件 .pts.json 到指定路径"""

--- a/swanlab/data/modules/text.py
+++ b/swanlab/data/modules/text.py
@@ -35,11 +35,7 @@ class Text(BaseType):
 
         # 设置文本数据的保存路径
         save_dir = os.path.join(self.settings.static_dir, self.tag)
-        save_name = (
-            f"{self.caption}-step{self.step}-{hash_name}.txt"
-            if self.caption is not None
-            else f"text-step{self.step}-{hash_name}.txt"
-        )
+        save_name = f"text-step{self.step}-{hash_name}.txt"
 
         # 如果路径不存在，则创建路径
         if not os.path.exists(save_dir):
@@ -88,7 +84,7 @@ class Text(BaseType):
             caption = None
         else:
             raise TypeError("caption must be a string, int or float.")
-        return caption
+        return caption.strip() if caption else None
 
     def get_more(self, *args, **kwargs) -> dict:
         """返回config数据"""

--- a/swanlab/data/modules/video.py
+++ b/swanlab/data/modules/video.py
@@ -78,11 +78,7 @@ class Video(BaseType):
         )
         # 设置视频保存路径, 保存文件名
         save_dir = os.path.join(self.settings.static_dir, self.tag)
-        save_name = (
-            f"{self.caption}-step{self.step}-{hash_name}.{self.format}"
-            if self.caption is not None
-            else f"video-step{self.step}-{hash_name}.{self.format}"
-        )
+        save_name = f"text-step{self.step}-{hash_name}.{self.format}"
         if not os.path.exists(save_dir):
             os.mkdir(save_dir)
         save_path = os.path.join(save_dir, save_name)
@@ -107,7 +103,7 @@ class Video(BaseType):
             caption = None
         else:
             raise TypeError("caption must be a string, int or float.")
-        return caption
+        return caption.strip() if caption else None
 
     def __preprocess(self, data):
         """将不同类型的输入转换为np.ndarray类型"""


### PR DESCRIPTION
之前将caption作为保存的媒体文件名的开头，但caption中可能有很多异常字符或换行符，不能作为操作系统的文件名。
此PR中将其进行修复。