### PR TITLE
update env test

### DIFF
--- a/swanlab/api/auth/login.py
+++ b/swanlab/api/auth/login.py
@@ -96,6 +96,7 @@ def terminal_login(api_key: str = None) -> LoginInfo:
     """
     终端登录，此时直接覆盖本地token文件，但是新增交互，让用户输入api_key
     运行此函数，如果是认证失败的错误，重新要求用户输入api_key
+    本地文件上层文件夹不保证存在，需要上层函数保证
     """
     # 1. api_key存在，跳过输入环节，直接请求登录接口，这与代码内swanlab.login方法一致
     # 2. api_key为None，提示用户输入

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -264,7 +264,10 @@ def get_swanlab_folder() -> str:
         用户家目录的.swanlab文件夹路径
     """
     if is_dev() and HOME in os.environ:
-        return os.path.join(os.environ[HOME], ".swanlab")
+        path = os.path.join(os.environ[HOME], ".swanlab")
+        if not assert_exist(path, target_type="folder", ra=False):
+            os.mkdir(path)
+        return path
 
     user_home = get_user_home()
     swanlab_folder = os.path.join(user_home, ".swanlab")

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -264,7 +264,7 @@ def get_swanlab_folder() -> str:
         用户家目录的.swanlab文件夹路径
     """
     if is_dev() and HOME in os.environ:
-        return os.environ[HOME]
+        return os.path.join(os.environ[HOME], ".swanlab")
 
     user_home = get_user_home()
     swanlab_folder = os.path.join(user_home, ".swanlab")

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -41,6 +41,13 @@ MODE = "SWANLAB_MODE"
 4. local: 本地模式，不会上传日志到云端，使用swanlab本地版本
 此外，SWANLAB_MODE为disabled时，会开启非严格模式，非严格模式不再要求文件路径存在
 """
+PACKAGE = "SWANLAB_PACKAGE_PATH"
+"""swanlab包路径SWANLAB_PACKAGE_PATH，用于开发模式下指定swanlab包的路径
+当SWANLAB_DEV为TRUE时，必须指定此路径，否则会抛出异常，非开发模式下此环境变量无效
+"""
+HOME = "SWANLAB_HOME"
+"""存放.swanlab文件夹的路径，用于开发模式下的测试，非开发模式下此环境变量无效
+"""
 
 
 class SwanLabMode(enum.Enum):
@@ -161,6 +168,7 @@ def get_server_host(env: Optional[Env] = None) -> Optional[str]:
 
 def is_dev(env: Optional[Env] = None) -> bool:
     """判断是否是开发模式
+    此函数会在一开始就被package.py调用，所以不需要判断是否已经初始化
 
     Returns
     -------
@@ -179,7 +187,7 @@ def is_dev(env: Optional[Env] = None) -> bool:
 # ---------------------------------- 初始化基础环境变量 ----------------------------------
 
 # 所有的初始化函数
-function_list = [get_mode, get_swanlog_dir, get_server_port, get_server_host, is_dev]
+function_list = [get_mode, get_swanlog_dir, get_server_port, get_server_host]
 
 
 def init_env(env: Optional[Env] = None):
@@ -255,6 +263,9 @@ def get_swanlab_folder() -> str:
     str
         用户家目录的.swanlab文件夹路径
     """
+    if is_dev() and HOME in os.environ:
+        return os.environ[HOME]
+
     user_home = get_user_home()
     swanlab_folder = os.path.join(user_home, ".swanlab")
     try:
@@ -264,6 +275,13 @@ def get_swanlab_folder() -> str:
         os.remove(swanlab_folder)
         os.mkdir(swanlab_folder)
     return swanlab_folder
+
+
+def get_package_path() -> Optional[str]:
+    if is_dev() and PACKAGE in os.environ:
+        return os.environ[PACKAGE]
+    else:
+        return os.path.join(os.path.dirname(__file__), "package.json")
 
 
 def assert_exist(path: str, target_type: str = None, ra: bool = True, desc: str = None, t_desc: str = None) -> bool:

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -271,7 +271,7 @@ def assert_exist(path: str, target_type: str = None, ra: bool = True, desc: str 
     检查文件是否存在，严格模式下，文件不存在会抛出异常，或者可以手动通过参数控制，存在则返回True，否则返回False
     :param path: 文件路径
     :param target_type: 文件类型(folder, file)，如果文件类型与预期不符，会抛出异常，非严格模式下不检测，为None不检测文件类型
-    :param ra: 文件不存在时是否抛出异常，非严格模式下强制不抛出，此参数无效
+    :param ra: 文件不存在时是否抛出异常，非严格模式下强制不抛出，此参数无效，此参数只影响文件是否存在，不影响文件类型判断时抛出异常
     :param desc: 异常描述信息，非严格模式下强制不抛出，此参数无效
     :param t_desc: 文件类型描述信息，非严格模式下强制不抛出，此参数无效
     """

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -9,16 +9,11 @@ r"""
 """
 import json
 import os
