### PR TITLE
When decoding the response, change the original call from the request…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 swankit==0.1.1b1
-swanboard==0.1.3b4
+swanboard==0.1.3b5
 cos-python-sdk-v5
 requests
 click

--- a/swanlab/api/http.py
+++ b/swanlab/api/http.py
@@ -18,6 +18,7 @@ from swanlab.package import get_host_api, get_package_version
 from swankit.log import FONT
 from swanlab.log import swanlog
 import requests
+import json
 
 
 def decode_response(resp: requests.Response) -> Union[Dict, AnyStr]:
@@ -26,7 +27,7 @@ def decode_response(resp: requests.Response) -> Union[Dict, AnyStr]:
     """
     try:
         return resp.json()
-    except requests.exceptions.JSONDecodeError:
+    except json.decoder.JSONDecodeError:
         return resp.text
 
 

--- a/test/unit/api/test_http.py
+++ b/test/unit/api/test_http.py
@@ -15,9 +15,21 @@ from swanlab.api.http import create_http, HTTP, CosClient
 from swanlab.api.auth.login import login_by_key
 from swanlab.data.modules import MediaBuffer
 from tutils import API_KEY, TEMP_PATH, is_skip_cloud_test
+from tutils.setup import UseMocker, UseSetupHttp
 import pytest
 
 alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+
+def test_decode_response():
+    with UseMocker() as mocker:
+        mocker.post("/json", json={"test": "test"})
+        mocker.post("/text", text="test")
+        with UseSetupHttp() as http:
+            data = http.post("/json")
+            assert data == {"test": "test"}
+            data = http.post("/text")
+            assert data == "test"
 
 
 @pytest.mark.skipif(is_skip_cloud_test, reason="skip cloud test")


### PR DESCRIPTION


## Description
The requests library does not have an exception named JSONDecodeError. Typically, JSON decoding errors are raised by the json library with the json.JSONDecodeError exception. If you encounter JSON decoding issues when handling the response from a request, you should catch the json.JSONDecodeError exception, not requests.exceptions.JSONDecodeError.
Closes: #(issue)

