### PR TITLE
refactor: linux cpu brand return

### DIFF
--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -23,9 +23,7 @@ from swanlab.env import get_mode, get_swanlog_dir
 from . import namer as N
 import random
 
-
 MAX_LIST_LENGTH = 108
-
 
 class SwanLabRunState(Enum):
     """SwanLabRunState is an enumeration class that represents the state of the experiment.

--- a/swanlab/data/run/system/info.py
+++ b/swanlab/data/run/system/info.py
@@ -109,7 +109,7 @@ def __get_cpu_info():
                 if "Model name:" in line:
                     cpu_brand = line.split(":")[1].strip()
                     return cpu_brand
-            return "无法获取 CPU 品牌"
+            return None
         except Exception as e:
             return None
 


### PR DESCRIPTION
修复了CPU品牌返回`无法获取 CPU 品牌`的问题
