### PR TITLE
fix: readme link

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ swanlab watch ./logs
 [demo-google-stock]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
 [demo-google-stock-image]: readme_files/example-lstm.png
 
-[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/PyTorch_Audio_Classification/charts
 [demo-audio-classification-image]: readme_files/example-audio-classification.png
 
-[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg

--- a/README_EN.md
+++ b/README_EN.md
@@ -388,8 +388,8 @@ This repository is licensed under the [Apache 2.0 License](https://github.com/Sw
 [demo-google-stock]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
 [demo-google-stock-image]: readme_files/example-lstm.png
 
-[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/PyTorch_Audio_Classification/charts
 [demo-audio-classification-image]: readme_files/example-audio-classification.png
 
-[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg

--- a/README_JP.md
+++ b/README_JP.md
@@ -390,8 +390,8 @@ SwanLabに貢献したいですか？まず、[貢献ガイド](CONTRIBUTING.md)
 [demo-google-stock]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
 [demo-google-stock-image]: readme_files/example-lstm.png
 
-[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/PyTorch_Audio_Classification/charts
 [demo-audio-classification-image]: readme_files/example-audio-classification.png
 
-[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg

--- a/README_RU.md
+++ b/README_RU.md
@@ -388,8 +388,8 @@ swanlab watch ./logs
 [demo-google-stock]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
 [demo-google-stock-image]: readme_files/example-lstm.png
 
-[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-audio-classification]:https://swanlab.cn/@ZeyiLin/PyTorch_Audio_Classification/charts
 [demo-audio-classification-image]: readme_files/example-audio-classification.png
 
-[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Google-Stock-Prediction/charts
+[demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg


### PR DESCRIPTION
This pull request updates the links in multiple language versions of the `README` files to point to the correct demo charts for the audio classification and Qwen2-VL projects. The most important changes include updating the URLs for the demo links in the English, Japanese, and Russian `README` files.

Updates to demo links:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L395-R398): Updated the links for `demo-audio-classification` and `demo-qwen2-vl` to point to the correct charts.
* [`README_EN.md`](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abL391-R394): Updated the links for `demo-audio-classification` and `demo-qwen2-vl` to point to the correct charts.
* [`README_JP.md`](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25L393-R396): Updated the links for `demo-audio-classification` and `demo-qwen2-vl` to point to the correct charts.
* [`README_RU.md`](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L391-R394): Updated the links for `demo-audio-classification` and `demo-qwen2-vl` to point to the correct charts.