### PR TITLE
opt config

### DIFF
--- a/swanlab/api/upload/__init__.py
+++ b/swanlab/api/upload/__init__.py
@@ -93,8 +93,6 @@ def upload_files(files: List[FileModel]):
         for i in range(1, len(files) - 1):
             file_model = FileModel.create(files[i], file_model)
     data = file_model.to_dict()
-    if len(data) == 0:
-        return swanlog.warning("No files to upload after creating model.")
     http.put(f'/project/{http.groupname}/{http.projname}/runs/{http.exp_id}/profile', data)
 
 

--- a/swanlab/data/callback_cloud.py
+++ b/swanlab/data/callback_cloud.py
@@ -123,9 +123,9 @@ class CloudRunCallback(LocalRunCallback):
         # 执行local逻辑，保存文件到本地
         super(CloudRunCallback, self).on_runtime_info_update(r)
         # 添加上传任务到线程池
-        rc = r.config.info if r.config is not None else None
-        rr = r.requirements.dumps() if r.requirements is not None else None
-        rm = r.metadata.info if r.metadata is not None else None
+        rc = r.config.to_dict() if r.config is not None else None
+        rr = r.requirements.info if r.requirements is not None else None
+        rm = r.metadata.to_dict() if r.metadata is not None else None
         # 不需要json序列化，上传时会自动序列化
         f = FileModel(requirements=rr, config=rc, metadata=rm)
         self.pool.queue.put((UploadType.FILE, [f]))

--- a/swanlab/data/run/callback/utils.py
+++ b/swanlab/data/run/callback/utils.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     工具类
 """
-from typing import Optional
+from typing import Optional, Any
 from swanlab.data.run.settings import SwanDataSettings
 from swanlab.log import swanlog
 from swanlab.utils.font import FONT
@@ -33,7 +33,7 @@ class U:
         self.settings = settings
 
     @staticmethod
-    def formate_windows_path(path: str) -> str:
+    def fmt_windows_path(path: str) -> str:
         """这主要针对windows环境，输入的绝对路径可能不包含盘符，这里进行补充
         主要是用于打印效果
         如果不是windows环境，直接返回path，相当于没有调用这个函数
@@ -66,7 +66,7 @@ class U:
         swanlog.debug("SwanLab Runtime has initialized")
         swanlog.debug("SwanLab will take over all the print information of the terminal from now on")
         swanlog.info("Tracking run with swanlab version " + get_package_version())
-        local_path = FONT.magenta(FONT.bold(self.formate_windows_path(self.settings.run_dir)))
+        local_path = FONT.magenta(FONT.bold(self.fmt_windows_path(self.settings.run_dir)))
         swanlog.info("Run data will be saved locally in " + local_path)
 
     def _watch_tip_print(self):
@@ -75,7 +75,7 @@ class U:
         """
         swanlog.info(
             "🌟 Run `"
-            + FONT.bold("swanlab watch -l {}".format(self.formate_windows_path(self.settings.swanlog_dir)))
+            + FONT.bold("swanlab watch -l {}".format(self.fmt_windows_path(self.settings.swanlog_dir)))
             + "` to view SwanLab Experiment Dashboard locally"
         )
 

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -144,6 +144,7 @@ class SwanLabConfig(MutableMapping):
         self.__fmt_config(data)
         r = RuntimeInfo(config=self.__config)
         self.__on_setter(r)
+        swanlog.debug(f"Save configuration.")
 
     # ---------------------------------- 实现对象风格 ----------------------------------
 

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -107,7 +107,11 @@ class SwanLabConfig(MutableMapping):
     The configuration item must be JSON serializable; Cannot set private attributes by `.__xxx`.
     """
 