-from .env import is_dev, get_swanlab_folder, is_strict_mode
+from .env import get_package_path, get_swanlab_folder, is_strict_mode
 from .utils.key import get_key
 from .error import KeyFileError
 
-package_path = None
-if is_dev():
-    # 当前运行时的位置
-    package_path = os.environ['SWANLAB_PACKAGE_PATH']
-else:
-    package_path = os.path.join(os.path.dirname(__file__), "package.json")
+package_path = get_package_path()
 
 
 def get_package_version(p=package_path) -> str:

--- a/test/unit/auth/pytest_login.py
+++ b/test/unit/auth/pytest_login.py
@@ -9,7 +9,6 @@ r"""
 """
 from swanlab.api.auth.login import login_by_key
 from tutils.config import CONFIG
-import pytest
 
 
 def test_login_success():

--- a/test/unit/auth/pytest_login.py
+++ b/test/unit/auth/pytest_login.py
@@ -7,17 +7,34 @@ r"""
 @Description:
     测试登录
 """
-from swanlab.api.auth.login import login_by_key
-from tutils.config import CONFIG
+from swanlab.api.auth.login import login_by_key, terminal_login, code_login
+from swanlab.error import ValidationError
+from swanlab.package import is_login
+import tutils as T
+from swanlab.env import reset_env, HOME
+import pytest
+import os
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_function():
+    """
+    在当前测试文件下的每个测试函数执行前后执行
+    """
+    reset_env()
+    yield
+    reset_env()
+    if HOME in os.environ:
+        del os.environ[HOME]
 
 
 def test_login_success():
     """
     测试登录成功
     """
-    login_info = login_by_key(CONFIG.get('api-key'), save=False)
+    login_info = login_by_key(T.KEY, save=False)
     assert not login_info.is_fail
-    assert login_info.api_key == CONFIG.get('api-key')
+    assert login_info.api_key == T.KEY
     assert login_info.__str__() == "Login success"
 
 
@@ -29,3 +46,28 @@ def test_login_error_key():
     assert login_info.is_fail
     assert login_info.api_key is None
     assert login_info.__str__() == "Error api key"
+
+
+def test_terminal_login(monkeypatch):
+    """
+    测试终端登录
+    """
+    os.environ[HOME] = T.TEMP_PATH
+    monkeypatch.setattr("getpass.getpass", T.get_password)
+    login_info = terminal_login(T.KEY)
+    assert not login_info.is_fail
+    assert login_info.api_key == T.KEY
+    assert login_info.__str__() == "Login success"
+    assert is_login()
+
+
+def test_code_login():
+    """
+    测试code登录
+    """
+    login_info = code_login(T.KEY)
+    assert not login_info.is_fail
+    assert login_info.api_key == T.KEY
+    assert login_info.__str__() == "Login success"
+    with pytest.raises(ValidationError):
+        _ = code_login("wrong-key")

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -8,8 +8,8 @@ r"""
     配置pytest
 """
 import pytest
-from tutils import clear, init_db, SWANLAB_DIR
-from swanlab.env import reset_env
+from tutils import clear, init_db, SWANLAB_DIR, SWANLAB_LOG_DIR, PACKAGE_PATH
+import swanlab.env as E
 import shutil
 import os
 
@@ -22,9 +22,12 @@ def setup_before_all():
 
 @pytest.fixture(scope="function", autouse=True)
 def setup_before_each():
-    reset_env()
+    E.reset_env()
     if os.path.exists(SWANLAB_DIR):
         shutil.rmtree(SWANLAB_DIR)
     yield
-    reset_env()
+    E.reset_env()
     shutil.rmtree(SWANLAB_DIR, ignore_errors=True)
+    os.environ[E.DEV] = "TRUE"
+    os.environ[E.ROOT] = SWANLAB_LOG_DIR
+    os.environ[E.PACKAGE] = PACKAGE_PATH

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -8,10 +8,23 @@ r"""
     配置pytest
 """
 import pytest
-from tutils import clear, init_db
+from tutils import clear, init_db, SWANLAB_DIR
+from swanlab.env import reset_env
+import shutil
+import os
 
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_before_all():
     clear()
     init_db()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_before_each():
