### PR TITLE
Feat/improve_config

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest
 pytest-asyncio
 
 nanoid
-
+omegaconf
 ipython
 ipython<8.13; python_version < '3.9'
 ipykernel

--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -4,7 +4,6 @@ from .data import (
     init,
     log,
     finish,
-    config,
     Audio,
     Image,
     Text,
@@ -14,6 +13,7 @@ from .data import (
 )
 
 
+from .data.run.main import config
 from .package import get_package_version
 
 

--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -10,6 +10,7 @@ from .data import (
     Run,
     State,
     get_run,
+    get_config,
 )
 
 

--- a/swanlab/data/__init__.py
+++ b/swanlab/data/__init__.py
@@ -27,4 +27,5 @@ from .run import (
     SwanLabRun as Run,
     SwanLabRunState as State,
     get_run,
+    get_config,
 )

--- a/swanlab/data/__init__.py
+++ b/swanlab/data/__init__.py
@@ -21,7 +21,6 @@ from .sdk import (
     init,
     log,
     finish,
-    _config as config,
 )
 
 from .run import (

--- a/swanlab/data/run/__init__.py
+++ b/swanlab/data/run/__init__.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     在此处导出SwanLabRun类，一次实验运行应该只有一个SwanLabRun实例
 """
-from .main import SwanLabRun, get_run, SwanLabRunState
+from .main import SwanLabRun, get_run, get_config, SwanLabRunState
 
 
 def register(*args, **kwargs) -> SwanLabRun:

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -260,7 +260,7 @@ class SwanLabConfig(Mapping):
         """
         清空配置字典
         """
-        self.__clean()
+        self.__config.clear()
 
     @need_inited
     def update(self, data: dict):
@@ -354,12 +354,6 @@ class SwanLabConfig(Mapping):
                 for index, (key, value) in enumerate(self.__config.items())
             }
             yaml.dump(config, f)
-
-    def __clean(self):
-        """
-        清空配置字典
-        """
-        self.__config.clear()
 
     def __iter__(self):
         """

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -40,7 +40,7 @@ def json_serializable(obj: dict):
     return str(obj)
 
 
-def check_keys(d: dict):
+def check_config_keys(d: dict):
     """检查字典的key是否合法，允许的key类型为str, int, float"""
     allowed_types = (str, int, float)
     invalid_keys = [key for key in d.keys() if not isinstance(key, allowed_types)]
@@ -107,7 +107,7 @@ class SwanLabConfig(Mapping):
             # 将config转换为json序列化的dict
             config = json_serializable(dict(config))
             # 检查config的key是否合法
-            invalid_keys = check_keys(config)
+            invalid_keys = check_config_keys(config)
             if invalid_keys:
                 raise TypeError(
                     f"swanlab.config has invalid keys {invalid_keys}, keys must be str, int, float, bool or None"

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -108,7 +108,7 @@ class SwanLabConfig(Mapping):
         self.__settings["save_path"] = settings.config_path if settings is not None else None
         self.__settings["should_save"] = settings.should_save if settings is not None else False
         if self._inited:
-            self.__save()
+            self.save()
 
     @property
     def should_shave(self):
@@ -178,7 +178,7 @@ class SwanLabConfig(Mapping):
         self.__dict__[name] = value
         # 同步到配置字典
         self.__config[name] = value
-        self.__save()
+        self.save()
 
     @need_inited
     def __setitem__(self, name: str, value: Any) -> None:
@@ -194,7 +194,7 @@ class SwanLabConfig(Mapping):
         name = str(name)
         self.__check_private(name)
         self.__config[name] = value
-        self.__save()
+        self.save()
 
     @need_inited
     def set(self, name: str, value: Any) -> None:
@@ -222,7 +222,7 @@ class SwanLabConfig(Mapping):
         name = str(name)
         self.__check_private(name)
         self.__config[name] = value
-        self.__save()
+        self.save()
 
     @need_inited
     def pop(self, name: str) -> bool:
@@ -241,7 +241,7 @@ class SwanLabConfig(Mapping):
         """
         try:
             del self.__config[name]
-            self.__save()
+            self.save()
             return True
         except KeyError:
             return False
@@ -286,7 +286,7 @@ class SwanLabConfig(Mapping):
         """
 
         self.__config.update(data)
-        self.__save()
+        self.save()
 
     @need_inited
     def __getattr__(self, name: str):
@@ -350,7 +350,7 @@ class SwanLabConfig(Mapping):
         except KeyError:
             return False
 
-    def __save(self):
+    def save(self):
         """
         保存config为json，不必校验config的YAML格式，将在写入时完成校验
         """

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -248,6 +248,12 @@ class SwanLabConfig(Mapping):
         except KeyError:
             raise AttributeError(f"You have not retrieved '{name}' in the config of the current experiment")
 
+    def clean(self):
+        """
+        清空配置字典
+        """
+        self.__clean()
+
     @need_inited
     def update(self, data: dict):
         """
@@ -340,6 +346,12 @@ class SwanLabConfig(Mapping):
                 for index, (key, value) in enumerate(self.__config.items())
             }
             yaml.dump(config, f)
+
+    def __clean(self):
+        """
+        清空配置字典
+        """
+        self.__config.clear()
 
     def __iter__(self):
         """

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -11,7 +11,7 @@ from typing import Any
 from collections.abc import Mapping
 import yaml
 import argparse
-from .settings import SwanDataSettings
+from ..settings import SwanDataSettings
 from swanlab.log import swanlog
 import datetime
 

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -41,8 +41,8 @@ def json_serializable(obj: dict):
 
 
 def check_keys(d: dict):
-    """检查字典的key是否合法"""
-    allowed_types = (str, int, float, bool, type(None))
+    """检查字典的key是否合法，允许的key类型为str, int, float"""
+    allowed_types = (str, int, float)
     invalid_keys = [key for key in d.keys() if not isinstance(key, allowed_types)]
     return invalid_keys
 
@@ -151,6 +151,9 @@ class SwanLabConfig(Mapping):
 
         值得注意的是类属性的设置不会触发此方法
         """
+        cfg = self.__check_config({name: value})
+        name, value = cfg.popitem()
+
         # 判断是否是私有属性
         self.__check_private(name)
         # 设置属性，并判断是否已经初始化，如果是，则调用保存方法
@@ -169,6 +172,8 @@ class SwanLabConfig(Mapping):
         run.config["__lr"] = 0.01 # 不允许
         ```
         """
+        cfg = self.__check_config({name: value})
+        name, value = cfg.popitem()
         # 判断是否是私有属性
         self.__check_private(name)
         self.__config[name] = value
@@ -197,6 +202,9 @@ class SwanLabConfig(Mapping):
         AttributeError
             If the attribute name is private, an exception is raised
         """
+        cfg = self.__check_config({name: value})
+        name, value = cfg.popitem()
+
         self.__check_private(name)
         self.__config[name] = value
         self.__save()

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -15,7 +15,7 @@ import random
 from enum import Enum
 from .exp import SwanLabExp
 from datetime import datetime
-from typing import Callable, Optional, Dict
+from typing import Callable, Optional, Dict, MutableMapping
 from .operator import SwanLabRunOperator
 from swanlab.env import get_mode, SwanLabMode
 
@@ -42,7 +42,7 @@ class SwanLabRun:
         project_name: str = None,
         experiment_name: str = None,
         description: str = None,
-        run_config: dict = None,
+        run_config: MutableMapping = None,
         log_level: str = None,
         suffix: str = None,
         exp_num: int = None,
@@ -61,7 +61,7 @@ class SwanLabRun:
         description : str, optional
             实验描述，用于对当前实验进行更详细的介绍或标注
             如果不提供此参数(为None)，可以在web界面中进行修改,这意味着必须在此改为空字符串""
-        run_config : dict, optional
+        run_config : MutableMapping, optional
             实验参数配置，可以在web界面中显示，如学习率、batch size等
             不需要做任何限制，但必须是字典类型，可被json序列化，否则会报错
         log_level : str, optional

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -10,7 +10,7 @@ r"""
 from ..settings import SwanDataSettings
 from swanlab.log import swanlog
 from swanlab.data.modules import BaseType
-from swanlab.data.run.config import SwanLabConfig
+from .config import SwanLabConfig
 import random
 from enum import Enum
 from .exp import SwanLabExp
@@ -84,7 +84,7 @@ class SwanLabRun:
         # ---------------------------------- 初始化类内参数 ----------------------------------
         self.__project_name = project_name
         # 生成一个唯一的id，随机生成一个8位的16进制字符串，小写
-        _id = hex(random.randint(0, 2**32 - 1))[2:].zfill(8)
+        _id = hex(random.randint(0, 2 ** 32 - 1))[2:].zfill(8)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.__run_id = "run-{}-{}".format(timestamp, _id)
         # 操作员初始化

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -84,7 +84,7 @@ class SwanLabRun:
         # ---------------------------------- 初始化类内参数 ----------------------------------
         self.__project_name = project_name
         # 生成一个唯一的id，随机生成一个8位的16进制字符串，小写
-        _id = hex(random.randint(0, 2 ** 32 - 1))[2:].zfill(8)
+        _id = hex(random.randint(0, 2**32 - 1))[2:].zfill(8)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.__run_id = "run-{}-{}".format(timestamp, _id)
         # 操作员初始化

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -10,7 +10,7 @@ r"""
 from ..settings import SwanDataSettings
 from swanlab.log import swanlog
 from swanlab.data.modules import BaseType
-from swanlab.data.config import SwanLabConfig
+from swanlab.data.run.config import SwanLabConfig
 import random
 from enum import Enum
 from .exp import SwanLabExp
@@ -24,6 +24,7 @@ class SwanLabRunState(Enum):
     """SwanLabRunState is an enumeration class that represents the state of the experiment.
     We Recommend that you use this enumeration class to represent the state of the experiment.
     """
+
     NOT_STARTED = -2
     SUCCESS = 1
     CRASHED = -1
@@ -75,13 +76,14 @@ class SwanLabRun:
         operator : SwanLabRunOperator, optional
             实验操作员，用于批量处理回调函数的调用，如果不提供此参数(为None)，则会自动生成一个实例
         """
+
         global run
         if run is not None:
             raise RuntimeError("SwanLabRun has been initialized")
         # ---------------------------------- 初始化类内参数 ----------------------------------
         self.__project_name = project_name
         # 生成一个唯一的id，随机生成一个8位的16进制字符串，小写
-        _id = hex(random.randint(0, 2 ** 32 - 1))[2:].zfill(8)
+        _id = hex(random.randint(0, 2**32 - 1))[2:].zfill(8)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         self.__run_id = "run-{}-{}".format(timestamp, _id)
         # 操作员初始化
@@ -307,6 +309,8 @@ _change_run_state: Optional["Callable"] = None
 """
 修改实验状态的函数，用于在实验状态改变时调用
 """
+config: Optional["SwanLabConfig"] = SwanLabConfig()
+"""Global config instance. After the user calls finish(), config will be set to None."""
 
 
 def _set_run_state(state: SwanLabRunState):
@@ -330,3 +334,11 @@ def get_run() -> Optional["SwanLabRun"]:
     """
     global run
     return run
+
+
+def get_config() -> Optional["SwanLabConfig"]:
+    """
+    Get the current config object.
+    """
+    global config
+    return config

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -42,7 +42,7 @@ class SwanLabRun:
         project_name: str = None,
         experiment_name: str = None,
         description: str = None,
-        config: dict = None,
+        run_config: dict = None,
         log_level: str = None,
         suffix: str = None,
         exp_num: int = None,
@@ -61,7 +61,7 @@ class SwanLabRun:
         description : str, optional
             实验描述，用于对当前实验进行更详细的介绍或标注
             如果不提供此参数(为None)，可以在web界面中进行修改,这意味着必须在此改为空字符串""
-        config : dict, optional
+        run_config : dict, optional
             实验参数配置，可以在web界面中显示，如学习率、batch size等
             不需要做任何限制，但必须是字典类型，可被json序列化，否则会报错
         log_level : str, optional
@@ -96,7 +96,7 @@ class SwanLabRun:
         swanlog.set_level(self.__check_log_level(log_level))
         # ---------------------------------- 初始化配置 ----------------------------------
         # 给外部1个config
-        self.__config = SwanLabConfig(config, self.__settings)
+        self.__config = SwanLabConfig(run_config, self.__settings)
         # ---------------------------------- 注册实验 ----------------------------------
         self.__exp: SwanLabExp = self.__register_exp(experiment_name, description, suffix, num=exp_num)
         # 实验状态标记，如果status不为0，则无法再次调用log方法

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -80,6 +80,7 @@ class SwanLabRun:
         global run
         if run is not None:
             raise RuntimeError("SwanLabRun has been initialized")
+
         # ---------------------------------- 初始化类内参数 ----------------------------------
         self.__project_name = project_name
         # 生成一个唯一的id，随机生成一个8位的16进制字符串，小写
@@ -182,7 +183,8 @@ class SwanLabRun:
         _run, run = run, None
 
         # 清空config
-        config.clean()
+        if isinstance(config, SwanLabConfig):
+            config.clean()
 
         return _run
 

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -160,11 +160,11 @@ class SwanLabRun:
         :param state: The state of the experiment, it can be 'SUCCESS', 'CRASHED' or 'RUNNING'.
         :param error: The error message when the experiment is marked as 'CRASHED'. If not 'CRASHED', it should be None.
         """
-        global run
+        global run, config
         # 分为几步
         # 1. 设置数据库实验状态为对应状态
         # 2. 判断是否为云端同步，如果是则开始关闭线程池和同步状态
-        # 3. 清空run对象，run改为局部变量_run
+        # 3. 清空run和config对象，run改为局部变量_run
         # 4. 返回_run
         if run is None:
             raise RuntimeError("The run object is None, please call `swanlab.init` first.")
@@ -180,6 +180,10 @@ class SwanLabRun:
             # disabled 模式下没有install，所以会报错
             pass
         _run, run = run, None
+
+        # 清空config
+        config.clean()
+
         return _run
 
     @property

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -165,7 +165,7 @@ class SwanLabRun:
         # 分为几步
         # 1. 设置数据库实验状态为对应状态
         # 2. 判断是否为云端同步，如果是则开始关闭线程池和同步状态
-        # 3. 清空run和config对象，run改为局部变量_run
+        # 3. 清空run和config对象，run改为局部变量_run，config被清空
         # 4. 返回_run
         if run is None:
             raise RuntimeError("The run object is None, please call `swanlab.init` first.")

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -249,7 +249,7 @@ class SwanLabRun:
         for key in data:
             # 遍历字典的key，记录到本地文件中
             d = data[key]
-            # 如果d的数据类型是list，且里面的数据全部为Image类型，则需要转换一下
+            # 如果d的数据类型是list，且里面的数据全部为DataType类型，则需要转换一下
             if isinstance(d, list) and all([isinstance(i, BaseType) for i in d]) and len(d) > 0:
                 # 将d作为输入，构造一个与d相同类型的实例
                 d = d[0].__class__(d)

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -161,7 +161,7 @@ class SwanLabRun:
         :param state: The state of the experiment, it can be 'SUCCESS', 'CRASHED' or 'RUNNING'.
         :param error: The error message when the experiment is marked as 'CRASHED'. If not 'CRASHED', it should be None.
         """
-        global run, config
+        global run
         # 分为几步
         # 1. 设置数据库实验状态为对应状态
         # 2. 判断是否为云端同步，如果是则开始关闭线程池和同步状态
@@ -180,11 +180,9 @@ class SwanLabRun:
         except RuntimeError:
             # disabled 模式下没有install，所以会报错
             pass
-        _run, run = run, None
 
-        # 清空config
-        if isinstance(config, SwanLabConfig):
-            config.clean()
+        run.config.clean()
+        _run, run = run, None
 
         return _run
 

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -190,7 +190,7 @@ def init(
         project_name=project,
         experiment_name=experiment_name,
         description=description,
-        config=config,
+        run_config=config,
         log_level=kwargs.get("log_level", "info"),
         suffix=suffix,
         exp_num=exp_num,

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -19,7 +19,6 @@ from .run import (
 from .callback_cloud import CloudRunCallback
 from .callback_local import LocalRunCallback
 from .run.operator import SwanLabRunOperator
-from .config import SwanLabConfig
 from swanlab.env import init_env, get_swanlog_dir, SwanLabMode, MODE
 from swanlab.log import swanlog
 from swanlab.utils import check_load_json_yaml, check_proj_name_format
@@ -27,7 +26,6 @@ from swanlab.api import code_login
 from swanlab.db import GlomCallback
 from swanlab.package import version_limit
 
-_config: Optional["SwanLabConfig"] = SwanLabConfig(None)
 """
 Allows users to record experiment configurations through swanlab.config.
 Before calling the init() function, config cannot be read or written, even if it is a SwanLabConfig object.

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -1,0 +1,62 @@
+from swanlab.data.run.main import SwanLabRun, get_run, SwanLabRunState, swanlog
+from tutils import clear, TEMP_PATH
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_function():
+    """
+    在当前测试文件下的每个测试函数执行前后执行
+    """
+    if get_run() is not None:
+        get_run().finish()
+    swanlog.disable_log()
+    yield
+    clear()
+    swanlog.enable_log()
+
+
+class TestSwanLabRunConfig:
+    def test_config_ok(self):
+        """
+        测试解析一个正常的数字
+        """
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": 2},
+        }
+        run = SwanLabRun(config=config_data)
+        assert run.config == config_data
+
+        assert run.config["a"] == 1
+        assert run.config["b"] == "mnist"
+        assert run.config["c/d"] == [1, 2, 3]
+        assert run.config["c/d"][0] == 1
+        assert run.config["e/f/h"] == {"a": 1, "b": 2}
+        assert run.config["e/f/h"]["a"] == 1
+
+        assert run.config.a == 1
+        assert run.config.b == "mnist"
+
+        assert run.config.get("a") == 1
+        assert run.config.get("b") == "mnist"
+        assert run.config.get("c/d") == [1, 2, 3]
+        assert run.config.get("c/d")[0] == 1
+        assert run.config.get("e/f/h") == {"a": 1, "b": 2}
+        assert run.config.get("e/f/h")["a"] == 1
+
+    # def test_config_set(self):
+    #     """
+    #     测试在init之后添加config参数
+    #     """
+    #     config_data = {
+    #         "a": 1,
+    #         "b": "mnist",
+    #         "c/d": [1, 2, 3],
+    #         "e/f/h": {"a": 1, "b": 2},
+    #     }
+
+    #     run = SwanLabRun()
+    #     assert len(run.config) == 0

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -230,3 +230,55 @@ class TestSwanLabRunConfig:
         assert run.config["b"] == "mnist"
         assert run.config["c/d"] == str([1, 2, 3])
         assert run.config["e/f/h"] == str({"a": 1, "b": {"c": 2}})
+
+    def test_insert_class(self):
+        """
+        测试插入类
+        """
+        from collections.abc import MutableMapping
+
+        class Test(MutableMapping):
+            def __init__(self, a, b):
+                self.data = {"a": a, "b": b}
+
+            def __setitem__(self, __key, __value):
+                self.data[__key] = __value
+
+            def __delitem__(self, __key):
+                del self.data[__key]
+
+            def __getitem__(self, __key):
+                return self.data.get(__key, None)
+
+            def __len__(self):
+                return len(self.data)
+
+            def __iter__(self):
+                return iter(self.data)
+
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+            "test": Test(1, 2)
+        }
+
+        run = SwanLabRun(run_config=config_data)
+        assert run.config.test.a == 1
+        assert run.config.test.b == 2
+
+    def test_not_json_serializable(self):
+        """
+        测试不可json化的数据
+        """
+        import math, json
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+            "test": math.nan
+        }
+        run = SwanLabRun(run_config=config_data)
+        json_data = json.dumps(SwanLabRun.config)

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -1,5 +1,5 @@
 from swanlab.data.run.main import SwanLabRun, get_run, SwanLabConfig, swanlog
