### PR TITLE
Feat/Env add PID and verbose Python version

### DIFF
--- a/swanlab/data/run/system/info.py
+++ b/swanlab/data/run/system/info.py
@@ -235,7 +235,8 @@ def get_system_info(version: str, logdir: str):
         "swanlab": {"version": version, "logdir": logdir},  # swanlab 版本号和日志目录
         "hostname": socket.gethostname(),  # 主机名
         "os": platform.platform(),  # 操作系统
-        "python": {"version": platform.python_version(), "verbose": sys.version},  # python版本
+        "python": platform.python_version(),  # python版本
+        "python_verbose": sys.version,  # python详细版本
         "executable": sys.executable,  # python 解释器路径
         "git_remote": __get_remote_url(),  # 获取远程仓库的链接
         "cpu": multiprocessing.cpu_count(),  # cpu 核心数

--- a/swanlab/data/run/system/info.py
+++ b/swanlab/data/run/system/info.py
@@ -14,6 +14,7 @@ import subprocess
 import multiprocessing
 import pynvml
 from swanlab.log import swanlog
+import os
 
 
 def __replace_second_colon(input_string, replacement):
@@ -231,10 +232,10 @@ def get_system_info(version: str, logdir: str):
     :param logdir: swanlab日志目录
     """
     return {
-        "swanlab": {"version": version, "logdir": logdir},
-        "hostname": socket.gethostname(),
-        "os": platform.platform(),
-        "python": platform.python_version(),
+        "swanlab": {"version": version, "logdir": logdir},  # swanlab 版本号和日志目录
+        "hostname": socket.gethostname(),  # 主机名
+        "os": platform.platform(),  # 操作系统
+        "python": {"version": platform.python_version(), "verbose": sys.version},  # python版本
         "executable": sys.executable,  # python 解释器路径
         "git_remote": __get_remote_url(),  # 获取远程仓库的链接
         "cpu": multiprocessing.cpu_count(),  # cpu 核心数
@@ -243,4 +244,5 @@ def get_system_info(version: str, logdir: str):
         "command": __get_command(),  # 完整命令行信息
         "memory": __get_memory_size(),  # 内存大小
         "cwd": __get_cwd(),  # 当前工作目录路径
+        "pid": os.getpid(),  # 当前进程ID
     }


### PR DESCRIPTION
## Description

1. "pid"：增加了对PID（进程号）的记录
2. "python_verbose"：增加了对Python详细版本信息的记录

```python
    return {
        "swanlab": {"version": version, "logdir": logdir},  # swanlab 版本号和日志目录
        "hostname": socket.gethostname(),  # 主机名
        "os": platform.platform(),  # 操作系统
        "python": platform.python_version(),  # python版本
        "python_verbose": sys.version,  # python详细版本
        "executable": sys.executable,  # python 解释器路径
        "git_remote": __get_remote_url(),  # 获取远程仓库的链接
        "cpu": multiprocessing.cpu_count(),  # cpu 核心数
        "gpu": __get_gpu_info(),  # gpu 相关信息
        "git_info": __get_git_branch_and_commit(),  # git 分支和最新 commit 信息
        "command": __get_command(),  # 完整命令行信息
        "memory": __get_memory_size(),  # 内存大小
        "cwd": __get_cwd(),  # 当前工作目录路径
        "pid": os.getpid(),  # 当前进程ID
    }

```