+    reset_env()
+    if os.path.exists(SWANLAB_DIR):
+        shutil.rmtree(SWANLAB_DIR)
+    yield
+    reset_env()
+    shutil.rmtree(SWANLAB_DIR, ignore_errors=True)

--- a/test/unit/data/pytest_sdk.py
+++ b/test/unit/data/pytest_sdk.py
@@ -29,14 +29,12 @@ def setup_function():
     """
     在当前测试文件下的每个测试函数执行前后执行
     """
-    reset_env()
     swanlog.disable_log()
     yield
     # 恢复原状
     swanlog.enable_log()
     if get_run() is not None:
         get_run().finish()
-    reset_env()
     os.environ[ROOT] = T.SWANLAB_LOG_DIR
     if HOME in os.environ:
         del os.environ[HOME]

--- a/test/unit/data/pytest_sdk.py
+++ b/test/unit/data/pytest_sdk.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     测试sdk的一些api
 """
-from swanlab import init
+import swanlab.data.sdk as S
 from swanlab.env import (
     reset_env,
     MODE,
@@ -40,7 +40,7 @@ class TestInitMode:
     """
 
     def test_init_disabled(self):
-        run = init(mode="disabled", logdir=generate())
+        run = S.init(mode="disabled", logdir=generate())
         assert os.environ[MODE] == "disabled"
         run.log({"TestInitMode": 1})  # 不会报错
         a = run.settings.run_dir
@@ -48,27 +48,27 @@ class TestInitMode:
         assert get_run() is not None
 
     def test_init_local(self):
-        run = init(mode="local")
+        run = S.init(mode="local")
         assert os.environ[MODE] == "local"
         run.log({"TestInitMode": 1})  # 不会报错
         assert get_run() is not None
 
     def test_init_cloud(self):
-        run = init(mode="cloud")
+        run = S.init(mode="cloud")
         assert os.environ[MODE] == "cloud"
         run.log({"TestInitMode": 1})  # 不会报错
         assert get_run() is not None
 
     def test_init_error(self):
         with pytest.raises(ValueError):
-            init(mode="123456")
+            S.init(mode="123456")
         assert get_run() is None
 
     # ---------------------------------- 测试环境变量输入 ----------------------------------
 
     def test_init_disabled_env(self):
         os.environ[MODE] = "disabled"
-        run = init()
+        run = S.init()
         assert os.environ[MODE] == "disabled"
         run.log({"TestInitMode": 1})
         a = run.settings.run_dir
@@ -77,13 +77,13 @@ class TestInitMode:
 
     def test_init_local_env(self):
         os.environ[MODE] = "local"
-        run = init()
+        run = S.init()
         assert os.environ[MODE] == "local"
         run.log({"TestInitMode": 1})
 
     def test_init_cloud_env(self):
         os.environ[MODE] = "cloud"
-        run = init()
+        run = S.init()
         assert os.environ[MODE] == "cloud"
         run.log({"TestInitMode": 1})
 
@@ -91,7 +91,7 @@ class TestInitMode:
 
     def test_init_disabled_env_mode(self):
         os.environ[MODE] = "local"
-        run = init(mode="disabled")
+        run = S.init(mode="disabled")
         assert os.environ[MODE] == "disabled"
         run.log({"TestInitMode": 1})
         a = run.settings.run_dir
@@ -108,7 +108,7 @@ class TestInitProject:
         """
         设置project为None
         """
-        run = init(project=None, mode="disabled")
+        run = S.init(project=None, mode="disabled")
         assert run.project_name == os.path.basename(os.getcwd())
 
     def test_init_project(self):
@@ -116,7 +116,7 @@ class TestInitProject:
         设置project为字符串
         """
         project = "test_project"
-        run = init(project=project, mode="disabled")
+        run = S.init(project=project, mode="disabled")
         assert run.project_name == project
 
 
@@ -130,12 +130,12 @@ class TestInitLogdir:
         disabled模式下设置logdir不生效，采用的是环境变量的设置
         """
         logdir = generate()
-        run = init(logdir=logdir, mode="disabled")
+        run = S.init(logdir=logdir, mode="disabled")
         assert run.settings.swanlog_dir != logdir
         assert run.settings.swanlog_dir == os.environ[ROOT]
         run.finish()
         del os.environ[ROOT]
-        run = init(logdir=logdir, mode="disabled")
+        run = S.init(logdir=logdir, mode="disabled")
         assert run.settings.swanlog_dir != logdir
         assert run.settings.swanlog_dir == os.path.join(os.getcwd(), "swanlog")
 