-from tutils import clear, TEMP_PATH
+from tutils import clear
 import pytest
 import swanlab
 import omegaconf

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -193,7 +193,7 @@ class TestSwanLabRunConfig:
 
     def test_config_get_config(self):
         """
-        测试在finish之后config是否置空
+        测试get_config
         """
         config_data = {
             "a": 1,

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -19,9 +19,9 @@ def setup_function():
 
 
 class TestSwanLabRunConfig:
-    def test_config_ok(self):
+    def test_config_have(self):
         """
-        测试解析一个正常的数字
+        初始化时有config参数，测试三种获取数据的方式
         """
         config_data = {
             "a": 1,
@@ -56,7 +56,7 @@ class TestSwanLabRunConfig:
 
     def test_config_null_update(self):
         """
-        测试在init之后通过update的方式添加config参数
+        测试init为空，之后通过update的方式添加config参数
         """
         config_data = {
             "a": 1,
@@ -81,20 +81,9 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"]["a"] == 1
         assert run.config["e/f/h"]["b"]["c"] == 2
 
-        assert run.config.a == 1
-        assert run.config.b == "mnist"
-
-        assert run.config.get("a") == 1
-        assert run.config.get("b") == "mnist"
-        assert run.config.get("c/d") == [1, 2, 3]
-        assert run.config.get("c/d")[0] == 1
-        assert run.config.get("e/f/h") == {"a": 1, "b": {"c": 2}}
-        assert run.config.get("e/f/h")["a"] == 1
-        assert run.config["e/f/h"]["b"]["c"] == 2
-
     def test_config_have_update(self):
         """
-        测试在init之后通过update的方式添加config参数
+        测试init不为空，之后通过update的方式添加config参数
         """
         config_data = {
             "a": 1,
@@ -197,8 +186,8 @@ class TestSwanLabRunConfig:
             "c/d": [1, 2, 3],
             "e/f/h": {"a": 1, "b": {"c": 2}},
         }
-        config = omegaconf.OmegaConf.create(config_data)
-        run = SwanLabRun(config=config)
+        cfg = omegaconf.OmegaConf.create(config_data)
+        run = SwanLabRun(config=cfg)
 
         assert isinstance(run.config, SwanLabConfig)
         assert len(run.config) == 4

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -29,7 +29,7 @@ class TestSwanLabRunConfig:
             "c/d": [1, 2, 3],
             "e/f/h": {"a": 1, "b": {"c": 2}},
         }
-        run = SwanLabRun(config=config_data)
+        run = SwanLabRun(run_config=config_data)
         assert isinstance(run.config, SwanLabConfig)
         assert len(run.config) == 4
 
@@ -92,7 +92,7 @@ class TestSwanLabRunConfig:
             "e/f/h": {"a": 1, "b": {"c": 2}},
         }
 
-        run = SwanLabRun(config=config_data)
+        run = SwanLabRun(run_config=config_data)
         assert isinstance(run.config, SwanLabConfig)
         assert len(run.config) == 4
 
@@ -137,7 +137,7 @@ class TestSwanLabRunConfig:
             "c/d": [1, 2, 3],
             "e/f/h": {"a": 1, "b": {"c": 2}},
         }
