### PR TITLE
chore: fix some misc

### DIFF
--- a/swanlab/data/run/metadata/hardware/gpu/nvidia.py
+++ b/swanlab/data/run/metadata/hardware/gpu/nvidia.py
@@ -44,6 +44,8 @@ def get_nvidia_gpu_info() -> HardwareFuncResult:
             info["type"].append(gpu_name)
             # 获取 GPU 的总显存, 单位为GB
             info["memory"].append(round(pynvml.nvmlDeviceGetMemoryInfo(handle).total / (1024**3)))
+    except UnicodeDecodeError:  # 部分GPU型号无法解码
+        return None, None
     except pynvml.NVMLError:
         pass
     finally:

--- a/swanlab/data/run/metadata/hardware/type.py
+++ b/swanlab/data/run/metadata/hardware/type.py
@@ -130,7 +130,7 @@ class HardwareCollector(CollectGuard, ABC):
         except NotImplementedError as n:
             raise n
         except Exception as e:
-            swanlog.error(f"Hardware info collection failed: {self.__class__.__name__}, {str(e)}")
+            swanlog.debug(f"Hardware info collection failed: {self.__class__.__name__}, {str(e)}")
             return None
         finally:
             self.after_collect()


### PR DESCRIPTION
* 在GPU检测时，部分机子可能出现GPU乱码的情况，此时忽略错误，但GPU硬件信息不再采集和监控
* 在硬件监控时，可能出现检测错误的情况，此时可能是GPU驱动过低、型号过于老旧等，原本设计是使用error的log，但是会影响用户体验，改为debug。

close #753 