### PR TITLE
replace settings to public

### DIFF
--- a/swanlab/data/run/public.py
+++ b/swanlab/data/run/public.py
@@ -1,0 +1,129 @@
+from swankit.core import SwanLabSharedSettings
+
+from swanlab.api import get_http
+from swanlab.package import get_project_url, get_experiment_url
+
+
+class SwanlabCloudConfig:
+    """
+    public data for the SwanLab project when running in cloud mode.
+    """
+
+    def __init__(self):
+        self.__http = None
+
+    def __get_property_from_http(self, name: str):
+        """
+        Get the property from the http object.
+        if the http object is None, it will be initialized.
+        if initialization fails, it will return None.
+        """
+        if self.available:
+            return getattr(self.__http, name)
+        return None
+
+    @property
+    def available(self):
+        """
+        Whether the SwanLab is running in cloud mode.
+        """
+        try:
+            if self.__http is None:
+                self.__http = get_http()
+            return True
+        except ValueError:
+            return False
+
+    @property
+    def project_name(self):
+        """
+        The name of the project. Equal to `run.public.project_name`.
+        If swanlab is not running in cloud mode, it will return None.
+        """
+        return self.__get_property_from_http("projname")
+
+    @property
+    def project_url(self):
+        """
+        The url of the project. It is the url of the project page on the SwanLab.
+        If swanlab is not running in cloud mode, it will return None.
+        """
+        if not self.available:
+            return None
+        groupname = self.__get_property_from_http("groupname")
+        projname = self.__get_property_from_http("projname")
+        return get_project_url(groupname, projname)
+
+    @property
+    def experiment_name(self):
+        """
+        The name of the experiment. It may be different from the name of swanboard.
+        """
+        return self.__get_property_from_http("exp_name")
+
+    @property
+    def experiment_url(self):
+        """
+        The url of the experiment. It is the url of the experiment page on the SwanLab.
+        """
+        if not self.available:
+            return None
+        groupname = self.__get_property_from_http("groupname")
+        projname = self.__get_property_from_http("projname")
+        exp_id = self.__get_property_from_http("exp_id")
+        return get_experiment_url(groupname, projname, exp_id)
+
+
+class SwanLabPublicConfig:
+    """
+    Public data for the SwanLab project.
+    """
+
+    def __init__(self, project_name: str, settings: SwanLabSharedSettings):
+        self.__project_name = project_name
+        self.__cloud = SwanlabCloudConfig()
+        self.__settings = settings
+
+    @property
+    def cloud(self):
+        """
+        The cloud configuration.
+        """
+        return self.__cloud
+
+    @property
+    def project_name(self):
+        """
+        The name of the project. Equal to `run.public.project_name`.
+        """
+        return self.__project_name
+
+    # ---------------------------------- 继承settings的属性 ----------------------------------
+
+    @property
+    def version(self) -> str:
+        """
+        The version of the SwanLab.
+        """
+        return self.__settings.version
+
+    @property
+    def run_id(self) -> str:
+        """
+        The id of the run.
+        """
+        return self.__settings.run_id
+
+    @property
+    def swanlog_dir(self) -> str:
+        """
+        The directory of the SwanLab log.
+        """
+        return self.__settings.swanlog_dir
+
+    @property
+    def run_dir(self) -> str:
+        """
+        The directory of the run.
+        """
+        return self.__settings.run_dir

--- a/swanlab/data/run/public.py
+++ b/swanlab/data/run/public.py
@@ -84,6 +84,25 @@ class SwanLabPublicConfig:
         self.__cloud = SwanlabCloudConfig()
         self.__settings = settings
 
