### PR TITLE
update:split

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-swankit==0.1.1b3
+swankit==0.1.1b1
 swanboard==0.1.3b5
 cos-python-sdk-v5
 urllib3>=1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-swankit==0.1.1b1
+swankit==0.1.1b3
 swanboard==0.1.3b5
 cos-python-sdk-v5
 urllib3>=1.26.0

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -21,7 +21,9 @@ from .operator import SwanLabRunOperator, RuntimeInfo
 from ..formater import check_key_format
 from swanlab.env import get_mode, get_swanlog_dir
 import random
-from swankit.env import is_windows
+
+
+MAX_LIST_LENGTH = 108
 
 
 class SwanLabRunState(Enum):
@@ -313,6 +315,9 @@ class SwanLabRun:
                 and all([isinstance(i, (Line, MediaType)) for i in v])
                 and all([i.__class__ == v[0].__class__ for i in v])
             ):
+                if len(v) > MAX_LIST_LENGTH:
+                    swanlog.warning(f"List length '{k}' is too long, cut to {MAX_LIST_LENGTH}.")
+                    v = v[:MAX_LIST_LENGTH]
                 v = DataWrapper(k, v)
             else:
                 # 其余情况被当作是非法的数据类型，交给Line处理

--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -6,6 +6,9 @@ from swankit.env import create_time
 import re
 
 
+MAX_UPLOAD_LEN = 200
+
+
 class SwanWriterProxy:
     """
     标准输出流拦截代理
@@ -81,7 +84,8 @@ class SwanWriterProxy:
             except UnicodeEncodeError:
                 # 遇到编码问题，直接pass，此时表现为终端不输出
                 pass
-            message = FONT.clear(message)
+            # 限制上传长度
+            message = FONT.clear(message)[:MAX_UPLOAD_LEN]
             self.write_callback and self.write_callback(message)
 
             # 检查文件分片

--- a/test/unit/data/run/test_main.py
+++ b/test/unit/data/run/test_main.py
@@ -199,6 +199,9 @@ class TestSwanLabRunLog:
         # list
         ll3 = run.log({"a": [Text("abc"), Text("def")]})
         assert ll3["a"].data == ["abc", "def"]
+        data = {"a": [Text("abc")] * 109}
+        ll4 = run.log(data, step=4)
+        assert ll4["a"].data == ["abc"] * 108
 
     # ---------------------------------- 解析log Audio ----------------------------------
 

--- a/test/unit/log/test_log.py
+++ b/test/unit/log/test_log.py
@@ -82,6 +82,18 @@ class TestSwanLogInstall:
             assert content[-2] == a + "\n"
             assert content[-1] == b + "\n"
 
+    def test_write_to_file_long_test(self):
+        console_dir = self.create_console_dir()
+        swanlog.install(console_dir)
+        # 加一行防止其他问题
+        print("\ntest write to file")
+        a = generate(size=201)
+        print(a)
+        files = os.listdir(console_dir)
+        with open(os.path.join(console_dir, files[0]), "r") as f:
+            content = f.readlines()
+            assert content[-1] == a[:200] + "\n"
+
     def test_write_logging_to_file(self):
         console_dir = self.create_console_dir()
         swanlog.install(console_dir, log_level="debug")


### PR DESCRIPTION
## Description

为了减少后端压力以及解决日志文本（进度条）过长导致服务器被冲的问题，添加上传的日志和媒体文件的长度限制，分别为一行200字符和一次108媒体（列表长度）