### PR TITLE
修复win环境下部分指标无法跟踪的问题

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,19 +37,26 @@
       "type": "debugpy",
       "request": "launch",
       "module": "pytest",
-      "args": [
-        "${file}"
-      ],
+      "args": ["${file}"],
       "console": "integratedTerminal"
+    },
+    {
+      "name": "（跳过云）进行所有单元测试",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["test/unit"],
+      "console": "integratedTerminal",
+      "env": {
+        "TEST_CLOUD_SKIP": "true"
+      }
     },
     {
       "name": "进行所有单元测试",
       "type": "debugpy",
       "request": "launch",
       "module": "pytest",
-      "args": [
-        "test/unit"
-      ],
+      "args": ["test/unit"],
       "console": "integratedTerminal"
     },
     // 打包命令

--- a/swanlab/data/formater.py
+++ b/swanlab/data/formater.py
@@ -198,6 +198,7 @@ def check_unique_on_case_insensitive(names: List[str]):
 def check_win_reserved_folder_name(folder_name: str, auto_fix=True) -> str:
     """
     Check if a folder name is reserved or not support to Windows.
+    see detail: https://learn.microsoft.com/zh-cn/biztalk/core/restrictions-when-configuring-the-file-adapter
 
     Parameters
     ----------
@@ -218,7 +219,7 @@ def check_win_reserved_folder_name(folder_name: str, auto_fix=True) -> str:
         key not support to Windows.
     """
     # Regular expression to match reserved names optionally followed by a dot (.) and any character
-    reserved_pattern = re.compile(r"^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$", re.IGNORECASE)
+    reserved_pattern = re.compile(r"^(CON|PRN|AUX|CLOCK\$|NUL|COM[1-9]|LPT[1-9])(\..*)?$", re.IGNORECASE)
 
     # Check if the cleaned folder name is in the reserved names list
     if bool(reserved_pattern.match(folder_name)):

--- a/swanlab/data/formater.py
+++ b/swanlab/data/formater.py
@@ -160,7 +160,7 @@ def check_key_format(key: str, auto_cut=True) -> str:
         raise ValueError(f"tag: {key} is an empty string")
     if key.startswith((".", "/")):
         raise ValueError(f"tag: {key} can't start with '.' or '/' and blank space")
-    if key.endswith(".", "/"):  # cannot create folder end with '.' or '/'
+    if key.endswith((".", "/")):  # cannot create folder end with '.' or '/'
         raise ValueError(f"tag: {key} can't end with '.' or '/' and blank space")
     # 检查长度
     return _auto_cut("tag", key, max_len, auto_cut)

--- a/swanlab/data/formater.py
+++ b/swanlab/data/formater.py
@@ -185,11 +185,13 @@ def check_unique_on_case_insensitive(names: List[str]):
     ValueError
         names are not unique
     """
-    lower_names_set = set([n.lower() for n in names])
-
+    exist_names_set = set()
     for n in names:
-        if n in lower_names_set:
+        n_lower = n.lower()
+        if n_lower in exist_names_set:
             raise ValueError(f'tag: Windows is case insensitive, find same name: "{n}"')
+        exist_names_set.add(n_lower)
+
     return True
 
 

--- a/swanlab/data/formater.py
+++ b/swanlab/data/formater.py
@@ -11,6 +11,7 @@ import os
 import re
 import json
 import yaml
+from typing import List
 
 
 def check_string(target: str) -> bool:
@@ -159,5 +160,67 @@ def check_key_format(key: str, auto_cut=True) -> str:
         raise ValueError(f"tag: {key} is an empty string")
     if key.startswith((".", "/")):
         raise ValueError(f"tag: {key} can't start with '.' or '/' and blank space")
+    if key.endswith(".", "/"):  # cannot create folder end with '.' or '/'
+        raise ValueError(f"tag: {key} can't end with '.' or '/' and blank space")
     # 检查长度
     return _auto_cut("tag", key, max_len, auto_cut)
+
+
+def check_unique_on_case_insensitive(names: List[str]):
+    """
+    Ensure that the names are unique in case-insensitive.
+
+    Parameters
+    ----------
+    names : List[str]
+        List of names.
+
+    Returns
+    -------
+    bool
+        True if names are unique
+
+    Raises
+    ------
+    ValueError
+        names are not unique
+    """
+    lower_names_set = set([n.lower() for n in names])
+
+    for n in names:
+        if n in lower_names_set:
+            raise ValueError(f'tag: Windows is case insensitive, find same name: "{n}"')
+    return True
+
+
+def check_win_reserved_folder_name(folder_name: str, auto_fix=True) -> str:
+    """
+    Check if a folder name is reserved or not support to Windows.
+
+    Parameters
+    ----------
+    folder_name : str
+        Name of the folder to check.
+    auto_fix : bool, optional
+        auto fix unsupport folder_name, default True
+        If the value is False, try to throw an ValueError
+
+    Returns
+    -------
+    bool
+        return fix name
+
+    Raises
+    ------
+    ValueError
+        key not support to Windows.
+    """
+    # Regular expression to match reserved names optionally followed by a dot (.) and any character
+    reserved_pattern = re.compile(r"^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$", re.IGNORECASE)
+
+    # Check if the cleaned folder name is in the reserved names list
+    if bool(reserved_pattern.match(folder_name)):
+        if not auto_fix:
+            raise ValueError(f"tag: {folder_name} is reserved names in windows")
+        folder_name = "_" + folder_name
+    return folder_name

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -18,10 +18,10 @@ from .exp import SwanLabExp
 from datetime import datetime
 from typing import Callable, Optional, Dict
 from .operator import SwanLabRunOperator, RuntimeInfo
-from ..formater import check_key_format
+from ..formater import check_key_format, check_win_reserved_folder_name, check_unique_on_case_insensitive
 from swanlab.env import get_mode, get_swanlog_dir
 import random
-
+from swankit.env import is_windows
 
 class SwanLabRunState(Enum):
     """SwanLabRunState is an enumeration class that represents the state of the experiment.