-        run = SwanLabRun(config=config_data)
+        run = SwanLabRun(run_config=config_data)
 
         run.config.a = 2
         run.config.set("e/f/h", [4, 5, 6])
@@ -185,7 +185,7 @@ class TestSwanLabRunConfig:
             "e/f/h": {"a": 1, "b": {"c": 2}},
         }
 
-        run = SwanLabRun(config=config_data)
+        run = SwanLabRun(run_config=config_data)
         run.finish()
 
         assert isinstance(run.config, SwanLabConfig)
@@ -205,7 +205,7 @@ class TestSwanLabRunConfig:
         assert isinstance(swanlab.get_config(), SwanLabConfig)
         assert len(swanlab.get_config()) == 0
 
-        run = SwanLabRun(config=config_data)
+        run = SwanLabRun(run_config=config_data)
 
         assert isinstance(swanlab.get_config(), SwanLabConfig)
         assert len(swanlab.get_config()) == 4
@@ -221,7 +221,7 @@ class TestSwanLabRunConfig:
             "e/f/h": {"a": 1, "b": {"c": 2}},
         }
         cfg = omegaconf.OmegaConf.create(config_data)
-        run = SwanLabRun(config=cfg)
+        run = SwanLabRun(run_config=cfg)
 
         assert isinstance(run.config, SwanLabConfig)
         assert len(run.config) == 4

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -228,57 +228,58 @@ class TestSwanLabRunConfig:
 
         assert run.config["a"] == 1
         assert run.config["b"] == "mnist"
