### PR TITLE
Feat/histogram-class

### DIFF
--- a/swanlab/data/__init__.py
+++ b/swanlab/data/__init__.py
@@ -14,6 +14,7 @@ from .modules import (
     Text,
     Video,
     Object3D,
+    Histogram,
 )
 from .sdk import (
     login,

--- a/swanlab/data/modules/__init__.py
+++ b/swanlab/data/modules/__init__.py
@@ -4,6 +4,8 @@ from .image import Image
 from .text import Text
 from .video import Video
 from .object_3d import Object3D
+from .histogram import Histogram
+
 # from .video import Video
 from typing import Protocol, Union, List
 

--- a/swanlab/data/modules/chart.py
+++ b/swanlab/data/modules/chart.py
@@ -24,3 +24,5 @@ class Chart:
     video = "video", [list, str]
     # 3D点云类型，list代表一步多3D点云
     object3d = "object3d", [list, str]
+    # 直方图类型，list代表一步多直方图
+    histogram = "histogram", [list, str]

--- a/swanlab/data/modules/histogram.py
+++ b/swanlab/data/modules/histogram.py
@@ -1,0 +1,92 @@
+import numpy as np
+from PIL import Image as PILImage
+from .base import BaseType
+from ..utils.file import get_file_hash_pil
+from typing import Union, List, Sequence, Tuple
+import os
+
+NumpyHistogram = Tuple[np.ndarray, np.ndarray]
+
+
+class Histogram(BaseType):
+    """
+    swanlab.Histogram 类型的数据，用于记录直方图数据
+
+    """
+
+    def __init__(
+        self,
+        data: Union[Sequence, List["Histogram"]],
+        bins: int = 10,
+        np_histogram: NumpyHistogram = None,
+    ):
+
+        super().__init__(data)
+        # 如果传入的是numpy直方图
+        if np_histogram:
+            if len(np_histogram) == 2:
+                self.histogram = np_histogram[0].tolist() if hasattr(np_histogram[0], "tolist") else np_histogram[0]
+                self.bins = np_histogram[1].tolist() if hasattr(np_histogram[1], "tolist") else np_histogram[1]
+            else:
+                raise ValueError(
+                    "Expected np_histogram to be a tuple of (values, bin_edges) or sequence to be specified"
+                )
+        # 如果传入的是自定义的数据
+        else:
+            self.histogram, self.bins = np.histogram(
+                data,
+                bins=bins,
+            )
+            self.histogram = self.histogram.tolist()
+            self.bins = self.bins.tolist()
+
+        if len(self.histogram) + 1 != len(self.bins):
+            raise ValueError("len(bins) must be len(histogram) + 1")
+
+    def get_data(self):
+        # 如果传入的是Image类列表
+        if isinstance(self.value, list):
+            return self.get_data_list()
+        # 图像预处理
+        self.__preprocess(self.value)
+        # 获取图像的hash值
+        hash_name = get_file_hash_pil(self.image_data)[:16]
+        # 设置保存路径, 保存文件名
+        save_dir = os.path.join(self.settings.static_dir, self.tag)
+        save_name = f"image-step{self.step}-{hash_name}.{self.format}"
+        # 如果不存在目录则创建
+        if os.path.exists(save_dir) is False:
+            os.makedirs(save_dir)
+        save_path = os.path.join(save_dir, save_name)
+        # 保存图像到指定目录
+        self.__save(save_path)
+        return save_name
+
+    def expect_types(self, *args, **kwargs) -> list:
+        return ["Sequence"]
+
+    def __save(self, save_path):
+        """将图像保存到指定路径"""
+        pil_image = self.image_data
+        if not isinstance(pil_image, PILImage.Image):
+            raise TypeError("Invalid image data for the image")
+        try:
+            if self.format == "jpg":
+                pil_image.save(save_path, format="JPEG")
+            else:
+                pil_image.save(save_path, format=self.format)
+
+        except Exception as e:
+            raise TypeError(f"Could not save the image to the path: {save_path}") from e
+
+    def get_more(self, *args, **kwargs) -> dict:
+        """返回config数据"""
+        return None
+
+    def get_namespace(self, *args, **kwargs) -> str:
+        """设定分组名"""
+        return "Histogram"
+
+    def get_chart_type(self) -> str:
+        """设定图表类型"""
+        return self.chart.histogram

--- a/swanlab/data/modules/histogram.py
+++ b/swanlab/data/modules/histogram.py
@@ -81,6 +81,12 @@ class Histogram(BaseType):
         except Exception as e:
             raise TypeError(f"Could not save the table data to the path: {save_path}") from e
 
+    def get_hist(self) -> List:
+        return self.histogram
+
+    def get_bins(self) -> List:
+        return self.bins
+
     def get_more(self, *args, **kwargs) -> dict:
         """返回config数据"""
         return None


### PR DESCRIPTION
`swanlab.Histogram`类，主要用于直方图可视化。

测试代码1：
```python
import swanlab

swanlab.init(cloud=False)

hist = swanlab.Histogram([1, 2, 3], bins=5)

swanlab.log({"hist": hist})
```

测试代码2 - 用np.histogram代入：
```
import swanlab
import numpy as np

swanlab.init(cloud=False)

a = np.random.rand(100, bins=10)

hist = swanlab.Histogram(np_histogram=np.histogram(a, bins=10))

swanlab.log({"hist": hist})
```

swanlab.Histogram会在`swanlog`下创建一个json文件，有`hist`和`bins`两个参数：
- hist代表频数分布，如[1, 0, 2, 0, 5]
- bins代表频率范围，并平均划分了区间，如[0, 0.2, 0.4, 0.6, 0.8, 1.0]