+    def json(self):
+        """
+        Return a dict of the public config.
+        This method is used to serialize the public config to json.
+        """
+        return {
+            "project_name": self.project_name,
+            "version": self.version,
+            "run_id": self.run_id,
+            "swanlog_dir": self.swanlog_dir,
+            "run_dir": self.run_dir,
+            "cloud": {
+                "project_name": self.cloud.project_name,
+                "project_url": self.cloud.project_url,
+                "experiment_name": self.cloud.experiment_name,
+                "experiment_url": self.cloud.experiment_url,
+            },
+        }
+
     @property
     def cloud(self):
         """

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -7,15 +7,17 @@ r"""
 @Description:
     测试sdk的一些api
 """
-import tutils as T
+import os
+
+import pytest
+from nanoid import generate
+
 import swanlab.data.sdk as S
 import swanlab.error as Err
-from swanlab.log import swanlog
-from swanlab.env import SwanLabEnv, get_save_dir
+import tutils as T
 from swanlab.data.run import get_run
-from nanoid import generate
-import pytest
-import os
+from swanlab.env import SwanLabEnv, get_save_dir
+from swanlab.log import swanlog
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -76,7 +78,7 @@ class TestInitMode:
         assert not os.path.exists(logdir)
         assert os.environ[MODE] == "disabled"
         run.log({"TestInitMode": 1})  # 不会报错
-        a = run.settings.run_dir
+        a = run.public.run_dir
         assert not os.path.exists(a)
         assert get_run() is not None
 
@@ -106,7 +108,7 @@ class TestInitMode:
         run = S.init()
         assert os.environ[MODE] == "disabled"
         run.log({"TestInitMode": 1})
-        a = run.settings.run_dir
+        a = run.public.run_dir
         assert not os.path.exists(a)
         assert get_run() is not None
 
@@ -131,7 +133,7 @@ class TestInitMode:
         run = S.init(mode="disabled")
         assert os.environ[MODE] == "disabled"
         run.log({"TestInitMode": 1})
-        a = run.settings.run_dir
+        a = run.public.run_dir
         assert not os.path.exists(a)
         assert get_run() is not None
 
@@ -146,7 +148,7 @@ class TestInitProject:
         设置project为None
         """
         run = S.init(project=None, mode="disabled")
-        assert run.project_name == os.path.basename(os.getcwd())
+        assert run.public.project_name == os.path.basename(os.getcwd())
 
     def test_init_project(self):
         """
@@ -154,7 +156,7 @@ class TestInitProject:
         """
         project = "test_project"
         run = S.init(project=project, mode="disabled")
-        assert run.project_name == project
+        assert run.public.project_name == project
 
 
 LOG_DIR = SwanLabEnv.SWANLOG_FOLDER.value
@@ -171,13 +173,13 @@ class TestInitLogdir:
         """
         logdir = generate()
         run = S.init(logdir=logdir, mode="disabled")
-        assert run.settings.swanlog_dir != logdir
-        assert run.settings.swanlog_dir == os.environ[LOG_DIR]
+        assert run.public.swanlog_dir != logdir
+        assert run.public.swanlog_dir == os.environ[LOG_DIR]
         run.finish()
         del os.environ[LOG_DIR]
         run = S.init(logdir=logdir, mode="disabled")
-        assert run.settings.swanlog_dir != logdir
-        assert run.settings.swanlog_dir == os.path.join(os.getcwd(), "swanlog")
+        assert run.public.swanlog_dir != logdir
+        assert run.public.swanlog_dir == os.path.join(os.getcwd(), "swanlog")
 
     def test_init_logdir_enabled(self):
         """
@@ -185,12 +187,12 @@ class TestInitLogdir:
         """
         logdir = os.path.join(T.TEMP_PATH, generate()).__str__()
         run = S.init(logdir=logdir, mode="local")
-        assert run.settings.swanlog_dir == logdir
+        assert run.public.swanlog_dir == logdir
         run.finish()
         del os.environ[LOG_DIR]
         logdir = os.path.join(T.TEMP_PATH, generate()).__str__()
         run = S.init(logdir=logdir, mode="local")
-        assert run.settings.swanlog_dir == logdir
+        assert run.public.swanlog_dir == logdir
 
     def test_init_logdir_env(self):
         """
@@ -199,13 +201,13 @@ class TestInitLogdir:
         logdir = os.path.join(T.TEMP_PATH, generate()).__str__()
         os.environ[LOG_DIR] = logdir
         run = S.init(mode="local")
-        assert run.settings.swanlog_dir == logdir
+        assert run.public.swanlog_dir == logdir
         run.finish()
         del os.environ[LOG_DIR]
         logdir = os.path.join(T.TEMP_PATH, generate()).__str__()
         os.environ[LOG_DIR] = logdir
         run = S.init(mode="local")
-        assert run.settings.swanlog_dir == logdir
+        assert run.public.swanlog_dir == logdir
 
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")


### PR DESCRIPTION
## Description

`swanlab.init`返回的类`run`会携带`public`属性，替换了之前的`settings`属性，他会返回：

1. project_name 当前运行的项目名称
2. version 当前运行的swanlab版本
3. run_id 一个唯一id
4. swanlog_dir swanlab保存文件夹
5. run_dir 本次实验的保存文件夹
6. cloud 云端环境的相关信息

cloud信息包括：

1. avaliable 是否运行在云端模式，如果不是，下面的属性全部为`None`
2. project_name 本次运行的项目名称
3. project_url 本次运行在云端项目url
4. experiment_name 本次运行的实验名称
5. experiment_url 本次运行的云端实验url