@@ -259,6 +259,11 @@ class SwanLabRun:
         step : int, optional
             The step number of the current data, if not provided, it will be automatically incremented.
             If step is duplicated, the data will be ignored.
+
+        Raise
+        ----------
+        ValueError:
+            Unsupported key names.
         """
         if self.__state != SwanLabRunState.RUNNING:
             raise RuntimeError("After experiment finished, you can no longer log data to the current experiment")
@@ -278,6 +283,9 @@ class SwanLabRun:
             step = None
 
         log_return = {}
+        if is_windows():
+            # 在windows不区分大小写的情况下需要检查key是否大小写不敏感独一
+            check_unique_on_case_insensitive(data.keys())
         # 遍历data，记录data
         for k, v in data.items():
             _k = k
@@ -285,6 +293,21 @@ class SwanLabRun:
             if k != _k:
                 # 超过255字符，截断
                 swanlog.warning(f"Key {_k} is too long, cut to 255 characters.")
+                if k in data.keys():
+                    raise ValueError(f'tag: Unsupport too long Key "{_k}" and auto cut failed')
+            if is_windows():
+                # windows 中要增加保留文件夹名的判断
+                _k = k
+                k = check_win_reserved_folder_name(k)
+                if k != _k:
+                    # key名为windows保留文件名
+                    lower_key_name = [k.lower() in data.keys()]
+                    if k.lower() in lower_key_name:
+                        # 修复后又和原先key重名（大小写不区分情况下）
+                        raise ValueError(
+                            f"Key {_k} unsupport on windows and auto fix it failed. Please change a key name instead"
+                        )
+                    swanlog.warning(f"Key {_k} unsupport on windows, auto used {k} instead")
             # ---------------------------------- 包装数据 ----------------------------------
             # 输入为可转换为float的数据类型
             if isinstance(v, (int, float, FloatConvertible)):

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -307,7 +307,7 @@ class SwanLabRun:
                         raise ValueError(
                             f"Key {_k} unsupport on windows and auto fix it failed. Please change a key name instead"
                         )
-                    swanlog.warning(f"Key {_k} unsupport on windows, auto used {k} instead")
+                    # swanlog.warning(f"Key {_k} unsupport on windows, auto used {k} instead")  # todo: 每次都打很烦，暂时先注释掉，回头最好弄成只打一次warning
             # ---------------------------------- 包装数据 ----------------------------------
             # 输入为可转换为float的数据类型
             if isinstance(v, (int, float, FloatConvertible)):


### PR DESCRIPTION
## bug原因

windows有保留文件夹名，参考https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN

## 测试代码

```python
import swanlab

swanlab.init(project='test_swanlab')

for i in range(100):
    swanlab.log({"test1":i})
    swanlab.log({'AUX':i**2})
```

Close: #639 