### PR TITLE
fix: add minimum version constraints for urllib3 and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 swankit==0.1.1b1
 swanboard==0.1.3b5
 cos-python-sdk-v5
-urllib3
-requests
+urllib3>=1.26.0
+requests>=2.25.0
 click
 pyyaml
 psutil


### PR DESCRIPTION
## Description

Added minimum version constraints for urllib3 and requests in requirements.txt. 
It is important to note that both the urllib3 and requests libraries are using **the oldest versions** that are free of bugs.

## 🎯 PRs Should Target Issues

To resolve the "TypeError: __init__() got an unexpected keyword argument 'allowed_methods'" error and JSONDecodeError. The error occurred in a user environment running Ubuntu 20.04, where the user was using the system’s pre-installed Python 3.8.10, with older versions of the Requests and urllib3 libraries already installed in the environment.

## Tests
Pass (In Ubuntu 20.04 + Python 3.8.10)