-    def __init__(self, config: MutableMapping = None, on_setter: Optional[Callable[[RuntimeInfo], Any]] = None):
+    def __init__(
+        self,
+        config: Union[MutableMapping, argparse.Namespace] = None,
+        on_setter: Optional[Callable[[RuntimeInfo], Any]] = None
+    ):
         """
         实例化配置类，如果settings不为None，说明是通过swanlab.init调用的，否则是通过swanlab.config调用的
         """

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -16,7 +16,7 @@ from enum import Enum
 from .exp import SwanLabExp
 from datetime import datetime
 from typing import Callable, Optional, Dict, MutableMapping
-from .operator import SwanLabRunOperator
+from .operator import SwanLabRunOperator, RuntimeInfo
 from swanlab.env import get_mode
 import random
 
@@ -43,7 +43,7 @@ class SwanLabRun:
         project_name: str = None,
         experiment_name: str = None,
         description: str = None,
-        run_config: MutableMapping = None,
+        run_config=None,
         log_level: str = None,
         suffix: str = None,
         exp_num: int = None,
@@ -62,7 +62,7 @@ class SwanLabRun:
         description : str, optional
             实验描述，用于对当前实验进行更详细的介绍或标注
             如果不提供此参数(为None)，可以在web界面中进行修改,这意味着必须在此改为空字符串""
-        run_config : MutableMapping, optional
+        run_config : Any, optional
             实验参数配置，可以在web界面中显示，如学习率、batch size等
             不需要做任何限制，但必须是字典类型，可被json序列化，否则会报错
         log_level : str, optional
@@ -93,8 +93,10 @@ class SwanLabRun:
         # ---------------------------------- 初始化日志记录器 ----------------------------------
         swanlog.set_level(self.__check_log_level(log_level))
         # ---------------------------------- 初始化配置 ----------------------------------
-        # 给外部1个config
-        self.__config = SwanLabConfig(run_config, self.__settings)
+        global config
+        config.update(run_config)
+        setattr(config, "_SwanLabConfig__on_setter", self.__operator.on_runtime_info_update)
+        self.__config = config
         # ---------------------------------- 注册实验 ----------------------------------
         self.__exp: SwanLabExp = self.__register_exp(experiment_name, description, suffix, num=exp_num)
         # 实验状态标记，如果status不为0，则无法再次调用log方法
@@ -175,11 +177,11 @@ class SwanLabRun:
         :param state: The state of the experiment, it can be 'SUCCESS', 'CRASHED' or 'RUNNING'.
         :param error: The error message when the experiment is marked as 'CRASHED'. If not 'CRASHED', it should be None.
         """
-        global run
+        global run, config
         # 分为几步
         # 1. 设置数据库实验状态为对应状态
         # 2. 判断是否为云端同步，如果是则开始关闭线程池和同步状态
-        # 3. 清空run和config对象，run改为局部变量_run，config被清空
+        # 3. 清空run和config对象，run改为局部变量_run，新建一个config对象，原本的config对象内容转移到新的config对象，全局config被清空
         # 4. 返回_run
         if run is None:
             raise RuntimeError("The run object is None, please call `swanlab.init` first.")
@@ -195,7 +197,10 @@ class SwanLabRun:
             # disabled 模式下没有install，所以会报错
             pass
 
-        run.config.clean()
+        # ---------------------------------- 清空config和run ----------------------------------
+        _config = SwanLabConfig(config)
+        setattr(run, "_SwanLabRun__config", _config)
+        config.clean()
         _run, run = run, None
 
         return _run
@@ -209,7 +214,7 @@ class SwanLabRun:
         return self.__settings
 
     @property
-    def config(self):
+    def config(self) -> SwanLabConfig:
         """
         This property allows you to access the 'config' content passed through `init`,
         and allows you to modify it. The latest configuration after each modification
@@ -343,8 +348,12 @@ _change_run_state: Optional["Callable"] = None
 """
 修改实验状态的函数，用于在实验状态改变时调用
 """
+
+# 全局唯一的config对象，不应该重新赋值
 config: Optional["SwanLabConfig"] = SwanLabConfig()
