### PR TITLE
chore: add api and web host to http obj

### DIFF
--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -7,8 +7,26 @@ r"""
 @Description:
     API模块，封装api请求接口
 """
-from .info import *
 from .auth.login import terminal_login, code_login
 from .http import create_http, get_http
+from .info import *
 
-__all__ = ["LoginInfo", 'ExperimentInfo', 'ProjectInfo', "code_login", 'terminal_login', 'create_http', 'get_http']
+
+def is_login() -> bool:
+    """判断是否登录(拥有http对象)"""
+    try:
+        return get_http() is not None
+    except ValueError:
+        return False
+
+
+__all__ = [
+    "LoginInfo",
+    'ExperimentInfo',
+    'ProjectInfo',
+    "code_login",
+    'terminal_login',
+    'create_http',
+    'get_http',
+    'is_login',
+]

--- a/swanlab/api/auth/login.py
+++ b/swanlab/api/auth/login.py
@@ -20,7 +20,7 @@ from swanlab.api.info import LoginInfo
 from swanlab.env import in_jupyter, SwanLabEnv
 from swanlab.error import ValidationError, APIKeyFormatError
 from swanlab.log import swanlog
-from swanlab.package import get_user_setting_path, get_host_api, get_host_web
+from swanlab.package import get_setting_url, get_host_api, get_host_web
 
 
 def login_request(api_key: str, api_host: str, timeout: int = 20) -> requests.Response:
