### PR TITLE
refactor/swanlog

### DIFF
--- a/swanlab/api/auth/login.py
+++ b/swanlab/api/auth/login.py
@@ -13,6 +13,7 @@ from swanlab.error import ValidationError
 from swanlab.utils import FONT
 from swanlab.package import get_user_setting_path, get_host_api
 from swanlab.api.info import LoginInfo
+from swanlab.log import swanlog
 import getpass
 import httpx
 import sys
@@ -70,8 +71,8 @@ def input_api_key(
     _t = sys.excepthook
     sys.excepthook = _abort_tip
     if not again:
-        print(FONT.swanlab("Logging into swanlab cloud."))
-        print(FONT.swanlab("You can find your API key at: " + get_user_setting_path()))
+        swanlog.info("Logging into swanlab cloud.")
+        swanlog.info("You can find your API key at: " + get_user_setting_path())
     key = getpass.getpass(FONT.swanlab(tip))
     sys.excepthook = _t
     return key
@@ -89,7 +90,7 @@ async def code_login(api_key: str) -> LoginInfo:
     tip = "Waiting for the swanlab cloud response."
     login_info: LoginInfo = await FONT.loading(tip, login_by_key(api_key), interval=0.5)
     if login_info.is_fail:
-        print(FONT.swanlab("Login failed: " + str(login_info).lower(), color="red"))
+        swanlog.error("Login failed: " + str(login_info).lower())
         raise ValidationError("Login failed: " + str(login_info))
     return login_info
 
@@ -118,6 +119,6 @@ def terminal_login(api_key: str = None) -> LoginInfo:
 def _abort_tip(tp, val, tb):
     """处理用户在input_api_key输入时按下CTRL+C的情况"""
     if tp == KeyboardInterrupt:
-        print("\n" + FONT.swanlab("Aborted!", color="red"))
+        swanlog.error("Aborted!")
         sys.exit(0)
     # 如果不是CTRL+C，交给默认的异常处理

--- a/swanlab/cloud/start_thread.py
+++ b/swanlab/cloud/start_thread.py
@@ -103,7 +103,7 @@ class ThreadPool:
                      sleep_time: float,
                      task: Callable,
                      args: Tuple[ThreadUtil, ...]
-                     ) -> tuple[AbstractEventLoop, Callable[[], Coroutine[Any, Any, None]]]:
+                     ) -> Tuple[AbstractEventLoop, Callable[[], Coroutine[Any, Any, None]]]:
         """
         创建一个事件循环，循环执行传入线程池的任务
         :param name: 线程名称

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -9,7 +9,7 @@ r"""
 """
 from typing import Any
 from ..settings import SwanDataSettings
-from ...log import register, swanlog
+from ...log import swanlog
 from ..system import get_system_info, get_requirements
 from .utils import (
     check_exp_name_format,
@@ -371,18 +371,14 @@ class SwanLabRun:
         """
         # ---------------------------------- 初始化类内参数 ----------------------------------
         # 生成一个唯一的id，随机生成一个8位的16进制字符串，小写
-        _id = hex(random.randint(0, 2**32 - 1))[2:].zfill(8)
+        _id = hex(random.randint(0, 2 ** 32 - 1))[2:].zfill(8)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.__run_id = "run-{}-{}".format(timestamp, _id)
         # 初始化配置
         self.__settings = SwanDataSettings(run_id=self.__run_id)
         # ---------------------------------- 初始化日志记录器 ----------------------------------
         # output、console_dir等内容不依赖于实验名称的设置