-"""Global config instance. After the user calls finish(), config will be set to None."""
+"""
+Global config instance.
+"""
 
 
 def _set_run_state(state: SwanLabRunState):

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -15,8 +15,8 @@ from .config import SwanLabConfig
 from enum import Enum
 from .exp import SwanLabExp
 from datetime import datetime
-from typing import Callable, Optional, Dict, MutableMapping
-from .operator import SwanLabRunOperator, RuntimeInfo
+from typing import Callable, Optional, Dict
+from .operator import SwanLabRunOperator
 from swanlab.env import get_mode
 import random
 
@@ -112,6 +112,8 @@ class SwanLabRun:
 
         # ---------------------------------- 初始化完成 ----------------------------------
         self.__operator.on_run()
+        # 执行__save，必须在on_run之后，因为on_run之前部分的信息还没完全初始化
+        getattr(config, "_SwanLabConfig__save")()
 
     @property
     def operator(self) -> SwanLabRunOperator:

--- a/swanlab/data/run/operator.py
+++ b/swanlab/data/run/operator.py
@@ -116,4 +116,7 @@ class SwanLabRunOperator(SwanLabRunCallback):
         return self.__run_all("on_column_create", column_info)
 
     def on_stop(self, error: str = None):
-        return self.__run_all("on_stop", error)
+        r = self.__run_all("on_stop", error)
+        # 清空所有注册的回调函数
+        self.callbacks.clear()
+        return r

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -4,7 +4,6 @@ from swanlab.data.run.main import SwanLabRun, get_run, swanlog, get_config
 from swanlab.data.run.config import SwanLabConfig, parse, Line, RuntimeInfo, MutableMapping
 from tutils import clear
 import pytest
-import swanlab
 import omegaconf
 import argparse
 

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -1,11 +1,12 @@
 import math
 import yaml
-from swanlab.data.run.main import SwanLabRun, get_run, swanlog
-from swanlab.data.run.config import SwanLabConfig, parse, Line, RuntimeInfo
+from swanlab.data.run.main import SwanLabRun, get_run, swanlog, get_config
+from swanlab.data.run.config import SwanLabConfig, parse, Line, RuntimeInfo, MutableMapping
 from tutils import clear
 import pytest
 import swanlab
 import omegaconf
+import argparse
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -35,7 +36,33 @@ def test_parse():
     cfg = omegaconf.OmegaConf.create(config_data)
     config = parse(cfg)
     assert yaml.dump(config) == yaml.dump(config_data)