@@ -144,12 +144,12 @@ class TestInitLogdir:
         其他模式下设置logdir生效
         """
         logdir = os.path.join(TEMP_PATH, generate()).__str__()
-        run = init(logdir=logdir, mode="local")
+        run = S.init(logdir=logdir, mode="local")
         assert run.settings.swanlog_dir == logdir
         run.finish()
         del os.environ[ROOT]
         logdir = os.path.join(TEMP_PATH, generate()).__str__()
-        run = init(logdir=logdir, mode="local")
+        run = S.init(logdir=logdir, mode="local")
         assert run.settings.swanlog_dir == logdir
 
     def test_init_logdir_env(self):
@@ -158,11 +158,17 @@ class TestInitLogdir:
         """
         logdir = os.path.join(TEMP_PATH, generate()).__str__()
         os.environ[ROOT] = logdir
-        run = init(mode="local")
+        run = S.init(mode="local")
         assert run.settings.swanlog_dir == logdir
         run.finish()
         del os.environ[ROOT]
         logdir = os.path.join(TEMP_PATH, generate()).__str__()
         os.environ[ROOT] = logdir
-        run = init(mode="local")
+        run = S.init(mode="local")
         assert run.settings.swanlog_dir == logdir
+
+
+class TestLogin:
+    """
+    通过
+    """

--- a/test/unit/data/pytest_sdk.py
+++ b/test/unit/data/pytest_sdk.py
@@ -13,7 +13,7 @@ from swanlab.env import (
     MODE,
     ROOT,
 )
-from tutils import TEMP_PATH
+from tutils import TEMP_PATH, SWANLAB_LOG_DIR
 from swanlab.log import swanlog
 from swanlab.data.run import get_run
 from nanoid import generate
@@ -29,9 +29,12 @@ def setup_function():
     reset_env()
     swanlog.disable_log()
     yield
+    # 恢复原状
     swanlog.enable_log()
     if get_run() is not None:
         get_run().finish()
+    reset_env()
+    os.environ[ROOT] = SWANLAB_LOG_DIR
 
 
 class TestInitMode:
@@ -170,5 +173,12 @@ class TestInitLogdir:
 
 class TestLogin:
     """
-    通过
+    测试通过sdk封装的login函数登录
+    不填apikey的部分不太好测
     """
+
+    def test_use_key(self):
+        """
+        需要保证key有效
+        """
+        S.login()

--- a/test/unit/data/pytest_sdk.py
+++ b/test/unit/data/pytest_sdk.py
@@ -187,16 +187,8 @@ class TestLogin:
         使用家目录下的key，不需要输入
         如果家目录下的key获取失败，会使用getpass.getpass要求用户输入，作为测试，使用monkeypatch替换getpass.getpass
         """
-
-        def get_password(prompt: str):
-            # 如果是第一次登录，使用错误的key，会提示重新输入
-            if "Paste" in prompt:
-                return generate()
-            else:
-                return T.KEY
-
         os.environ[HOME] = T.TEMP_PATH
-        monkeypatch.setattr("getpass.getpass", get_password)
+        monkeypatch.setattr("getpass.getpass", T.get_password)
         S.login()
         # 默认保存Key
         assert os.path.exists(os.path.join(get_swanlab_folder(), ".netrc"))

--- a/test/unit/pytest_env.py
+++ b/test/unit/pytest_env.py
@@ -25,7 +25,6 @@ def setup_function():
     """
     在当前测试文件下的每个测试函数执行前后执行
     """
-    reset_env()
     if MODE in os.environ:
         del os.environ[MODE]
     if E.ROOT in os.environ:
@@ -36,12 +35,8 @@ def setup_function():
         del os.environ[E.DEV]
     yield
     # 恢复原状
-    reset_env()
     if MODE in os.environ:
         del os.environ[MODE]
-    os.environ[E.DEV] = "TRUE"
-    os.environ[E.ROOT] = SWANLAB_LOG_DIR
-    os.environ[E.PACKAGE] = PACKAGE_PATH
 
 
 def use_strict_mode():

--- a/test/unit/pytest_env.py
+++ b/test/unit/pytest_env.py
@@ -279,12 +279,10 @@ class TestGetSwanLabFolder:
     """
 
     def test_use_env(self):
-        _dir = os.path.join(TEMP_PATH, ".swanlab")
-        os.environ[E.HOME] = _dir
-        assert E.get_swanlab_folder() != _dir
+        os.environ[E.HOME] = TEMP_PATH
+        assert TEMP_PATH not in E.get_swanlab_folder()
 
     def test_use_env_dev(self):