-        assert run.config["c/d"] == str([1, 2, 3])
-        assert run.config["e/f/h"] == str({"a": 1, "b": {"c": 2}})
-
-    def test_insert_class(self):
-        """
-        测试插入类
-        """
-        from collections.abc import MutableMapping
-
-        class Test(MutableMapping):
-            def __init__(self, a, b):
-                self.data = {"a": a, "b": b}
-
-            def __setitem__(self, __key, __value):
-                self.data[__key] = __value
-
-            def __delitem__(self, __key):
-                del self.data[__key]
-
-            def __getitem__(self, __key):
-                return self.data.get(__key, None)
-
-            def __len__(self):
-                return len(self.data)
-
-            def __iter__(self):
-                return iter(self.data)
-
-        config_data = {
-            "a": 1,
-            "b": "mnist",
-            "c/d": [1, 2, 3],
-            "e/f/h": {"a": 1, "b": {"c": 2}},
-            "test": Test(1, 2)
-        }
-
-        run = SwanLabRun(run_config=config_data)
-        assert run.config.test.a == 1
-        assert run.config.test.b == 2
+        assert run.config["c/d"] == [1, 2, 3]
+        assert run.config["e/f/h"] == {"a": 1, "b": {"c": 2}}
 
     def test_not_json_serializable(self):
         """
         测试不可json化的数据
         """
         import math, json