-    # ---------------------------------- 包含NaN或者INF ----------------------------------
+
+    # ---------------------------------- 自定义继承自MutableMapping的类 ----------------------------------
+
+    class Test(MutableMapping):
+        def __init__(self, a, b):
+            self.data = {"a": a, "b": b}
+
+        def __setitem__(self, __key, __value):
+            self.data[__key] = __value
+
+        def __delitem__(self, __key):
+            del self.data[__key]
+
+        def __getitem__(self, __key):
+            return self.data.get(__key, None)
+
+        def __len__(self):
+            return len(self.data)
+
+        def __iter__(self):
+            return iter(self.data)
+
+    config_data = {"a": 1, "b": "mnist", "c/d": [1, 2, 3], "e/f/h": {"a": 1, "b": {"c": 2}}, "test": Test(1, 2)}
+    config = parse(config_data)
+    assert config["test"]["a"] == 1
+    assert config["test"]["b"] == 2
+    # ---------------------------------- 包含NaN或者INF的dict对象 ----------------------------------
     config_data = {
         "inf": math.inf,
         "nan": math.nan,
@@ -43,9 +70,13 @@ def test_parse():
     config = parse(config_data)
     assert config["inf"] == Line.inf
     assert config["nan"] == Line.nan
+    # ---------------------------------- argparse.Namespace ----------------------------------
+    config_data = argparse.Namespace(a=1, b="mnist", c=[1, 2, 3], d={"a": 1, "b": {"c": 2}})
+    config = parse(config_data)
+    assert yaml.dump(config) == yaml.dump(vars(config_data))
 
 
-class TestSwanLabRunConfigOperation:
+class TestSwanLabConfigOperation:
     """
     单独测试TestSwanLabRunConfig这个类
     """
@@ -96,6 +127,10 @@ class TestSwanLabRunConfigOperation:
             del config["__a"]  # 重复删除失败
         with pytest.raises(KeyError):
             config["__a"]  # noqa
+        # int访问，设置
+        config[1] = 1  # noqa
+        with pytest.raises(TypeError):
+            assert config[1] == 1  # noqa
 
     def test_dict_iter(self):
         """
@@ -165,6 +200,20 @@ class TestSwanLabRunConfigOperation:
         assert config["x"] == 2
         assert config["y"] == 3
         assert config["z"] == {"a": 2, "b": 3}
+        # update自己
+        _config = SwanLabConfig()
+        _config.update(config)
+        assert _config == config
+        # update，argparse.Namespace
+        _config = SwanLabConfig()
+        _config.update(argparse.Namespace(a=1, b=2))
+        assert _config["a"] == 1
+        assert _config["b"] == 2
+        # update, use kwargs
+        _config = SwanLabConfig()
+        _config.update(a=2, b=1)
+        assert _config["a"] == 2
+        assert _config["b"] == 1
 
 
 def test_on_setter():
@@ -228,251 +277,82 @@ def test_on_setter():
     assert num == 11
 
 
-class TestSwanLabRunConfigUseRun:
+class TestSwanLabConfigWithRun:
     """
-    测试SwanLabRun的config属性
+    测试SwanLabConfig与SwanLabRun的交互
     """
 
-    def test_config_normal_haverun(self):
+    def test_use_dict(self):
         """
-        初始化时有config参数，测试三种获取数据的方式，且使用的run对象
+        正常流程，输入字典
         """
-        config_data = {
+        run = SwanLabRun(run_config={
             "a": 1,
             "b": "mnist",
             "c/d": [1, 2, 3],
             "e/f/h": {"a": 1, "b": {"c": 2}},
-        }
-        run = SwanLabRun(run_config=config_data)
-        assert isinstance(run.config, SwanLabConfig)
-        assert len(run.config) == 4
+        })
+        config = run.config
+        _config = get_config()
+        assert config["a"] == _config["a"] == 1
+        assert config["b"] == _config["b"] == "mnist"
+        assert config["c/d"] == _config["c/d"] == [1, 2, 3]
 
-        assert run.config == config_data
-
-        assert run.config["a"] == 1
-        assert run.config["b"] == "mnist"
-        assert run.config["c/d"] == [1, 2, 3]
-        assert run.config["c/d"][0] == 1
-        assert run.config["e/f/h"] == {"a": 1, "b": {"c": 2}}
-        assert run.config["e/f/h"]["a"] == 1
-        assert run.config["e/f/h"]["b"]["c"] == 2
-
-        assert run.config.a == 1
-        assert run.config.b == "mnist"
-
-        assert run.config.get("a") == 1
-        assert run.config.get("b") == "mnist"
-        assert run.config.get("c/d") == [1, 2, 3]
-        assert run.config.get("c/d")[0] == 1
-        assert run.config.get("e/f/h") == {"a": 1, "b": {"c": 2}}
-        assert run.config.get("e/f/h")["a"] == 1
-        assert run.config["e/f/h"]["b"]["c"] == 2
-
-        run.config.save()
-
-    def test_config_finish_haverun(self):
+    def test_use_omegaconf(self):
         """
-        测试在run.finish()之后config是否置空
+        正常流程，输入OmegaConf
         """
-        config_data = {
+        run = SwanLabRun(run_config=omegaconf.OmegaConf.create({
             "a": 1,
             "b": "mnist",
             "c/d": [1, 2, 3],
             "e/f/h": {"a": 1, "b": {"c": 2}},
-        }
+        }))
+        config = run.config
+        _config = get_config()
+        assert config["a"] == _config["a"] == 1
+        assert config["b"] == _config["b"] == "mnist"
+        assert config["c/d"] == _config["c/d"] == [1, 2, 3]
 
-        run = SwanLabRun(run_config=config_data)
+    def test_use_argparse(self):
+        """
+        正常流程，输入argparse.Namespace
+        """
+        run = SwanLabRun(run_config=argparse.Namespace(a=1, b="mnist", c=[1, 2, 3], d={"a": 1, "b": {"c": 2}}))
+        config = run.config
+        _config = get_config()
+        assert config["a"] == _config["a"] == 1
+        assert config["b"] == _config["b"] == "mnist"
+        assert config["c"] == _config["c"] == [1, 2, 3]
+
+    def test_use_config(self):
+        """
+        正常流程，输入SwanLabConfig
+        """
+        run = SwanLabRun(run_config=SwanLabConfig({
+            "a": 1,
+            "b": "mnist",
+            "c": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+        }))
+        config = run.config
+        _config = get_config()
+        assert config["a"] == _config["a"] == 1
+        assert config["b"] == _config["b"] == "mnist"
+        assert config["c"] == _config["c"] == [1, 2, 3]
+
+    def test_after_finish(self):
+        """
+        测试在finish之后config的变化
+        """
+        run = SwanLabRun(run_config={
+            "a": 1,
+            "b": "mnist",
+            "c/d": [1, 2, 3],
+            "e/f/h": {"a": 1, "b": {"c": 2}},
+        })
         run.finish()
-
-        assert isinstance(run.config, SwanLabConfig)
-        assert len(run.config) == 0
-
-        run.config.save()
-
-    def test_config_normal(self):
-        """
-        初始化时有config参数，测试三种获取数据的方式，直接用全局的config对象
-        """
-        config_data = {
-            "a": 1,
-            "b": "mnist",
-            "c/d": [1, 2, 3],
-            "e/f/h": {"a": 1, "b": {"c": 2}},
-        }
-        config = SwanLabConfig(config=config_data)
-
-        assert isinstance(config, SwanLabConfig)
+        config = run.config
+        _config = get_config()
         assert len(config) == 4
-
-        assert config == config_data
-
-        assert config["a"] == 1
-        assert config["b"] == "mnist"
-        assert config["c/d"] == [1, 2, 3]
-        assert config["c/d"][0] == 1
-        assert config["e/f/h"] == {"a": 1, "b": {"c": 2}}
-        assert config["e/f/h"]["a"] == 1
-        assert config["e/f/h"]["b"]["c"] == 2
-
-        assert config.a == 1
-        assert config.b == "mnist"
-
-        assert config.get("a") == 1
-        assert config.get("b") == "mnist"
-        assert config.get("c/d") == [1, 2, 3]
-        assert config.get("c/d")[0] == 1
-        assert config.get("e/f/h") == {"a": 1, "b": {"c": 2}}
-        assert config.get("e/f/h")["a"] == 1
-        assert config["e/f/h"]["b"]["c"] == 2
-
-        config.save()
-        config.clean()
-
-    def test_config_update(self):
-        """
-        测试config初始为空，之后通过update的方式添加config参数
-        """
-
-        config_data = {
-            "a": 1,
-            "b": "mnist",
-            "c/d": [1, 2, 3],
-            "e/f/h": {"a": 1, "b": {"c": 2}},
-        }
-
-        update_data = {
-            "a": 2,
-            "e/f/h": [4, 5, 6],
-            "j": 3,
-        }
-
-        config = SwanLabConfig()
-        assert len(config) == 0
-
-        # 第一次更新
-        config.update(config_data)
-        assert config == config_data
-        assert len(config) == 4
-
-        assert config["a"] == 1
-        assert config["b"] == "mnist"
-        assert config["c/d"] == [1, 2, 3]
-        assert config["c/d"][0] == 1
-        assert config["e/f/h"] == {"a": 1, "b": {"c": 2}}
-        assert config["e/f/h"]["a"] == 1
-        assert config["e/f/h"]["b"]["c"] == 2
-
-        # 第二次更新
-        config.update(update_data)
-        assert len(config) == 5
-
-        assert config["a"] == 2
-        assert config["e/f/h"] == [4, 5, 6]
-        assert config["e/f/h"][0] == 4
-        assert config["j"] == 3
-
-        config.save()
-        config.clean()
-
-    def test_config_get_config(self):
-        """
-        测试get_config
-        """
-        config_data = {
-            "a": 1,
-            "b": "mnist",
-            "c/d": [1, 2, 3],
-            "e/f/h": {"a": 1, "b": {"c": 2}},
-        }
-
-        assert isinstance(swanlab.get_config(), SwanLabConfig)
-        assert len(swanlab.get_config()) == 0
-
-        config = SwanLabConfig(config=config_data)
-
-        assert isinstance(swanlab.get_config(), SwanLabConfig)
-        assert len(swanlab.get_config()) == 4
-
-        config.save()
-        config.clean()
-
-    def test_config_from_omegaconf(self):
-        """
-        测试config导入omegaconf的情况
-        """
-        config_data = {
-            "a": 1,
-            "b": "mnist",
-            "c/d": [1, 2, 3],
-            "e/f/h": {"a": 1, "b": {"c": 2}},
-        }
-        cfg = omegaconf.OmegaConf.create(config_data)
-        config = SwanLabConfig(config=config_data)
-
-        assert isinstance(config, SwanLabConfig)
-        assert len(config) == 4
-
-        assert config["a"] == 1
-        assert config["b"] == "mnist"
-        assert config["c/d"] == [1, 2, 3]
-        assert config["e/f/h"] == {"a": 1, "b": {"c": 2}}
-
-        config.save()
-        config.clean()
-
-    def test_not_json_serializable(self):
-        """
-        测试不可json化的数据
-        """
-        import math, json
-
-        config_data = {
-            "a": 1,
-            "b": "mnist",
-            "c/d": [1, 2, 3],
-            "e/f/h": {"a": 1, "b": {"c": 2}},
-            "test_nan": math.nan,
-            "test_inf": math.inf,
-        }
-
-        config = SwanLabConfig(config=config_data)
-
-        json_data = json.dumps(dict(config))
-
-        config.save()
-        config.clean()
-
-    def test_insert_class(self):
-        """
-        测试插入类
-        """
-        from collections.abc import MutableMapping
-
-        class Test(MutableMapping):
-            def __init__(self, a, b):
-                self.data = {"a": a, "b": b}
-
-            def __setitem__(self, __key, __value):
-                self.data[__key] = __value
-
-            def __delitem__(self, __key):
-                del self.data[__key]
-
-            def __getitem__(self, __key):
-                return self.data.get(__key, None)
-
-            def __len__(self):
-                return len(self.data)
-
-            def __iter__(self):
-                return iter(self.data)
-
-        config_data = {"a": 1, "b": "mnist", "c/d": [1, 2, 3], "e/f/h": {"a": 1, "b": {"c": 2}}, "test": Test(1, 2)}
-
-        config = SwanLabConfig(config=config_data)
-
-        assert config.test.data["a"] == 1
-        assert config.test.data["b"] == 2
-
-        config.save()
-        config.clean()
+        assert len(_config) == 0

--- a/test/unit/data/run/pytest_config.py
+++ b/test/unit/data/run/pytest_config.py
@@ -1,4 +1,7 @@
-from swanlab.data.run.main import SwanLabRun, get_run, SwanLabConfig, swanlog
+import math
+import yaml
+from swanlab.data.run.main import SwanLabRun, get_run, swanlog
+from swanlab.data.run.config import SwanLabConfig, parse, Line, RuntimeInfo
 from tutils import clear
 import pytest
 import swanlab
@@ -18,7 +21,218 @@ def setup_function():
     swanlog.enable_log()
 
 
-class TestSwanLabRunConfig:
+def test_parse():
+    """
+    测试config.parse函数
+    """
+    # ---------------------------------- omegaConf ----------------------------------
+    config_data = {
+        "a": 1,
+        "b": "mnist",
+        "c/d": [1, 2, 3],
+        "e/f/h": {"a": 1, "b": {"c": 2}},
+    }
+    cfg = omegaconf.OmegaConf.create(config_data)
+    config = parse(cfg)
+    assert yaml.dump(config) == yaml.dump(config_data)
+    # ---------------------------------- 包含NaN或者INF ----------------------------------
+    config_data = {
+        "inf": math.inf,
+        "nan": math.nan,
+    }
+    config = parse(config_data)
+    assert config["inf"] == Line.inf
+    assert config["nan"] == Line.nan
+
+
+class TestSwanLabRunConfigOperation:
+    """
+    单独测试TestSwanLabRunConfig这个类
+    """
+
+    def test_basic_operation_object(self):
+        """
+        测试类的基本操作，增删改
+        """
+        config = SwanLabConfig()
+        # ---------------------------------- 对象风格设置 ----------------------------------
+        config.a = 1
+        assert config.a == 1
+        config.a = 2
+        assert config.a == 2
+        with pytest.raises(AttributeError):
+            config.__a = 1
+        # 不存在的属性
+        with pytest.raises(AttributeError):
+            config.b  # noqa
+        # 删除属性
+        del config.a
+        with pytest.raises(AttributeError):
+            del config.a  # 重复删除报错
+        with pytest.raises(AttributeError):
+            config.a  # noqa
+
+    def test_basic_operation_dict(self):
+        """
+        测试字典的基本操作，增删改
+        """
+        config = SwanLabConfig()
+        # ---------------------------------- 字典风格设置 ----------------------------------
+        config["a"] = 1
+        assert config["a"] == 1
+        config["a"] = 2
+        assert config["a"] == 2
+        # 删除属性
+        del config["a"]
+        with pytest.raises(KeyError):
+            del config["a"]
+        with pytest.raises(KeyError):
+            config["a"]  # noqa
+        # 字典风格可以设置，读取，删除私有属性
+        config["__a"] = 1
+        assert config["__a"] == 1
+        del config["__a"]
+        with pytest.raises(KeyError):
+            del config["__a"]  # 重复删除失败
+        with pytest.raises(KeyError):
+            config["__a"]  # noqa
+
+    def test_dict_iter(self):
+        """
+        测试字典风格的迭代
+        """
+        config = SwanLabConfig()
+        ll = ["a", "b", "c", "d"]
+        for i in ll:
+            config[i] = i
+        assert set(config) == {"a", "b", "c", "d"}
+        index = 0
+        # 返回顺序相同
+        for key in config:
+            assert key == ll[index]
+            index += 1
+
+    def test_dict_len(self):
+        """
+        测试字典风格的长度
+        """
+        config = SwanLabConfig()
+        assert len(config) == 0
+        config["a"] = 1
+        assert len(config) == 1
+        config["b"] = 2
+        assert len(config) == 2
+        del config["a"]
+        assert len(config) == 1
+        del config["b"]
+        assert len(config) == 0
+
+    def test_func_operation(self):
+        """
+        测试内置函数操作
+        """
+        config = SwanLabConfig()
+        # ---------------------------------- get ----------------------------------
+        a = config.get("a")
+        assert a is None
+        a = config.get("a", 1)
+        assert a == 1
+        config["a"] = 5
+        a = config.get("a")
+        assert a == 5
+        # ---------------------------------- set ----------------------------------
+        config.set("b", 1)
+        assert config["b"] == 1
+        config.set("__b", 1)
+        assert config["__b"] == 1
+        # ---------------------------------- pop ----------------------------------
+        config["c"] = 9
+        c = config.pop("c")
+        assert c == 9
+        assert config.pop("d") is None
+        # ---------------------------------- clean ----------------------------------
+        config["e"] = 1
+        config["g"] = 0
+        config.clean()
+        assert len(config) == 0
+        with pytest.raises(KeyError):
+            config["e"]  # noqa
+        # ---------------------------------- update ----------------------------------
+        config["x"] = 1
+        config["y"] = 2
+        config["z"] = {"a": 1, "b": 2}
+        config.update({"x": 2, "y": 3, "z": {"a": 2, "b": 3}})
+        assert config["x"] == 2
+        assert config["y"] == 3
+        assert config["z"] == {"a": 2, "b": 3}
+
+
+def test_on_setter():
+    """
+    测试on_setter函数，在设置属性时触发
+    """
+    num = 1
+
+    def on_setter(_: RuntimeInfo):
+        nonlocal num
+        num += 1
+
+    config = SwanLabConfig(on_setter=on_setter)
+
+    # ---------------------------------- 对象、字典风格 ----------------------------------
+
+    # 设置触发
+    config.a = 1
+    assert num == 2
+    del config.a
+    assert num == 3
+    config["b"] = 1
+    assert num == 4
+    del config["b"]
+    assert num == 5
+
+    # 读取不触发
+    config.x = 1
+    assert num == 6
+    _ = config.x
+    assert num == 6
+    config["y"] = 1
+    assert num == 7
+    _ = config["y"]
+    assert num == 7
+
+    # ---------------------------------- api ----------------------------------
+
+    # 设置触发
+    config.set("c", 1)
+    assert num == 8
+    config.pop("c")
+    assert num == 9
+    config.update({"d": {}})
+    assert num == 10
+    # 深层设置无法触发
+    config.d["e"] = 1
+    assert num == 10
+
+    # 读取不触发
+    config.get("f", 1)
+    config["g"] = 1
+    assert num == 11
+    config.get("g")
+    assert num == 11
+
+    # ---------------------------------- clean以后再设置无法触发 ----------------------------------
+
+    config.clean()
+    config.h = 1
+    assert num == 11
+
+
+class TestSwanLabRunConfigUseRun:
+    """
+    测试SwanLabRun的config属性
+    """
+
     def test_config_normal_haverun(self):
         """
         初始化时有config参数，测试三种获取数据的方式，且使用的run对象


### PR DESCRIPTION
## Description

对config做了一些优化，并增加一些测试，包括如下内容：

> 以下设计基于用户不设置私有属性，也就是说无法通过`config.__a = 1`的方式设置配置，在python层面这就是不被推荐的

### 更改SwanLabConfig

SwanLabConfig继承 `MutableMapping`，这意味着可以使用与字典相同的方式使用SwanLabConfig实例，并且增加以下内容：

1. 支持通过属性的方式设置和访问，类似：`config.a=1`与`config.a==1`——需要注意的是如果访问属性时不存在将报错，这与字典类似，并且不允许设置私有属性
2. SwanLabConfig实例化时可输入两个参数，分别是`config`和`on_setter`，config可支持MutableMapping，包括输入的是SwanLabConfig
4. 添加了与字典一样的get方法，可以设置默认值
5. 添加update方法，传入的对象必须是MutableMapping或者argparse.Namespace，也支持类似`update(a=1)`的方式设置——不过update只能覆盖，比如原本数据是`config.a={"b":1}`，此时设置`config.update(a={"c":1})`会变为`config.a={"c":1}`
6. 需要注意的是，处于性能考虑，如果是深层次的设置，例如`config.a["b"]`此时无法触发保存方法，这种情况推荐使用update方法

### config全局挂载

在实验开始前，可以通过`swanlab.config`访问、设置配置，当实验开始后，`run.config`和`swanlab.config`本质上指向同一个实例，因此对于其修改，本质上是对同一个实例的修改。

在实验结束后，swanlab.config被清空，`run.config`保留，但是run.config的设置将不再触发保存。

----

并且，保存时接入操作员——`cloud-only`模式即将完成，将在下一个pr实现。