### PR TITLE
fix sharding and encoding

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ ipykernel
 torch
 torchvision
 python-dotenv
+freezegun

--- a/test/unit/log/pytest_log.py
+++ b/test/unit/log/pytest_log.py
@@ -7,11 +7,13 @@ r"""
 @Description:
     测试swanlog类，只需测试其日志监听功能
 """
+import os
+import sys
 import pytest
 from swanlab.log import swanlog
 from tutils import TEMP_PATH
 from nanoid import generate
-import os
+from freezegun import freeze_time
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -111,3 +113,18 @@ class TestSwanLogInstall:
             content = f.readlines()
             assert content[-2] != "swanlab: " + a + "\n"
             assert content[-1] == "swanlab: " + b + "\n"
+
+    def test_write_sharding(self, monkeypatch):
+        """
+        测试日志文件分片
+        """
+        console_dir = self.create_console_dir()
+        with freeze_time('2020-10-06'):
+            swanlog.install(console_dir)
+            print("1234")
+            assert os.path.exists(os.path.join(console_dir, "2020-10-06.log"))
+        with freeze_time('2020-10-07'):
+            p = os.path.join(console_dir, "2020-10-07.log")
+            assert not os.path.exists(p)
+            print("1234")
+            assert os.path.exists(p)

--- a/tutils/__init__.py
+++ b/tutils/__init__.py
@@ -33,4 +33,6 @@ def open_dev_mode() -> str:
     在上层config部分已经执行了环境变量注入
     :return: api-key
     """
+    if not os.path.exists(TEMP_PATH):
+        os.mkdir(TEMP_PATH)
     return TEST_CLOUD_KEY

--- a/tutils/__init__.py
+++ b/tutils/__init__.py
@@ -24,6 +24,8 @@ def reset_some_env():
         os.environ[SwanLabEnv.SWANLAB_WEB_HOST.value] = web
 
 
+if not os.path.exists(TEMP_PATH):
+    os.mkdir(TEMP_PATH)
 reset_some_env()
 
 
@@ -33,6 +35,4 @@ def open_dev_mode() -> str:
     在上层config部分已经执行了环境变量注入
     :return: api-key
     """
-    if not os.path.exists(TEMP_PATH):
-        os.mkdir(TEMP_PATH)
     return TEST_CLOUD_KEY

--- a/tutils/check.py
+++ b/tutils/check.py
@@ -19,8 +19,8 @@ swanlab_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 swanboard = subprocess.run("pip show swanboard", shell=True, capture_output=True).stdout.decode()
 swankit = subprocess.run("pip show swankit", shell=True, capture_output=True).stdout.decode()
-swanboard_version = [i.split(": ")[1] for i in swanboard.split("\n") if i.startswith("Version")][0]
-swankit_version = [i.split(": ")[1] for i in swankit.split("\n") if i.startswith("Version")][0]
+swanboard_version = [i.split(": ")[1] for i in swanboard.split("\n") if i.startswith("Version")][0].split('\r')[0]
+swankit_version = [i.split(": ")[1] for i in swankit.split("\n") if i.startswith("Version")][0].split('\r')[0]
 with open(os.path.join(swanlab_dir, "requirements.txt"), "r") as f:
     packages = f.read().split("\n")
 packages = [i for i in packages if "swanboard" in i or "swankit" in i]


### PR DESCRIPTION
## Description

解决了两个问题：

* 修复日志文件分片，新增加一个`freezegun`工具用于测试时的时间冻结
* 终端标准输出流编码问题，如果系统为gbk编码，输出类似emoji符号时将会报错，但此问题无法有效复现，正确的处理应该是用户设置`LANG=utf-8`环境变量，现在的处理是增加`UnicodeEncodeError`捕获，如果出错就pass

---

如果有比较详细的错误描述和复现流程会更好，但目前没有
