### PR TITLE
integration-torchtune

### DIFF
--- a/swanlab/integration/torchtune.py
+++ b/swanlab/integration/torchtune.py
@@ -1,0 +1,88 @@
+from torchtune.utils._distributed import get_world_size_and_rank
+from torchtune.utils.metric_logging import MetricLoggerInterface
+from typing import Mapping, Optional, Union
+
+from numpy import ndarray
+from omegaconf import DictConfig, OmegaConf
+from torch import Tensor
+
+Scalar = Union[Tensor, ndarray, int, float]
+
+
+class SwanLabLogger(MetricLoggerInterface):
+    """
+    Example:
+        In torchtune config:
+        >>> # Logging
+        >>> metric_logger:
+        >>>     _component_: swanlab.integration.huggingface.SwanLabLogger
+        >>>     project: "gemma-lora-finetune"
+        >>>     experiment_name: "gemma-2b"
+        >>>     log_dir: ${output_dir}
+
+    Raises:
+        ImportError: If ``swanlab`` package is not installed.
+
+    Note:
+        This logger requires the swanlab package to be installed.
+        You can install it with `pip install swanlab`.
+        In order to use the logger, you need to login to your SwanLab account.
+        You can do this by running `swanlab login` in your terminal.
+    """
+
+    def __init__(
+        self,
+        project: str = "torchtune",
+        workspace: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        description: Optional[str] = None,
+        mode: Optional[str] = None,
+        log_dir: Optional[str] = None,
+        **kwargs,
+    ):
+        try:
+            import swanlab
+        except ImportError as e:
+            raise ImportError(
+                "``swanlab`` package not found. Please install swanlab using `pip install swanlab` to use SwanLabLogger."
+            ) from e
+        self._swanlab = swanlab
+
+        # Use dir if specified, otherwise use log_dir.
+        self.log_dir = kwargs.pop("dir", log_dir)
+
+        _, self.rank = get_world_size_and_rank()
+
+        if self._swanlab.get_run() is None and self.rank == 0:
+            run = self._swanlab.init(
+                project=project,
+                workspace=workspace,
+                name=experiment_name,
+                description=description,
+                mode=mode,
+                logdir=self.log_dir,
+                **kwargs,
+            )
+
+        self.config_allow_val_change = kwargs.get("allow_val_change", False)
+
+    def log_config(self, config: DictConfig) -> None:
+        if self._swanlab.get_run():
+            resolved = OmegaConf.to_container(config, resolve=True)
+            self._swanlab.config.update(resolved, allow_val_change=self.config_allow_val_change)
+
+    def log(self, name: str, data: Scalar, step: int) -> None:
+        if self._swanlab.get_run():
+            self._swanlab.log({name: data}, step=step)
+
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
+        if self._swanlab.get_run():
+            self._swanlab.log({**payload}, step=step)
+
+    def __del__(self) -> None:
+        if self._swanlab.get_run():
+            self._swanlab.finish()
+
+    def close(self) -> None:
+        if self._swanlab.get_run():
+            self._swanlab.finish()


### PR DESCRIPTION
## Description

与torchtune微调框架的集成，已在Gemma-2b模型微调上试验成功。

![image](https://github.com/user-attachments/assets/60a70881-0a90-41bf-a986-4497b0b695af)

使用方法：

1. 安装torchtune：
```bash
pip install torchtune
```

2. 下载gemma-2b预训练模型到本地：

```python
from modelscope import snapshot_download
model_dir = snapshot_download('AI-ModelScope/gemma-2b', cache_dir="./",)
```

3. 创建`2B_qlora_single_device.yaml`：

```yaml
# Config for multi-device QLoRA finetuning in lora_finetune_single_device.py
# using a gemma 2B model
#
# This config assumes that you've run the following command before launching
# this run:
#   tune download google/gemma-2b --hf-token <HF_TOKEN> --ignore-patterns ""
#
# To launch on a single device, run the following command from root:
#   tune run lora_finetune_single_device --config gemma/2B_qlora_single_device
#
# You can add specific overrides through the command line. For example
# to override the checkpointer directory while launching training
# you can run:
#   tune run lora_finetune_single_device --config gemma/2B_qlora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
#
# This config works only for training on single device.

# Tokenizer
tokenizer:
  _component_: torchtune.models.gemma.gemma_tokenizer
  path: ./AI-ModelScope/gemma-2b/tokenizer.model

# Dataset
dataset:
  _component_: torchtune.datasets.alpaca_dataset
seed: null
shuffle: True

# Model Arguments
model:
  _component_: torchtune.models.gemma.qlora_gemma_2b
  lora_attn_modules: ['q_proj', 'k_proj', 'v_proj']
  apply_lora_to_mlp: True
  lora_rank: 64
  lora_alpha: 16

checkpointer:
  _component_: torchtune.utils.FullModelHFCheckpointer
  checkpoint_dir: ./AI-ModelScope/gemma-2b/
  checkpoint_files: [
    model-00001-of-00002.safetensors,
    model-00002-of-00002.safetensors,
  ]
  recipe_checkpoint: null
  output_dir: ./output/gemma-2b
  model_type: GEMMA
resume_from_checkpoint: False

optimizer:
  _component_: torch.optim.AdamW
  lr: 2e-5

lr_scheduler:
  _component_: torchtune.modules.get_cosine_schedule_with_warmup
  num_warmup_steps: 100

loss:
  _component_: torch.nn.CrossEntropyLoss

# Fine-tuning arguments
batch_size: 4
epochs: 3
max_steps_per_epoch: null
gradient_accumulation_steps: 4
compile: False

# Training env
device: cuda

# Memory management
enable_activation_checkpointing: True

# Reduced precision
dtype: bf16

# Logging
metric_logger:
  _component_: swanlab.integration.huggingface.SwanLabLogger
  project: "gemma-fintune"
  experiment_name: "gemma-2b"
  log_dir: ${output_dir}
output_dir: ./output/alpaca-gemma-lora
log_every_n_steps: 1
log_peak_memory_stats: False

# Show case the usage of pytorch profiler
# Set enabled to False as it's only needed for debugging training
profiler:
  _component_: torchtune.utils.setup_torch_profiler
  enabled: False

  #Output directory of trace artifacts
  output_dir: ${output_dir}/profiling_outputs

  #`torch.profiler.ProfilerActivity` types to trace
  cpu: True
  cuda: True

  #trace options passed to `torch.profiler.profile`
  profile_memory: False
  with_stack: False
  record_shapes: True
  with_flops: False

  # `torch.profiler.schedule` options:
  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
  wait_steps: 5
  warmup_steps: 5
  active_steps: 2
  num_cycles: 1
```

4. 开始训练：

```bash
tune run lora_finetune_single_device --config 2B_qlora_single_device.yaml
```



Closes: #617 