-        register(self.__settings.output_path, self.__settings.console_dir)
-        # 初始化日志等级
-        level = self.__check_log_level(log_level)
-        swanlog.set_level(level)
-
+        swanlog.install(self.__settings.console_dir, self.__check_log_level(log_level))
         # ---------------------------------- 初始化配置 ----------------------------------
         # 给外部1个config
         self.__config = SwanLabConfig(config, self.__settings)

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -216,10 +216,10 @@ def init(
         sniffer = LogSnifferTask(run.settings.files_dir)
         pool.create_thread(sniffer.task, name="sniffer", callback=sniffer.callback)
 
-        def _(message):
+        def _write_call_call(message):
             pool.queue.put((UploadType.LOG, [message]))
 
-        swanlog.write_callback = _
+        swanlog.write_callback = _write_call_call
 
         # FIXME not a good way to mount pool
         run.settings.pool = pool

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -219,7 +219,7 @@ def init(
         def _write_call_call(message):
             pool.queue.put((UploadType.LOG, [message]))
 
-        swanlog.write_callback = _write_call_call
+        swanlog.set_write_callback(_write_call_call)
 
         # FIXME not a good way to mount pool
         run.settings.pool = pool

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -285,8 +285,7 @@ def finish():
         return swanlog.error("After calling finish(), you can no longer close the current experiment")
     # FIXME not a good way to handle this
     run._success()
-    swanlog.set_success()
-    swanlog.reset_console()
+    swanlog.uninstall()
     run.settings.pool and not exit_in_cloud and _before_exit_in_cloud(True)
     run = None
 
@@ -394,7 +393,7 @@ def _clean_handler():
         # FIXME not a good way to handle this
         run._success()
         swanlog.set_success()
-        swanlog.reset_console()
+        swanlog.uninstall()
 
 
 # 定义异常处理函数
@@ -430,6 +429,6 @@ def except_handler(tp, val, tb):
         print(html, file=fError)
     # 重置控制台记录器
     run.settings.pool and not exit_in_cloud and _before_exit_in_cloud(False, error=str(html))
-    swanlog.reset_console()
+    swanlog.uninstall()
     if tp != KeyboardInterrupt:
         raise tp(val)

--- a/swanlab/data/settings.py
+++ b/swanlab/data/settings.py
@@ -106,11 +106,6 @@ class SwanDataSettings:
         return os.path.join(get_swanlog_dir(), self.run_id)
 
     @property
-    def output_path(self) -> str:
-        """输出文件路径"""
-        return os.path.join(self.run_dir, "output.log")
-
-    @property
     def error_path(self) -> str:
         """错误日志文件路径"""
         return os.path.join(self.console_dir, "error.log")

--- a/swanlab/log/__init__.py
+++ b/swanlab/log/__init__.py
@@ -16,4 +16,4 @@ install = swanlog.install
 
 uninstall = swanlog.uninstall
 
-__all__ = ["install", "uninstall", "SwanLog", "swanlog"]
+__all__ = ["install", "uninstall", "swanlog"]

--- a/swanlab/log/__init__.py
+++ b/swanlab/log/__init__.py
@@ -12,30 +12,8 @@ from .log import SwanLog
 
 swanlog: Optional["SwanLog"] = SwanLog("swanlab")
 
+install = swanlog.install
 
-def register(
-    output_path: str = None,
-    console_path: str = None,
-    log_level: str = None,
-    enable_logging: bool = False,
-) -> SwanLog:
-    """注册日志模块
+uninstall = swanlog.uninstall
 
-    Parameters
-    ----------
-    output_path : str
-        输出路径
-    use_console_log : str
-        是否记录控制台打印信息
-    log_level : str
-        日志等级
-    enable_logging : bool
-        是否启用日志
-
-    Returns
-    -------
-    SwanLog
-        初始化后的swanlog对象
-    """
-    swanlog.init(path=output_path, console_path=console_path, level=log_level, enable_logging=enable_logging)
-    return swanlog
+__all__ = ["install", "uninstall", "SwanLog", "swanlog"]

--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -141,7 +141,7 @@ class Consoler(ConsolerParent):
         # 封装一层func，加入epoch处理逻辑
         def _func(message):
             self.__epoch += 1
-            func({"message": FONT.clear(message), "create_time": create_time(), "epoch": self.__epoch})
+            func({"message": message, "create_time": create_time(), "epoch": self.__epoch})
 
         # 封装第二层，加入message处理逻辑以及是否调用逻辑
         def _(message):

--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -75,10 +75,10 @@ class Consoler(ConsolerParent):
         """
         当前正在写入的文件
         """
-        self.__write_callback = None
-        """
-        注入的上传回调函数本体
-        """
+        # self.__write_callback = None
+        # """
+        # 注入的上传回调函数本体
+        # """
         self.write_callback = None
         """
         封装后的上传回调函数
@@ -97,7 +97,7 @@ class Consoler(ConsolerParent):
 
     @property
     def can_callback(self) -> bool:
-        return self.__write_callback is not None
+        return self.write_callback is not None
 
     def init(self, path, stdout):
         self.console_folder = path
@@ -138,7 +138,6 @@ class Consoler(ConsolerParent):
         self.file.flush()
 
     def set_write_callback(self, func):
-
         # 封装一层func，加入epoch处理逻辑
         def _func(message):
             self.__epoch += 1
@@ -191,6 +190,5 @@ class SwanConsoler:
     def write_callback(self):
         return self.consoler.write_callback
 
-    @write_callback.setter
-    def write_callback(self, func):
+    def set_write_callback(self, func):
         self.consoler.set_write_callback(func)

--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -126,7 +126,6 @@ class Consoler(ConsolerParent):
         """
         重写 write 函数，将输出信息写入到控制台和日志文件中
         """
-
         # 先写入原始 sys.stdout，即输出到控制台
         self.stdout.write(message)
         self.stdout.flush()

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -137,9 +137,6 @@ def concat_messages(func):
     return wrapper
 
 
-_ = None
-
-
 class SwanLog(LogSys):
     # 日志系统支持的输出等级
     __levels = {

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -224,9 +224,8 @@ class SwanLog(LogSys):
     def write_callback(self):
         return self.__consoler.write_callback
 
-    @write_callback.setter
-    def write_callback(self, func):
-        self.__consoler.write_callback = func
+    def set_write_callback(self, func):
+        self.__consoler.set_write_callback(func)
 
     @property
     def epoch(self):

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -4,7 +4,6 @@ import logging.handlers
 import sys
 from .console import SwanConsoler
 from swanlab.utils import FONT
-from typing import Union
 
 
 class LogSys:
@@ -200,6 +199,7 @@ class SwanLog(LogSys):
         if console_dir:
             self.debug("Init consoler to record console log")
             self.__consoler.install(console_dir)
+        self.write_callback = None
         return self
 
     def uninstall(self):
@@ -213,8 +213,22 @@ class SwanLog(LogSys):
         self.set_level("info")
         self.__logger.removeHandler(self.__handler)
         self.__handler = None
-
         self.__consoler.uninstall()
+        self.write_callback = None
+
+    @property
+    def write_callback(self):
+        """
+        当swanlog触发日志写入文件的操作时，会调用此函数
+        目前在设计上它与install方法绑定，即install、uninstall以后会设置为None
+        不过uninstall以后也无法触发此函数
+        如果此值为None，那么不会触发回调
+        """
+        return self.__consoler.write_callback
+
+    @write_callback.setter
+    def write_callback(self, callback):
+        self.__consoler.write_callback = callback
 
     @property
     def epoch(self):
@@ -222,9 +236,6 @@ class SwanLog(LogSys):
         获取当前日志的 epoch
         """
         return self.__consoler.consoler.epoch
-
-    def set_pool(self, pool):
-        self.__consoler.consoler.pool = pool
 
     def set_level(self, level):
         """

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -165,6 +165,9 @@ class SwanLog(LogSys):
 
     @property
     def installed(self):
+        """
+        判断日志系统是否已经安装，在设计上__handler随着安装而初始化，所以只要__handler不为空，就表示已经安装
+        """
         return self.__handler is not None
 
     def install(self, console_dir: str = None, log_level: str = None) -> "SwanLog":

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -133,7 +133,7 @@ def concat_messages(func):
         message = " ".join(args)
         can_write = func(self, message, **kwargs)
         if can_write and self.file:
-            message = self.prefix + message + '\n'
+            message = self.prefix + FONT.clear(message) + '\n'
             self.file.write(message)
             self.file.flush()
             self.write_callback and self.write_callback(message)

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -137,6 +137,9 @@ def concat_messages(func):
     return wrapper
 
 
+_ = None
+
+
 class SwanLog(LogSys):
     # 日志系统支持的输出等级
     __levels = {
@@ -205,6 +208,7 @@ class SwanLog(LogSys):
     def uninstall(self):
         """
         卸载日志系统，卸载后需要重新安装
+        在设计上我们并不希望外界乱用这个函数，所以我们不提供外部调用（不在最外层的__all__中）
         """
         if not self.installed:
             raise RuntimeError("SwanLog has not been installed")
@@ -212,6 +216,7 @@ class SwanLog(LogSys):
         self.set_level("info")
         self.__logger.removeHandler(self.__handler)
         self.__handler = None
+
         self.__consoler.uninstall()
 
     @property

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -134,6 +134,7 @@ def concat_messages(func):
         can_write = func(self, message, **kwargs)
         if can_write and self.file:
             self.file.write(message + "\n")
+            self.file.flush()
 
     return wrapper
 

--- a/swanlab/server/__init__.py
+++ b/swanlab/server/__init__.py
@@ -8,12 +8,12 @@ r"""
         在此处引出swanlab的web服务器框架，名为SwanWeb以及一些神奇的路由配置，以完成在库最外层的函数式调用
 """
 from ..env import init_env
-from ..log import register
+from ..log import install
 
 # 在此处完成环境变量的初始化
 init_env()
-# 日志注册
-register()
+# 日志安装
+install()
 
 # 导出app对象
 from .app import app

--- a/swanlab/utils/font.py
+++ b/swanlab/utils/font.py
@@ -11,7 +11,7 @@ r"""
 import sys
 import asyncio
 import re
-from typing import Any, Coroutine
+from typing import Any, Coroutine, Tuple
 
 light_colors = [
     "#528d59",  # 绿色
@@ -38,7 +38,7 @@ COLOR_LIST = {
 }
 
 
-def generate_color(number: int = 1) -> tuple[str | Any, str | Any]:
+def generate_color(number: int = 1):
     """输入数字，在设定好顺序的颜色列表中返回十六进制颜色字符串
 
     Returns

--- a/test/unit/auth/pytest_login.py
+++ b/test/unit/auth/pytest_login.py
@@ -32,14 +32,3 @@ async def test_login_error_key():
     assert login_info.is_fail
     assert login_info.api_key is None
     assert login_info.__str__() == "Error api key"
-
-
-@pytest.mark.asyncio
-async def test_login_no_key():
-    """
-    测试登录失败, 未输入key
-    """
-    login_info = await login_by_key(None, save=False)
-    assert login_info.is_fail
-    assert login_info.api_key is None
-    assert login_info.__str__() == "Error api key"

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -8,20 +8,9 @@ r"""
     配置pytest
 """
 import pytest
-import os
-from tutils.config import TEMP_PATH, SWANLAB_LOG_DIR
-import shutil
-
-# 在整个 pytest 运行之前执行的前置操作
-if os.path.exists(TEMP_PATH):
-    shutil.rmtree(TEMP_PATH)
-os.mkdir(TEMP_PATH)
-os.mkdir(SWANLAB_LOG_DIR)
+from tutils import clear
 
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_before_all():
-    if os.path.exists(TEMP_PATH):
-        shutil.rmtree(TEMP_PATH)
-    os.mkdir(TEMP_PATH)
-    os.mkdir(SWANLAB_LOG_DIR)
+    clear()

--- a/test/unit/log/log.py
+++ b/test/unit/log/log.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2024/4/21 16:57
+@File: log.py
+@IDE: pycharm
+@Description:
+    测试swanlog类
+"""
+import pytest
+from swanlab.log import SwanLog, swanlog
+
+
+class TestSwanLogInstall:
+    def test_install_success(self):
+        lg = SwanLog('tmp')
+        lg.install()
+        assert lg.installed is True
+
+    def test_install_duplicate(self):
+        lg = SwanLog('tmp')
+        lg.install()
+        with pytest.raises(RuntimeError) as e:
+            lg.install()
+        assert str(e.value) == 'SwanLog has been installed'
+
+    def test_global_install(self):
+        swanlog.install()
+        assert swanlog.installed is True
+        with pytest.raises(RuntimeError) as e:
+            swanlog.install()
+        assert str(e.value) == 'SwanLog has been installed'

--- a/test/unit/log/log.py
+++ b/test/unit/log/log.py
@@ -9,6 +9,22 @@ r"""
 """
 import pytest
 from swanlab.log import SwanLog, swanlog
+from tutils import clear, SWANLAB_LOG_DIR
+from nanoid import generate
+import os
+
+
+@pytest.fixture(scope="function", autouse=True)
+def before_test_global_swanlog():
+    """
+    在测试之前清除全局swanlog的状态
+    """
+    try:
+        swanlog.uninstall()
+    except RuntimeError:
+        pass
+    # clear操作需要在uninstall之后
+    clear()
 
 
 class TestSwanLogInstall:
@@ -24,9 +40,42 @@ class TestSwanLogInstall:
             lg.install()
         assert str(e.value) == 'SwanLog has been installed'
 
-    def test_global_install(self):
+    def test_global_install(self, before_test_global_swanlog):
         swanlog.install()
         assert swanlog.installed is True
         with pytest.raises(RuntimeError) as e:
             swanlog.install()
         assert str(e.value) == 'SwanLog has been installed'
+
+    def test_write_to_file(self, before_test_global_swanlog):
+        console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
+        os.mkdir(console_dir)
+        swanlog.install(console_dir)
+        # 加一行防止其他问题
+        print('\ntest write to file')
+        a = generate()
+        print(a)
+        b = generate()
+        print(b)
+        files = os.listdir(console_dir)
+        assert len(files) == 1
+        # 比较最后两行内容
+        with open(os.path.join(console_dir, files[0]), 'r') as f:
+            content = f.readlines()
+            assert content[-2] == a + '\n'
+            assert content[-1] == b + '\n'
+        swanlog.uninstall()
+
+    # def test_write_after_uninstall(self, before_test_global_swanlog):
+    #     console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
+    #     os.mkdir(console_dir)
+    #     swanlog.install(console_dir)
+    #     swanlog.uninstall()
+    #     # 加一行防止其他问题
+    #     print('\ntest write after uninstall')
+    #     a = generate()
+    #     print(a)
+    #     b = generate()
+    #     print(b)
+    #     files = os.listdir(console_dir)
+    #     assert len(files) == 0

--- a/test/unit/log/log.py
+++ b/test/unit/log/log.py
@@ -25,6 +25,7 @@ def before_test_global_swanlog():
         pass
     # clear操作需要在uninstall之后
     clear()
+    yield
 
 
 class TestSwanLogInstall:
@@ -32,7 +33,6 @@ class TestSwanLogInstall:
         lg = SwanLog('tmp')
         lg.install()
         assert lg.installed is True
-        lg.uninstall()
 
     def test_install_duplicate(self):
         lg = SwanLog('tmp')
@@ -40,44 +40,23 @@ class TestSwanLogInstall:
         with pytest.raises(RuntimeError) as e:
             lg.install()
         assert str(e.value) == 'SwanLog has been installed'
-        lg.uninstall()
 
-    def test_global_install(self, before_test_global_swanlog):
-        swanlog.install()
-        assert swanlog.installed is True
-        with pytest.raises(RuntimeError) as e:
-            swanlog.install()
-        assert str(e.value) == 'SwanLog has been installed'
-
-    def test_write_to_file(self, before_test_global_swanlog):
+    def test_write_after_uninstall(self, before_test_global_swanlog):
         console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
         os.mkdir(console_dir)
         swanlog.install(console_dir)
+        swanlog.uninstall()
         # 加一行防止其他问题
-        print('\ntest write to file')
+        import sys
+        # 开启标准输出流
+        sys.stdout = sys.__stdout__
+        print('\ntest write after uninstall')
         a = generate()
         print(a)
         b = generate()
         print(b)
         files = os.listdir(console_dir)
         assert len(files) == 1
-        # 比较最后两行内容
         with open(os.path.join(console_dir, files[0]), 'r') as f:
             content = f.readlines()
-            assert content[-2] == a + '\n'
-            assert content[-1] == b + '\n'
-        swanlog.uninstall()
-
-    # def test_write_after_uninstall(self, before_test_global_swanlog):
-    #     console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
-    #     os.mkdir(console_dir)
-    #     swanlog.install(console_dir)
-    #     swanlog.uninstall()
-    #     # 加一行防止其他问题
-    #     print('\ntest write after uninstall')
-    #     a = generate()
-    #     print(a)
-    #     b = generate()
-    #     print(b)
-    #     files = os.listdir(console_dir)
-    #     assert len(files) == 0
+            assert len(content) == 0

--- a/test/unit/log/log.py
+++ b/test/unit/log/log.py
@@ -8,7 +8,7 @@ r"""
     测试swanlog类
 """
 import pytest
-from swanlab.log import SwanLog, swanlog
+from swanlab.log import swanlog
 from tutils import clear, SWANLAB_LOG_DIR
 from nanoid import generate
 import os
@@ -29,27 +29,39 @@ def before_test_global_swanlog():
 
 
 class TestSwanLogInstall:
-    def test_install_success(self):
-        lg = SwanLog('tmp')
-        lg.install()
-        assert lg.installed is True
+    """
+    目前在设计上不希望外界实例化SwanLog，所以不提供实例化测试
+    """
 
-    def test_install_duplicate(self):
-        lg = SwanLog('tmp')
-        lg.install()
+    # def test_install_success(self):
+    #     lg = SwanLog('tmp')
+    #     lg.install()
+    #     assert lg.installed is True
+    #     lg.uninstall()
+    #
+    # def test_install_duplicate(self):
+    #     lg = SwanLog('tmp')
+    #     lg.install()
+    #     with pytest.raises(RuntimeError) as e:
+    #         lg.install()
+    #     assert str(e.value) == 'SwanLog has been installed'
+
+    def test_global_install(self):
+        swanlog.install()
+        assert swanlog.installed is True
         with pytest.raises(RuntimeError) as e:
-            lg.install()
+            swanlog.install()
         assert str(e.value) == 'SwanLog has been installed'
+        swanlog.uninstall()
+        swanlog.install()
+        assert swanlog.installed is True
 
-    def test_write_after_uninstall(self, before_test_global_swanlog):
+    def test_write_after_uninstall(self):
         console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
         os.mkdir(console_dir)
         swanlog.install(console_dir)
         swanlog.uninstall()
         # 加一行防止其他问题
-        import sys
-        # 开启标准输出流
-        sys.stdout = sys.__stdout__
         print('\ntest write after uninstall')
         a = generate()
         print(a)
@@ -60,3 +72,21 @@ class TestSwanLogInstall:
         with open(os.path.join(console_dir, files[0]), 'r') as f:
             content = f.readlines()
             assert len(content) == 0
+
+    def test_write_to_file(self):
+        console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
+        os.mkdir(console_dir)
+        swanlog.install(console_dir)
+        # 加一行防止其他问题
+        print('\ntest write to file')
+        a = generate()
+        print(a)
+        b = generate()
+        print(b)
+        files = os.listdir(console_dir)
+        assert len(files) == 1
+        # 比较最后两行内容
+        with open(os.path.join(console_dir, files[0]), 'r') as f:
+            content = f.readlines()
+            assert content[-2] == a + '\n'
+            assert content[-1] == b + '\n'

--- a/test/unit/log/log.py
+++ b/test/unit/log/log.py
@@ -32,6 +32,7 @@ class TestSwanLogInstall:
         lg = SwanLog('tmp')
         lg.install()
         assert lg.installed is True
+        lg.uninstall()
 
     def test_install_duplicate(self):
         lg = SwanLog('tmp')
@@ -39,6 +40,7 @@ class TestSwanLogInstall:
         with pytest.raises(RuntimeError) as e:
             lg.install()
         assert str(e.value) == 'SwanLog has been installed'
+        lg.uninstall()
 
     def test_global_install(self, before_test_global_swanlog):
         swanlog.install()

--- a/test/unit/log/pytest_log.py
+++ b/test/unit/log/pytest_log.py
@@ -105,8 +105,8 @@ class TestSwanLogInstall:
         assert len(files) == 1
         with open(os.path.join(console_dir, files[0]), "r") as f:
             content = f.readlines()
-            assert content[-2] == a + "\n"
-            assert content[-1] == b + "\n"
+            assert content[-2] == swanlog.prefix + a + "\n"
+            assert content[-1] == swanlog.prefix + b + "\n"
 
     def test_can_write_logging(self):
         console_dir = os.path.join(SWANLAB_LOG_DIR, "console")
@@ -122,5 +122,5 @@ class TestSwanLogInstall:
         assert len(files) == 1
         with open(os.path.join(console_dir, files[0]), "r") as f:
             content = f.readlines()
-            assert content[-2] != a + "\n"
-            assert content[-1] == b + "\n"
+            assert content[-2] != swanlog.prefix + a + "\n"
+            assert content[-1] == swanlog.prefix + b + "\n"

--- a/test/unit/log/pytest_log.py
+++ b/test/unit/log/pytest_log.py
@@ -38,7 +38,7 @@ class TestSwanLogInstall:
     #     lg.install()
     #     assert lg.installed is True
     #     lg.uninstall()
-    
+
     # def test_install_duplicate(self):
     #     lg = SwanLog('tmp')
     #     lg.install()
@@ -51,34 +51,34 @@ class TestSwanLogInstall:
         assert swanlog.installed is True
         with pytest.raises(RuntimeError) as e:
             swanlog.install()
-        assert str(e.value) == 'SwanLog has been installed'
+        assert str(e.value) == "SwanLog has been installed"
         swanlog.uninstall()
         swanlog.install()
         assert swanlog.installed is True
 
     def test_write_after_uninstall(self):
-        console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
+        console_dir = os.path.join(SWANLAB_LOG_DIR, "console")
         os.mkdir(console_dir)
         swanlog.install(console_dir)
         swanlog.uninstall()
         # 加一行防止其他问题
-        print('\ntest write after uninstall')
+        print("\ntest write after uninstall")
         a = generate()
         print(a)
         b = generate()
         print(b)
         files = os.listdir(console_dir)
         assert len(files) == 1
-        with open(os.path.join(console_dir, files[0]), 'r') as f:
+        with open(os.path.join(console_dir, files[0]), "r") as f:
             content = f.readlines()
             assert len(content) == 0
 
     def test_write_to_file(self):
-        console_dir = os.path.join(SWANLAB_LOG_DIR, 'console')
+        console_dir = os.path.join(SWANLAB_LOG_DIR, "console")
         os.mkdir(console_dir)
         swanlog.install(console_dir)
         # 加一行防止其他问题
-        print('\ntest write to file')
+        print("\ntest write to file")
         a = generate()
         print(a)
         b = generate()
@@ -86,7 +86,41 @@ class TestSwanLogInstall:
         files = os.listdir(console_dir)
         assert len(files) == 1
         # 比较最后两行内容
-        with open(os.path.join(console_dir, files[0]), 'r') as f:
+        with open(os.path.join(console_dir, files[0]), "r") as f:
             content = f.readlines()
-            assert content[-2] == a + '\n'
-            assert content[-1] == b + '\n'
+            assert content[-2] == a + "\n"
+            assert content[-1] == b + "\n"
+
+    def test_write_logging_to_file(self):
+        console_dir = os.path.join(SWANLAB_LOG_DIR, "console")
+        os.mkdir(console_dir)
+        swanlog.install(console_dir, log_level="debug")
+        # 加一行防止其他问题
+        print("\ntest write to file")
+        a = generate()
+        swanlog.debug(a)
+        b = generate()
+        swanlog.info(b)
+        files = os.listdir(console_dir)
+        assert len(files) == 1
+        with open(os.path.join(console_dir, files[0]), "r") as f:
+            content = f.readlines()
+            assert content[-2] == a + "\n"
+            assert content[-1] == b + "\n"
+
+    def test_can_write_logging(self):
+        console_dir = os.path.join(SWANLAB_LOG_DIR, "console")
+        os.mkdir(console_dir)
+        swanlog.install(console_dir)
+        # 加一行防止其他问题
+        print("\ntest write to file")
+        a = generate()
+        swanlog.debug(a)
+        b = generate()
+        swanlog.info(b)
+        files = os.listdir(console_dir)
+        assert len(files) == 1
+        with open(os.path.join(console_dir, files[0]), "r") as f:
+            content = f.readlines()
+            assert content[-2] != a + "\n"
+            assert content[-1] == b + "\n"

--- a/test/unit/log/pytest_log.py
+++ b/test/unit/log/pytest_log.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 r"""
 @DATE: 2024/4/21 16:57
-@File: log.py
+@File: pytest_log.py
 @IDE: pycharm
 @Description:
     测试swanlog类
@@ -38,7 +38,7 @@ class TestSwanLogInstall:
     #     lg.install()
     #     assert lg.installed is True
     #     lg.uninstall()
-    #
+    
     # def test_install_duplicate(self):
     #     lg = SwanLog('tmp')
     #     lg.install()

--- a/tutils/__init__.py
+++ b/tutils/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2024/4/21 17:01
+@File: __init__.py
+@IDE: pycharm
+@Description:
+    tutils模块的初始化文件
+"""
+
+from .config import *
+import shutil
+import os
+
+
+def clear():
+    """
+    清空临时文件夹
+    """
+    if os.path.exists(TEMP_PATH):
+        shutil.rmtree(TEMP_PATH)
+    os.mkdir(TEMP_PATH)
+    os.mkdir(SWANLAB_LOG_DIR)
+
+
+def init_db():
+    """
+    初始化数据库
+    """
+    from swanlab.db import connect, Project
+    clear()
+    connect(autocreate=True)
+    Project.init(name="pytest-swanlab", description="测试swanlab")


### PR DESCRIPTION
## Description

* 对swanlog类进行了重构，目前在设计上依旧不支持swanlog类导出，而是以唯一实例导出，这样做的好处是可以在导入swanlab的一瞬间拿到原始的标准输出流，避免出现类似 https://github.com/pytest-dev/pytest/issues/5502 的问题
* swanlog支持`install`和`uninstall`api以重新挂载标准输出流，并且在在程序运行过程中支持动态卸载它 #445：
![img_v3_02a5_39e3acce-caad-4f8a-9e41-69c886fbc0bg](https://github.com/SwanHubX/SwanLab/assets/79990647/05f91c72-6e1b-47bc-8f28-c3a6874ee0cc)
* 程序启动的一瞬间，就支持使用其打印api进行终端打印，默认日志等级为`info` #445 
* 删除了历史出现的一些冗余代码


----

目前在代码中，`LogSys`实际上应该被删除，这属于设计上的冗余，但是在其他地方还在使用它，这将在完成 #482 时删除它。

close #445 
