### PR TITLE
feat: sync wandb add params

### DIFF
--- a/swanlab/sync/wandb.py
+++ b/swanlab/sync/wandb.py
@@ -1,23 +1,33 @@
 import swanlab
 
-def sync_wandb():
+def sync_wandb(mode:str="cloud", wandb_run:bool=True):
     """
-    sync wandb with swanlab
+    sync wandb with swanlab, 暂时不支持log非标量类型
+    
+    - mode: "cloud", "local" or "disabled". https://docs.swanlab.cn/api/py-init.html
+    - wandb_run: 如果此参数设置为False，则不会将数据上传到wandb，等同于设置wandb.init(mode="offline")。
     
     usecase:
     ```python
+    import wandb
+    import random
     import swanlab
+
     swanlab.sync_wandb()
-    
+    # swanlab.init(project="sync_wandb")
+
     wandb.init(
         project="test",
         config={"a": 1, "b": 2},
         name="test",
     )
 
-    for epoch in range(10):
+    epochs = 10
+    offset = random.random() / 5
+    for epoch in range(2, epochs):
         acc = 1 - 2 ** -epoch - random.random() / epoch - offset
         loss = 2 ** -epoch + random.random() / epoch + offset
+
         wandb.log({"acc": acc, "loss": loss})
     ```
     """
@@ -30,6 +40,7 @@ def sync_wandb():
     original_init = wandb.init
     original_log = wandb_sdk.wandb_run.Run.log
     original_finish = wandb_sdk.finish
+    original_config_update = wandb_sdk.wandb_config.Config.update
     
     def patched_init(*args, **kwargs):
         project = kwargs.get('project', None)
@@ -40,11 +51,25 @@ def sync_wandb():
             swanlab.init(
                 project=project,
                 experiment_name=name,
-                config=config)
+                config=config,
+                mode=mode)
         else:
             swanlab.config.update(config)
         
-        return original_init(*args, **kwargs)
+        if wandb_run is False:
+            kwargs["mode"] = "offline"
+            return original_init(*args, **kwargs)
+        else:
+            return original_init(*args, **kwargs)
+
+    def patched_config_update(*args, **kwargs):
+        try:
+            config= args[1]
+        except:
+            config= None
+        if config is not None:
+            swanlab.config.update(config)
+        return original_config_update(*args, **kwargs)
 
     def patched_log(*args, **kwargs):
         data = args[1]
@@ -67,3 +92,4 @@ def sync_wandb():
     wandb.init = patched_init
     wandb_sdk.wandb_run.Run.log = patched_log
     wandb_sdk.wandb_run.Run.finish = patched_finish
+    wandb_sdk.wandb_config.Config.update = patched_config_update


### PR DESCRIPTION
## Description

此拉取请求包括对`swanlab/sync/wandb.py`文件中的`sync_wandb`函数的更新，以增强其功能并改善与Swanlab和Weights & Biases（wandb）库的集成。这些更改引入了新参数、额外的日志记录功能以及更好的配置处理。

对`sync_wandb`函数的增强：

- 在`sync_wandb`函数中添加了`mode`和`wandb_run`参数，以便更好地控制同步模式以及是否应将数据上传到wandb。（`swanlab/sync/wandb.py`）
- 更新了`patched_init`函数，以包含新的`mode`参数并处理`wandb_run`设置，如果`wandb_run`设置为`False`，则允许离线模式。（`swanlab/sync/wandb.py`）

配置和日志记录改进：

- 引入了`patched_config_update`函数，以便在wandb的配置更新时更新Swanlab的配置。（`swanlab/sync/wandb.py`）
- 修补了wandb配置更新方法，以使用新的`patched_config_update`函数。（`swanlab/sync/wandb.py`）

Closes: #793 