+
         config_data = {
             "a": 1,
             "b": "mnist",
             "c/d": [1, 2, 3],
             "e/f/h": {"a": 1, "b": {"c": 2}},
-            "test": math.nan
+            "test_nan": math.nan,
+            "test_inf": math.inf,
         }
+
         run = SwanLabRun(run_config=config_data)
-        json_data = json.dumps(SwanLabRun.config)
+
+        assert run.config.test_nan == "nan"
+        assert run.config.test_inf == "inf"
+
+        json_data = json.dumps(dict(run.config))
+
+    # def test_insert_class(self):
+    #     """
+    #     测试插入类
+    #     """
+    #     from collections.abc import MutableMapping
+
+    #     class Test(MutableMapping):
+    #         def __init__(self, a, b):
+    #             self.data = {"a": a, "b": b}
+
+    #         def __setitem__(self, __key, __value):
+    #             self.data[__key] = __value
+
+    #         def __delitem__(self, __key):
+    #             del self.data[__key]
+
+    #         def __getitem__(self, __key):
+    #             return self.data.get(__key, None)
+
+    #         def __len__(self):
+    #             return len(self.data)
+
+    #         def __iter__(self):
+    #             return iter(self.data)
+
+    #     config_data = {"a": 1, "b": "mnist", "c/d": [1, 2, 3], "e/f/h": {"a": 1, "b": {"c": 2}}, "test": Test(1, 2)}
+
+    #     run = SwanLabRun(run_config=config_data)
+    #     assert run.config.test.a == 1
+    #     assert run.config.test.b == 2

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -54,6 +54,8 @@ class TestSwanLabRunConfig:
         assert run.config.get("e/f/h")["a"] == 1
         assert run.config["e/f/h"]["b"]["c"] == 2
 
