### PR TITLE
Feat/text-chart-csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 .DS_Store
+.eslintrc-auto-import.json

--- a/swanlab/data/modules/text.py
+++ b/swanlab/data/modules/text.py
@@ -37,9 +37,6 @@ class Text(BaseType):
         # 预处理文本数据
         self.__preprocess(self.value)
 
-        # 获取文本的hash值
-        # hash_name = get_text_sha256_hash(self.text_data)[:16]
-
         # 设置文本数据的保存路径
         save_dir = os.path.join(self.settings.static_dir, self.tag)
         save_name = f"text-step{self.step}.csv"


### PR DESCRIPTION
将swanlab.Text的API进行大幅度改进，以支持多列文本的需求。

Close: #433 

API改为：
```python
swanlab.Text(columns=["Input", "Output"], data=[["input1", "output1"], ["input2", "output2"]])
```

- columns为表头，data为表的内容
- columns必须为一维列表，data必须为二维列表。

1. 数据保存为csv文件
2. 不支持swanlab.log({"text": [Text, Text]})这种用法（多列数据用csv即可）