### PR TITLE
fix: temporary domain

### DIFF
--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -13,6 +13,19 @@ from typing import List
 
 import swankit.env as E
 from swankit.env import SwanLabSharedEnv
+import requests
+
+
+DOMAIN = 'swanlab.cn'
+DOMAIN1 = 'swanlab.115.zone' # temporary domain
+
+# domain state detection
+try:
+    response = requests.get(f'https://{DOMAIN}/api', timeout=3)
+    if response.status_code != 200:
+        DOMAIN = DOMAIN1
+except Exception:
+    DOMAIN = DOMAIN1
 
 
 # ---------------------------------- 环境变量枚举类 ----------------------------------
@@ -73,9 +86,13 @@ class SwanLabEnv(enum.Enum):
         """
         设置默认的环境变量值
         """
+        api_host = f'https://api.{DOMAIN}/api'
+        if DOMAIN == DOMAIN1:
+            api_host = f'https://{DOMAIN}/api'
+
         envs = {
-            cls.WEB_HOST.value: "https://swanlab.cn",
-            cls.API_HOST.value: "https://api.swanlab.cn/api",
+            cls.WEB_HOST.value: f"https://{DOMAIN}",
+            cls.API_HOST.value: api_host,
             cls.RUNTIME.value: "user",
         }
         for k, v in envs.items():


### PR DESCRIPTION
Add temporary domain `swanlab.115.zone`.  If the primary domain is broken, the temporary domain can be used.

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please
mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/SwanHubX/SwanLab/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
<!-- There are no hive tests yet -->