+        run.config.save()
+
     def test_config_null_update(self):
         """
         测试init为空，之后通过update的方式添加config参数
@@ -80,6 +82,8 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"] == {"a": 1, "b": {"c": 2}}
         assert run.config["e/f/h"]["a"] == 1
         assert run.config["e/f/h"]["b"]["c"] == 2
+
+        run.config.save()
 
     def test_config_have_update(self):
         """
@@ -110,6 +114,8 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"][0] == 4
         assert run.config["j"] == 3
 
+        run.config.save()
+
     def test_config_null_set(self):
         """
         测试在没有config初始化时，init之后更新config的参数
@@ -126,6 +132,8 @@ class TestSwanLabRunConfig:
         assert run.config.b == "mnist"
         assert run.config["c/d"] == [1, 2, 3]
         assert run.config["e/f/h"] == {"a": 1, "b": {"c": 2}}
+
+        run.config.save()
 
     def test_config_have_set(self):
         """
@@ -148,6 +156,8 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"] == [4, 5, 6]
         assert run.config["e/f/h"][0] == 4
         assert run.config["j"] == 3
+
+        run.config.save()
 
     def test_config_before_init(self):
         """
@@ -174,6 +184,8 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"]["a"] == 1
         assert run.config["e/f/h"]["b"]["c"] == 2
 
+        run.config.save()
+
     def test_config_clean(self):
         """
         测试在finish之后config是否置空
