### PR TITLE
feat: only one api key

### DIFF
--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -1,6 +1,7 @@
 import json
 import netrc
 import os
+import time
 
 import nanoid
 import pytest
@@ -168,17 +169,20 @@ class TestSaveKey:
         P.save_key("user", password, host=host)
         assert self.get_key(path, host) == password
         assert os.path.getmtime(path) == change_time
+        time.sleep(0.1)
         # 再次保存，但是账号不同
         new_password = nanoid.generate()
         P.save_key("user2", new_password, host=host)
         assert self.get_key(path, host) == new_password
         assert os.path.getmtime(path) != change_time
+        time.sleep(0.1)
         # 再次保存，但是host不同
         new_host = nanoid.generate()
         P.save_key("user", new_password, host=new_host)
         nrc = netrc.netrc(path)
         assert len(nrc.hosts) == 1
         assert nrc.authenticators(new_host) is not None
+        time.sleep(0.1)
         # 再次保存，但是密码不同
         new_password = nanoid.generate()
         P.save_key("user", new_password, host=new_host)

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -148,6 +148,43 @@ class TestSaveKey:
         host = P.get_host_api()
         P.save_key("user", password, host=host)
         assert self.get_key(path, host) == password
+        # 在保存一次，保证只存在一个host
+        new_host = nanoid.generate()
+        P.save_key("user", password, host=new_host)
+        nrc = netrc.netrc(path)
+        assert len(nrc.hosts) == 1
+        assert nrc.authenticators(new_host) is not None
+
+    def test_duplicate(self):
+        """
+        测试重复保存，此时会略过
+        """
+        path = os.path.join(get_save_dir(), ".netrc")
+        password = nanoid.generate()
+        host = P.get_host_api()
+        P.save_key("user", password, host=host)
+        change_time = os.path.getmtime(path)
+        assert self.get_key(path, host) == password
+        P.save_key("user", password, host=host)
+        assert self.get_key(path, host) == password
+        assert os.path.getmtime(path) == change_time
+        # 再次保存，但是账号不同
+        new_password = nanoid.generate()
+        P.save_key("user2", new_password, host=host)
+        assert self.get_key(path, host) == new_password
+        assert os.path.getmtime(path) != change_time
+        # 再次保存，但是host不同
+        new_host = nanoid.generate()
+        P.save_key("user", new_password, host=new_host)
+        nrc = netrc.netrc(path)
+        assert len(nrc.hosts) == 1
+        assert nrc.authenticators(new_host) is not None
+        # 再次保存，但是密码不同
+        new_password = nanoid.generate()
+        P.save_key("user", new_password, host=new_host)
+        nrc = netrc.netrc(path)
+        assert len(nrc.hosts) == 1
+        assert nrc.authenticators(new_host)[2] == new_password
 
 
 class TestIsLogin:


### PR DESCRIPTION
## Description

This pull request includes several changes to the `swanlab/package.py` file and the associated unit tests to improve the handling of `.netrc` files and ensure that only one host entry is maintained. The most important changes include the addition of a new function to get the `.netrc` file path, updates to existing functions to use this new function, and enhancements to the unit tests to verify the new behavior.

### Enhancements to `.netrc` file handling:

* [`swanlab/package.py`](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8R100-R106): Added a new function `get_nrc_path()` to obtain the `.netrc` file path.
* [`swanlab/package.py`](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L108-R115): Updated the `get_key()` and `save_key()` functions to use the new `get_nrc_path()` function for obtaining the `.netrc` file path. [[1]](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L108-R115) [[2]](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L129-R145)
* [`swanlab/package.py`](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L129-R145): Modified the `save_key()` function to avoid writing duplicate host entries and ensure only one host entry is maintained.

### Improvements to unit tests:

* [`test/unit/test_package.py`](diffhunk://#diff-c97f3cacc647e043e22cb866d8d3e34e199daf602badcf5232cc551ce1cb1b5bR151-R187): Enhanced the `test_ok` test to verify that only one host entry is maintained after saving a new host.
* [`test/unit/test_package.py`](diffhunk://#diff-c97f3cacc647e043e22cb866d8d3e34e199daf602badcf5232cc551ce1cb1b5bR151-R187): Added a new test `test_duplicate` to check the behavior of saving duplicate entries, ensuring that the `.netrc` file is not modified unnecessarily.


----


closes #797 