@@ -67,7 +67,7 @@ def input_api_key(
     _t = sys.excepthook
     sys.excepthook = _abort_tip
     if not again:
-        swanlog.info("You can find your API key at: " + FONT.yellow(get_user_setting_path()))
+        swanlog.info("You can find your API key at: " + FONT.yellow(get_setting_url()))
     # windows 额外打印提示信息
     if is_windows():
         tip += (

--- a/swanlab/api/auth/login.py
+++ b/swanlab/api/auth/login.py
@@ -20,12 +20,12 @@ from swanlab.api.info import LoginInfo
 from swanlab.env import in_jupyter, SwanLabEnv
 from swanlab.error import ValidationError, APIKeyFormatError
 from swanlab.log import swanlog
-from swanlab.package import get_user_setting_path, get_host_api
+from swanlab.package import get_user_setting_path, get_host_api, get_host_web
 
 
-def login_request(api_key: str, timeout: int = 20) -> requests.Response:
+def login_request(api_key: str, api_host: str, timeout: int = 20) -> requests.Response:
     """用户登录，请求后端接口完成验证"""
-    resp = requests.post(url=f"{get_host_api()}/login/api_key", headers={"authorization": api_key}, timeout=timeout)
+    resp = requests.post(url=f"{api_host}/login/api_key", headers={"authorization": api_key}, timeout=timeout)
     return resp
 
 
@@ -42,9 +42,10 @@ def login_by_key(api_key: str, timeout: int = 20, save: bool = True) -> LoginInf
     save : bool, optional
         是否保存到本地token文件
     """
-    resp = login_request(api_key, timeout)
+    api_host, web_host = get_host_api(), get_host_web()
+    resp = login_request(api_key, api_host, timeout)
     # api key写入token文件
-    login_info = LoginInfo(resp, api_key)
+    login_info = LoginInfo(resp, api_key, api_host, web_host)
     save and not login_info.is_fail and login_info.save()
     return login_info
 

--- a/swanlab/api/http.py
+++ b/swanlab/api/http.py
@@ -67,6 +67,8 @@ class HTTP:
         # 创建会话
         self.__create_session()
 
+    # ---------------------------------- 一些辅助属性 ----------------------------------
+
     @property
     def base_url(self):
         return self.__login_info.api_host
@@ -119,6 +121,16 @@ class HTTP:
         获取sid的过期时间，字符串格式转时间
         """
         return datetime.strptime(self.__login_info.expired_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+    @property
+    def web_proj_url(self):
+        return f"{self.web_host}/@{self.groupname}/{self.projname}"
+
+    @property
+    def web_exp_url(self):
+        return f"{self.web_proj_url}/runs/{self.exp_id}"
+
+    # ---------------------------------- http方法 ----------------------------------
 
     def __before_request(self):
         """
@@ -197,6 +209,8 @@ class HTTP:
         resp = self.__session.patch(url, json=data)
         return decode_response(resp)
 
+    # ---------------------------------- 对象存储方法 ----------------------------------
+
     def __get_cos(self):
         cos = self.get(f"/project/{self.groupname}/{self.projname}/runs/{self.exp_id}/sts")
         self.__cos = CosClient(cos)
@@ -220,6 +234,8 @@ class HTTP:
             swanlog.debug("Refresh cos...")
             self.__get_cos()
         return self.__cos.upload_files(buffers)
+
+    # ---------------------------------- 接入后端api ----------------------------------
 
     def mount_project(self, name: str, username: str = None, public: bool = None) -> ProjectInfo:
         """

--- a/swanlab/api/info.py
+++ b/swanlab/api/info.py
@@ -7,9 +7,11 @@ r"""
 @Description:
     定义认证数据格式
 """
-import requests
-from swanlab.package import save_key
 from typing import Union
+
+import requests
+
+from swanlab.package import save_key
 
 
 class LoginInfo:
@@ -18,7 +20,7 @@ class LoginInfo:
     无论接口请求成功还是失败，都会初始化一个LoginInfo对象
     """
 
-    def __init__(self, resp: requests.Response, api_key: str):
+    def __init__(self, resp: requests.Response, api_key: str, api_host: str, web_host: str):
         self.__api_key = api_key
         self.__resp = resp
         self.__body = resp.json() if resp.status_code == 200 else {}
@@ -26,6 +28,8 @@ class LoginInfo:
         """
         如果此属性不为None，username返回此属性
         """
+        self.web_host = web_host
+        self.api_host = api_host
 
     @property
     def sid(self) -> Union[str, None]:

--- a/swanlab/cli/commands/auth/login.py
+++ b/swanlab/cli/commands/auth/login.py
@@ -8,28 +8,31 @@ r"""
     登录模块
 """
 import click
-from swanlab.package import is_login
-from swanlab.api.auth import terminal_login
 from swankit.log import FONT
+
+from swanlab.api.auth import terminal_login
+from swanlab.package import has_api_key
 
 
 @click.command()
 @click.option(
-    "--relogin", "-r",
+    "--relogin",
+    "-r",
     is_flag=True,
     default=False,
     help="Relogin to the swanlab cloud, it will recover the token file.",
 )
 @click.option(
-    "--api-key", "-k",
+    "--api-key",
+    "-k",
     default=None,
     type=str,
     help="If you prefer not to engage in commands-line interaction to input the api key, "
-         "this will allow automatic login.",
+    "this will allow automatic login.",
 )
 def login(api_key: str, relogin: bool):
     """Login to the swanlab cloud."""
-    if not relogin and is_login():
+    if not relogin and has_api_key():
         # 此时代表token已经获取，需要打印一条信息：已经登录
         command = FONT.bold("swanlab login --relogin")
         tip = FONT.swanlab("You are already logged in. Use `" + command + "` to force relogin.")

--- a/swanlab/cli/commands/auth/logout.py
+++ b/swanlab/cli/commands/auth/logout.py
@@ -7,19 +7,21 @@ r"""
 @Description:
     登出模块
 """
-import click
-from swanlab.package import is_login
-from swankit.log import FONT
-from swanlab.env import get_save_dir
 import shutil
 import sys
+
+import click
+from swankit.log import FONT
+
+from swanlab.env import get_save_dir
+from swanlab.package import has_api_key
 
 
 @click.command()
 def logout():
     """Logout to the swanlab cloud."""
     command = FONT.bold("swanlab login")
-    if is_login():
+    if has_api_key():
         # 如果已经是登录状态，那么则询问用户是否确认，如果确认则删除token文件夹
         confirm = input(FONT.swanlab("Are you sure you want to logout? (y/N): "))
         if confirm.lower() == "y":

--- a/swanlab/data/callback_cloud.py
+++ b/swanlab/data/callback_cloud.py
@@ -27,8 +27,6 @@ from swanlab.log import swanlog
 from swanlab.package import (
     get_package_version,
     get_package_latest_version,
-    get_experiment_url,
-    get_project_url,
     get_key,
 )
 from .callback_local import LocalRunCallback, get_run, SwanLabRunState
@@ -171,11 +169,10 @@ class CloudRunCallback(LocalRunCallback):
     def _view_web_print(self):
         self._watch_tip_print()
         http = get_http()
-        project_url = get_project_url(http.groupname, http.projname)
-        experiment_url = get_experiment_url(http.groupname, http.projname, http.exp_id)
-        swanlog.info("🏠 View project at " + FONT.blue(FONT.underline(project_url)))
-        swanlog.info("🚀 View run at " + FONT.blue(FONT.underline(experiment_url)))
-        return experiment_url
+        proj_url, exp_url = http.web_proj_url, http.web_exp_url
+        swanlog.info("🏠 View project at " + FONT.blue(FONT.underline(proj_url)))
+        swanlog.info("🚀 View run at " + FONT.blue(FONT.underline(exp_url)))
+        return exp_url
 
     def _clean_handler(self):
         run = get_run()

--- a/swanlab/data/run/metadata/cooperation/__init__.py
+++ b/swanlab/data/run/metadata/cooperation/__init__.py
@@ -11,7 +11,6 @@ from swankit.env import get_swanlog_dir
 
 from swanlab.api import get_http
 from swanlab.env import get_mode
-from swanlab.package import get_experiment_url
 from swanlab.package import get_package_version
 from .qing_cloud import get_qing_cloud_info
 
@@ -47,7 +46,7 @@ def get_swanlab_info() -> SwanLabInfo:
     }
     try:
         http = get_http()
-        data["exp_url"] = get_experiment_url(http.username, http.projname, http.exp_id)
+        data["exp_url"] = http.web_exp_url
     except ValueError:
         pass
     return data

--- a/swanlab/data/run/public.py
+++ b/swanlab/data/run/public.py
@@ -2,7 +2,6 @@ from swankit.core import SwanLabSharedSettings
 
 from swanlab.api import get_http
 from swanlab.env import get_mode
-from swanlab.package import get_project_url, get_experiment_url
 
 
 class SwanlabCloudConfig:
@@ -52,9 +51,7 @@ class SwanlabCloudConfig:
         """
         if not self.available:
             return None
-        groupname = self.__get_property_from_http("groupname")
-        projname = self.__get_property_from_http("projname")
-        return get_project_url(groupname, projname)
+        return self.__get_property_from_http("web_proj_url")
 
     @property
     def experiment_name(self):
@@ -70,10 +67,7 @@ class SwanlabCloudConfig:
         """
         if not self.available:
             return None
-        groupname = self.__get_property_from_http("groupname")
-        projname = self.__get_property_from_http("projname")
-        exp_id = self.__get_property_from_http("exp_id")
-        return get_experiment_url(groupname, projname, exp_id)
+        return self.__get_property_from_http("web_exp_url")
 
 
 class SwanLabPublicConfig:

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -263,6 +263,8 @@ def _init_mode(mode: str = None):
     except KeyFileError:
         no_api_key = True
     login_info = None
+    # 三选一只允许登录官方的host，除非在此之前手动设置了环境变量
+    # 详见 https://github.com/SwanHubX/SwanLab/issues/792#issuecomment-2603959483
     if mode == "cloud" and no_api_key:
         # 判断当前进程是否在交互模式下
         if is_interactive():
@@ -273,6 +275,7 @@ def _init_mode(mode: str = None):
             swanlog.info("(2) Use an existing SwanLab account.")
             swanlog.info("(3) Don't visualize my results.")
 
+            web_host = get_host_web()
             # 交互选择
             tip = FONT.swanlab("Enter your choice: ")
             code = input(tip)
@@ -283,16 +286,16 @@ def _init_mode(mode: str = None):
                 mode = "local"
             elif code == "2":
                 swanlog.info("You chose 'Use an existing swanlab account'")
-                swanlog.info("Logging into " + FONT.yellow(get_host_web()))
+                swanlog.info("Logging into " + FONT.yellow(web_host))
                 login_info = terminal_login()
             elif code == "1":
                 swanlog.info("You chose 'Create a swanlab account'")
-                swanlog.info("Create a SwanLab account here: " + FONT.yellow(get_host_web() + "/login"))
+                swanlog.info("Create a SwanLab account here: " + FONT.yellow(web_host + "/login"))
                 login_info = terminal_login()
             else:
                 raise ValueError("Invalid choice")
-
         # 如果不在就不管
+
     os.environ[mode_key] = mode
     return mode, login_info
 

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -51,7 +51,7 @@ def get_package_latest_version(timeout=0.5) -> Optional[str]:
         return None
 
 
-# ---------------------------------- 云端url相关 ----------------------------------
+# ---------------------------------- 云端相关 ----------------------------------
 
 
 def get_host_web() -> str:
@@ -68,30 +68,32 @@ def get_host_api() -> str:
     return os.getenv(SwanLabEnv.API_HOST.value, "https://api.swanlab.cn/api")
 
 
-def get_user_setting_path() -> str:
+def fmt_web_host(web_host: str = None) -> str:
+    """
+    如果web_host为None，则使用默认的web_host
+    并且格式化web_host，去除结尾的/
+    :param web_host: web_host
+    :return: 格式化后的web_host
+    """
+    if web_host is None:
+        web_host = get_host_web()
+    return web_host.rstrip("/")
+
+
+def get_setting_url(web_host: str = None) -> str:
     """获取用户设置的url
+    与实验相关的url不同，这个url在http对象之前被使用，因此不绑定在http对象中
     :return: 用户设置的url
     """
-    return get_host_web() + "/space/~/settings"
+    return fmt_web_host(web_host) + "/space/~/settings"
 
 
-def get_project_url(username: str, projname: str) -> str:
-    """获取项目的url
-    :param username: 用户名
-    :param projname: 项目名
-    :return: 项目的url
+def get_login_url(web_host: str = None) -> str:
+    """获取登录的url
+    与实验相关的url不同，这个url在http对象之前被使用，因此不绑定在http对象中
+    :return: 登录的url
     """
-    return get_host_web() + "/@" + username + "/" + projname
-
-
-def get_experiment_url(username: str, projname: str, expid: str) -> str:
-    """获取实验的url
-    :param username: 用户名
-    :param projname: 项目名
-    :param expid: 实验id
-    :return: 实验的url
-    """
-    return get_project_url(username, projname) + "/runs/" + expid
+    return fmt_web_host(web_host) + "/login"
 
 
 # ---------------------------------- 登录相关 ----------------------------------

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -124,13 +124,14 @@ def get_key():
     return info[2]
 
 
-def save_key(username: str, password: str, host: str = None):
+def save_key(username: str, password: str, host: str = None) -> bool:
     """
     保存key到对应的文件目录下，文件名称为.netrc（basename）
     此函数不考虑上层文件存在的清空，但是会在调用的get_save_dir()函数中进行检查
     :param username: 保存的用户名
     :param password: 保存的密码
     :param host: 保存的host
+    :return: 是否保存，如果已经存在，则不保存
     """
     if host is None:
         host = get_host_api()
@@ -142,11 +143,13 @@ def save_key(username: str, password: str, host: str = None):
     new_info = (username, "", password)
     # 避免重复的写
     info = nrc.authenticators(host)
-    if info != new_info:
+    if info is None or (info[0], info[2]) != (new_info[0], new_info[2]):
         # 同时只允许存在一个host： https://github.com/SwanHubX/SwanLab/issues/797
         nrc.hosts = {host: new_info}
         with open(path, "w") as f:
             f.write(nrc.__repr__())
+        return True
+    return False
 
 
 class LoginCheckContext:

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -180,7 +180,7 @@ class LoginCheckContext:
         return True
 
 
-def is_login() -> bool:
+def has_api_key() -> bool:
     """判断是否已经登录，与当前的host相关
     如果环境变量中有api key，则认为已经登录
     但不会检查key的有效性

--- a/test/unit/api/auth/test_login.py
+++ b/test/unit/api/auth/test_login.py
@@ -10,14 +10,14 @@ r"""
 import os
 
 import nanoid
-
-from swanlab.env import SwanLabEnv
-from swanlab.api.auth.login import login_by_key, terminal_login, code_login
-from swanlab.error import ValidationError, APIKeyFormatError
-from swanlab.package import is_login
-from nanoid import generate
-import tutils as T
 import pytest
+from nanoid import generate
+
+import tutils as T
+from swanlab.api.auth.login import login_by_key, terminal_login, code_login
+from swanlab.env import SwanLabEnv
+from swanlab.error import APIKeyFormatError
+from swanlab.package import has_api_key
 
 
 def get_password(prompt: str):
@@ -60,7 +60,7 @@ def test_terminal_login(monkeypatch):
     assert not login_info.is_fail
     assert login_info.api_key == T.API_KEY
     assert login_info.__str__() == "Login success"
-    assert is_login()
+    assert has_api_key()
 
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
@@ -102,4 +102,4 @@ def test_code_login_task_runtime():
     assert not login_info.is_fail
     # 没有保存在本地
     del os.environ[SwanLabEnv.API_KEY.value]
-    assert not is_login()
+    assert not has_api_key()

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -46,33 +46,12 @@ def test_get_host_api_env():
     assert P.get_host_api() == os.environ[SwanLabEnv.API_HOST.value]
 
 
-def test_get_user_setting_path():
+def test_fmt_web_host():
     """
-    测试获取用户设置文件路径
+    测试格式化web地址
     """
-    assert P.get_user_setting_path() == P.get_host_web() + "/space/~/settings"
-
-
-def test_get_project_url():
-    """
-    测试获取项目url
-    """
-    username = nanoid.generate()
-    projname = nanoid.generate()
-    assert P.get_project_url(username, projname) == P.get_host_web() + "/@" + username + "/" + projname
-
-
-def test_get_experiment_url():
-    """
-    测试获取实验url
-    """
-    username = nanoid.generate()
-    projname = nanoid.generate()
-    expid = nanoid.generate()
-    assert (
-        P.get_experiment_url(username, projname, expid)
-        == P.get_host_web() + "/@" + username + "/" + projname + "/runs/" + expid
-    )
+    assert P.fmt_web_host() == P.get_host_web().rstrip("/")
+    assert P.fmt_web_host("https://abc.cn/") == "https://abc.cn"
 
 
 # ---------------------------------- 登录部分 ----------------------------------

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -191,9 +191,9 @@ class TestSaveKey:
         assert nrc.authenticators(new_host)[2] == new_password
 
 
-class TestIsLogin:
+class TestHasApiKey:
     @staticmethod
-    def login():
+    def save_api_key():
         path = os.path.join(get_save_dir(), ".netrc")
         with open(path, "w"):
             pass
@@ -207,19 +207,19 @@ class TestIsLogin:
         """
         已经登录
         """
-        self.login()
-        assert P.is_login()
+        self.save_api_key()
+        assert P.has_api_key()
 
     def test_no_file(self):
         """
         文件不存在
         """
-        assert not P.is_login()
+        assert not P.has_api_key()
 
     def test_wrong_host(self):
         """
         host不匹配
         """
-        self.login()
+        self.save_api_key()
         os.environ[SwanLabEnv.API_HOST.value] = nanoid.generate()
-        assert not P.is_login()
+        assert not P.has_api_key()


### PR DESCRIPTION
此拉取请求包含对`swanlab`模块的多项更改，主要集中在改进登录功能、URL处理和代码组织上。最重要的更改包括新增了用于处理URL的属性和方法、更新了登录机制，并进行了重构以提高代码清晰度。

主要是为 #792 的实现做准备。

### 登录功能改进：

* 在`swanlab/api/__init__.py`中添加了`is_login`函数，通过验证HTTP对象的存在来检查用户是否已登录。

* 更新了`swanlab/api/auth/login.py`中的`login_request`和`login_by_key`函数，使其接受并使用`api_host`和`web_host`参数。[[1]](diffhunk://#diff-2a5827973e640dc996618a75e9ff2f6e97ab778095647f13cd5a5de7e54fd516L23-R28) [[2]](diffhunk://#diff-2a5827973e640dc996618a75e9ff2f6e97ab778095647f13cd5a5de7e54fd516L45-R48)

### URL处理增强：

* 在`swanlab/api/http.py`中引入了`base_url`、`api_host`、`web_host`、`web_proj_url`和`web_exp_url`属性，以便更好地管理URL。[[1]](diffhunk://#diff-59d6f0332f63c34567b4c6ad36216611d1ec51e7a6f6fc991c360a2736b3f4ecR70-R83) [[2]](diffhunk://#diff-59d6f0332f63c34567b4c6ad36216611d1ec51e7a6f6fc991c360a2736b3f4ecR125-R139)

* 移除了硬编码的URL，并在多个文件中替换为动态URL属性，包括`swanlab/data/callback_cloud.py`、`swanlab/data/run/metadata/cooperation/__init__.py`和`swanlab/data/run/public.py`。[[1]](diffhunk://#diff-b3b5c0593a6849a6d186be5309082b4a634889492dc59121798d523b25c0413cL174-R175) [[2]](diffhunk://#diff-35b14a20b9dda8e779720a135ad7707d274d5712b63c420b4c3e61c253bb6cfeL50-R49) [[3]](diffhunk://#diff-d75c156cafa9b6869f974694c71f9c6b0c6ade6189dee27455f16bde67eee6f7L55-R54) [[4]](diffhunk://#diff-d75c156cafa9b6869f974694c71f9c6b0c6ade6189dee27455f16bde67eee6f7L73-R70)

### 代码重构：

* 重新组织了导入并移除了多个文件中未使用的导入，以提高代码的清晰度和可维护性。[[1]](diffhunk://#diff-59d6f0332f63c34567b4c6ad36216611d1ec51e7a6f6fc991c360a2736b3f4ecL10-R25) [[2]](diffhunk://#diff-b18458402c6b61bc7e67220fca1bf765070faf743bcaa788b95d0638f5843c00R10-L12) [[3]](diffhunk://#diff-83ce08b81418d68c4fd49cd4f7f81f5888a9681a45cd5fa0b9f20b9b89852ae0L13-R20)

* 更新了`swanlab/api/__init__.py`中的`__all__`，以包含新的`is_login`函数。

### CLI命令更新：

* 在`swanlab/cli/commands/auth/login.py`和`swanlab/cli/commands/auth/logout.py`中将`is_login`替换为`has_api_key`，以更好地反映检查API密钥存在的功能。[[1]](diffhunk://#diff-da72db98bad169fd2e9579d63e633101fd03ed147b77f10989069f85293c067bL11-R35) [[2]](diffhunk://#diff-5664466d75bb4a2f0eb80ce92f44c852f4c8ce70f01df41c5127a4d03adfd269R10-R24)

### 额外改进：

* 修改了 `swanlab/package.py`，新增了用于格式化和获取 URL 的函数，例如 `fmt_web_host`、`get_setting_url` 和 `get_login_url`。[[1]](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L71-R96) [[2]](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L183-R185)

---

顺便修复了一下之前的测试(#797)在action执行时的错误问题。

close #804 