@@ -190,6 +202,8 @@ class TestSwanLabRunConfig:
 
         assert isinstance(run.config, SwanLabConfig)
         assert len(run.config) == 0
+
+        run.config.save()
 
     def test_config_get_config(self):
         """
@@ -209,6 +223,8 @@ class TestSwanLabRunConfig:
 
         assert isinstance(swanlab.get_config(), SwanLabConfig)
         assert len(swanlab.get_config()) == 4
+
+        run.config.save()
 
     def test_config_from_omegaconf(self):
         """
@@ -231,6 +247,8 @@ class TestSwanLabRunConfig:
         assert run.config["c/d"] == [1, 2, 3]
         assert run.config["e/f/h"] == {"a": 1, "b": {"c": 2}}
 
+        run.config.save()
+
     def test_not_json_serializable(self):
         """
         测试不可json化的数据
@@ -249,6 +267,8 @@ class TestSwanLabRunConfig:
         run = SwanLabRun(run_config=config_data)
 
         json_data = json.dumps(dict(run.config))
+
+        run.config.save()
 
     def test_insert_class(self):
         """
@@ -280,3 +300,5 @@ class TestSwanLabRunConfig:
         run = SwanLabRun(run_config=config_data)
         assert run.config.test.data["a"] == 1
         assert run.config.test.data["b"] == 2
+
+        run.config.save()

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -47,16 +47,36 @@ class TestSwanLabRunConfig:
         assert run.config.get("e/f/h") == {"a": 1, "b": 2}
         assert run.config.get("e/f/h")["a"] == 1
 
-    # def test_config_set(self):
-    #     """
-    #     测试在init之后添加config参数
-    #     """
-    #     config_data = {
-    #         "a": 1,
-    #         "b": "mnist",
-    #         "c/d": [1, 2, 3],
-    #         "e/f/h": {"a": 1, "b": 2},
-    #     }
+    def test_config_update(self):
+        """
+        测试在init之后通过update的方式添加config参数
+        """
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": 2},
+        }
 
-    #     run = SwanLabRun()
-    #     assert len(run.config) == 0
+        run = SwanLabRun()
+        # assert len(run.config) == 0
+
+        run.config.update(config_data)
+        assert run.config == config_data
+
+        assert run.config["a"] == 1
+        assert run.config["b"] == "mnist"
+        assert run.config["c/d"] == [1, 2, 3]
+        assert run.config["c/d"][0] == 1
+        assert run.config["e/f/h"] == {"a": 1, "b": 2}
+        assert run.config["e/f/h"]["a"] == 1
+
+        assert run.config.a == 1
+        assert run.config.b == "mnist"
+
+        assert run.config.get("a") == 1
+        assert run.config.get("b") == "mnist"
+        assert run.config.get("c/d") == [1, 2, 3]
+        assert run.config.get("c/d")[0] == 1
+        assert run.config.get("e/f/h") == {"a": 1, "b": 2}
+        assert run.config.get("e/f/h")["a"] == 1

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -2,7 +2,6 @@ from swanlab.data.run.main import SwanLabRun, get_run, SwanLabConfig, swanlog
 from tutils import clear, TEMP_PATH
 import pytest
 import swanlab
-import argparse
 import omegaconf
 
 
@@ -188,13 +187,23 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"]["a"] == 1
         assert run.config["e/f/h"]["b"]["c"] == 2
 
-        assert run.config.a == 1
-        assert run.config.b == "mnist"
+    def test_config_from_omegaconf(self):
+        """
+        测试config导入omegaconf的情况
+        """
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+        }
+        config = omegaconf.OmegaConf.create(config_data)
+        run = SwanLabRun(config=config)
 
-        assert run.config.get("a") == 1
-        assert run.config.get("b") == "mnist"
-        assert run.config.get("c/d") == [1, 2, 3]
-        assert run.config.get("c/d")[0] == 1
-        assert run.config.get("e/f/h") == {"a": 1, "b": {"c": 2}}
-        assert run.config.get("e/f/h")["a"] == 1
-        assert run.config["e/f/h"]["b"]["c"] == 2
+        assert isinstance(run.config, SwanLabConfig)
+        assert len(run.config) == 4
+
+        assert run.config["a"] == 1
+        assert run.config["b"] == "mnist"
+        assert run.config["c/d"] == str([1, 2, 3])
+        assert run.config["e/f/h"] == str({"a": 1, "b": {"c": 2}})

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -248,38 +248,35 @@ class TestSwanLabRunConfig:
 
         run = SwanLabRun(run_config=config_data)
 
-        assert run.config.test_nan == "nan"
-        assert run.config.test_inf == "inf"
-
         json_data = json.dumps(dict(run.config))
 