-        _dir = os.path.join(TEMP_PATH, ".swanlab")
         os.environ[E.DEV] = "TRUE"
-        os.environ[E.HOME] = _dir
-        assert E.get_swanlab_folder() == _dir
+        os.environ[E.HOME] = TEMP_PATH
+        assert E.get_swanlab_folder() == os.path.join(TEMP_PATH, ".swanlab")

--- a/tutils/__init__.py
+++ b/tutils/__init__.py
@@ -9,6 +9,7 @@ r"""
 """
 
 from .config import *
+from .utils import *
 import shutil
 import os
 

--- a/tutils/__init__.py
+++ b/tutils/__init__.py
@@ -21,6 +21,7 @@ def clear():
         shutil.rmtree(TEMP_PATH)
     os.mkdir(TEMP_PATH)
     os.mkdir(SWANLAB_LOG_DIR)
+    os.mkdir(SWANLAB_DIR)
 
 
 def init_db():

--- a/tutils/config.py
+++ b/tutils/config.py
@@ -22,6 +22,11 @@ __test_path = os.path.join(
 
 TEMP_PATH = os.path.join(__test_path, "temp")
 
+SWANLAB_DIR = os.path.join(TEMP_PATH, ".swanlab")
+"""
+测试时.swanlab文件夹存放的位置
+"""
+
 SWANLAB_LOG_DIR = os.path.join(TEMP_PATH, "swanlog")
 """
 测试时swanlog文件夹存放的位置
@@ -39,4 +44,4 @@ os.environ["SWANLAB_DEV"] = "TRUE"
 os.environ["SWANLAB_PACKAGE_PATH"] = PACKAGE_PATH
 os.environ["SWANLAB_LOG_DIR"] = SWANLAB_LOG_DIR
 
-__all__ = ["TEMP_PATH", "SWANLAB_LOG_DIR", "CONFIG", "nanoid"]
+__all__ = ["TEMP_PATH", "SWANLAB_LOG_DIR", "CONFIG", "nanoid", "PACKAGE_PATH", "SWANLAB_DIR"]

--- a/tutils/config.py
+++ b/tutils/config.py
@@ -47,5 +47,6 @@ PACKAGE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "package
 os.environ["SWANLAB_DEV"] = "TRUE"
 os.environ["SWANLAB_PACKAGE_PATH"] = PACKAGE_PATH
 os.environ["SWANLAB_LOG_DIR"] = SWANLAB_LOG_DIR
+os.environ["SWANLAB_HOME"] = TEMP_PATH
 
 __all__ = ["TEMP_PATH", "SWANLAB_LOG_DIR", "CONFIG", "nanoid", "PACKAGE_PATH", "SWANLAB_DIR", "KEY"]

--- a/tutils/config.py
+++ b/tutils/config.py
@@ -36,6 +36,10 @@ CONFIG: dict = json.load(open(os.path.join(os.path.dirname(os.path.abspath(__fil
 """
 开发快捷配置
 """
+KEY: str = CONFIG["api-key"]
+"""
+测试时使用的api-key
+"""
 
 PACKAGE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "package.mock.json")
 
@@ -44,4 +48,4 @@ os.environ["SWANLAB_DEV"] = "TRUE"
 os.environ["SWANLAB_PACKAGE_PATH"] = PACKAGE_PATH
 os.environ["SWANLAB_LOG_DIR"] = SWANLAB_LOG_DIR
 
-__all__ = ["TEMP_PATH", "SWANLAB_LOG_DIR", "CONFIG", "nanoid", "PACKAGE_PATH", "SWANLAB_DIR"]
+__all__ = ["TEMP_PATH", "SWANLAB_LOG_DIR", "CONFIG", "nanoid", "PACKAGE_PATH", "SWANLAB_DIR", "KEY"]

--- a/tutils/utils.py
+++ b/tutils/utils.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2024/5/28 16:33
+@File: utils.py
+@IDE: pycharm
+@Description:
+    一些工具函数
+"""
+from nanoid import generate
+from .config import KEY
+
+
+def get_password(prompt: str):
+    # 如果是第一次登录，使用错误的key，会提示重新输入
+    if "Paste" in prompt:
+        return generate()
+    else:
+        return KEY


### PR DESCRIPTION
## Description

* 完善环境变量部分的单元测试
* 为单元测试编写一些hook，避免重复操作
* 完善登录的单元测试

为了实现单元测试，新增两个环境变量`SWANLAB_PACKAGE_PATH`和`SWANLAB_HOME`，前者设置swanlab包配置文件路径，后者设置.swanlab路径，都只有在开发模式生效


closes: #577 