-    # def test_insert_class(self):
-    #     """
-    #     测试插入类
-    #     """
-    #     from collections.abc import MutableMapping
+    def test_insert_class(self):
+        """
+        测试插入类
+        """
+        from collections.abc import MutableMapping
 
-    #     class Test(MutableMapping):
-    #         def __init__(self, a, b):
-    #             self.data = {"a": a, "b": b}
+        class Test(MutableMapping):
+            def __init__(self, a, b):
+                self.data = {"a": a, "b": b}
 
-    #         def __setitem__(self, __key, __value):
-    #             self.data[__key] = __value
+            def __setitem__(self, __key, __value):
+                self.data[__key] = __value
 
-    #         def __delitem__(self, __key):
-    #             del self.data[__key]
+            def __delitem__(self, __key):
+                del self.data[__key]
 
-    #         def __getitem__(self, __key):
-    #             return self.data.get(__key, None)
+            def __getitem__(self, __key):
+                return self.data.get(__key, None)
 
-    #         def __len__(self):
-    #             return len(self.data)
+            def __len__(self):
+                return len(self.data)
 
-    #         def __iter__(self):
-    #             return iter(self.data)
+            def __iter__(self):
+                return iter(self.data)
 
-    #     config_data = {"a": 1, "b": "mnist", "c/d": [1, 2, 3], "e/f/h": {"a": 1, "b": {"c": 2}}, "test": Test(1, 2)}
+        config_data = {"a": 1, "b": "mnist", "c/d": [1, 2, 3], "e/f/h": {"a": 1, "b": {"c": 2}}, "test": Test(1, 2)}
 
-    #     run = SwanLabRun(run_config=config_data)
-    #     assert run.config.test.a == 1
-    #     assert run.config.test.b == 2
+        run = SwanLabRun(run_config=config_data)
+        assert run.config.test.data["a"] == 1
+        assert run.config.test.data["b"] == 2

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -166,8 +166,6 @@ class TestSwanLabRunConfig:
         assert isinstance(run.config, SwanLabConfig)
         assert len(run.config) == 4
 
-        assert run.config == config_data
-
         assert run.config["a"] == 1
         assert run.config["b"] == "mnist"
         assert run.config["c/d"] == [1, 2, 3]
@@ -175,6 +173,42 @@ class TestSwanLabRunConfig:
         assert run.config["e/f/h"] == {"a": 1, "b": {"c": 2}}
         assert run.config["e/f/h"]["a"] == 1
         assert run.config["e/f/h"]["b"]["c"] == 2
+
+    def test_config_clean(self):
+        """
+        测试在finish之后config是否置空
+        """
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+        }
+
+        run = SwanLabRun(config=config_data)
+        run.finish()
+
+        assert isinstance(run.config, SwanLabConfig)
+        assert len(run.config) == 0
+
+    def test_config_get_config(self):
+        """
+        测试在finish之后config是否置空
+        """
+        config_data = {
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+        }
+
+        assert isinstance(swanlab.get_config(), SwanLabConfig)
+        assert len(swanlab.get_config()) == 0
+
+        run = SwanLabRun(config=config_data)
+
+        assert isinstance(swanlab.get_config(), SwanLabConfig)
+        assert len(swanlab.get_config()) == 4
 
     def test_config_from_omegaconf(self):
         """

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -1,6 +1,7 @@
-from swanlab.data.run.main import SwanLabRun, get_run, SwanLabRunState, swanlog
+from swanlab.data.run.main import SwanLabRun, get_run, SwanLabConfig, swanlog
 from tutils import clear, TEMP_PATH
 import pytest
+import swanlab
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -28,6 +29,8 @@ class TestSwanLabRunConfig:
             "e/f/h": {"a": 1, "b": 2},
         }
         run = SwanLabRun(config=config_data)
+        assert isinstance(run.config, SwanLabConfig)
+
         assert run.config == config_data
 
         assert run.config["a"] == 1
@@ -59,7 +62,10 @@ class TestSwanLabRunConfig:
         }
 
         run = SwanLabRun()
-        # assert len(run.config) == 0
+        assert isinstance(run.config, SwanLabConfig)
+
+        # 判断为空
+        assert len(run.config) == 0
 
         run.config.update(config_data)
         assert run.config == config_data


### PR DESCRIPTION
## Description

1. 较大地改进了config类，以应对更多可能出现bug的情况
2. 增加了对config的单元测试

Close: #594 

___________

其中对于在swanlab.init前定义swanlab.config的逻辑：

1. 我们支持在`swanlab.init`前，使用`swanlab.config.update`或`swanlab.config.set`等方式设置key, value，`swanlab.init`的时候config会被更新；
2. 如果直接用`swanlab.config={...}`的方式，相当于把`SwanLabConfig`类变成了一个dict，那么`swanlab.init`的时候config并不会被swanlab.config的内容更新，且swanlab.config失去了原有的诸多效果，但run.config并不受影响，代码的运行也不受影响
3. 第2点会在文档中提起
4. swanlab.finish()之后，config将被清空

