### PR TITLE
feat: support nest log

### DIFF
--- a/test/unit/data/run/test_main.py
+++ b/test/unit/data/run/test_main.py
@@ -113,13 +113,14 @@ class TestSwanLabRunLog:
     # ---------------------------------- 解析log数字/Line ----------------------------------
     def test_log_number_ok(self):
         run = SwanLabRun()
-        data = {"a": 1, "b": 0.1, "math.nan": math.nan, "math.inf": math.inf}
+        data = {"a": 1, "b": 0.1, "c": {"d": 2}, "math.nan": math.nan, "math.inf": math.inf}
         ll = run.log(data)
-        assert len(ll) == 4
+        assert len(ll) == 5
         # 都没有错误
         assert all([ll[k].is_error is False for k in ll])
         assert ll["a"].data == 1
         assert ll["b"].data == 0.1
+        assert ll["c.d"].data == 2
         assert ll["math.nan"].data == Line.nan
         assert ll["math.inf"].data == Line.inf
         assert all([ll[k].column_info.chart_type == ll[k].column_info.chart_type.LINE for k in ll])
@@ -146,9 +147,9 @@ class TestSwanLabRunLog:
         使用Line类型log，本质上应该与数字类型一样，数字类型是Line类型的语法糖
         """
         run = SwanLabRun()
-        data = {"a": Line(1), "b": Line(0.1), "math.nan": Line(math.nan), "math.inf": Line(math.inf)}
+        data = {"a": Line(1), "b": Line(0.1), "c": {"d": Line(2)}, "math.nan": Line(math.nan), "math.inf": Line(math.inf)}
         ll = run.log(data)
-        assert len(ll) == 4
+        assert len(ll) == 5
         # line(1)和[line(1)]是一样的
         ll2 = run.log({"a": [Line(1)]})
         assert ll2["a"].data == ll["a"].data


### PR DESCRIPTION
## Description

This pull request includes changes to the `swanlab/data/run/main.py` file to add support for logging nested dictionaries by flattening them. The most important changes include adding a helper method to flatten nested dictionaries, updating the `log` method to handle nested dictionaries, and modifying the key format check to work with the flattened dictionary.

Improvements to nested dictionary handling:

* [`swanlab/data/run/main.py`](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR312-R322): Added a helper method `__flatten_dict` to flatten nested dictionaries with dot notation.
* [`swanlab/data/run/main.py`](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaL323-R335): Updated the `log` method to accept nested dictionaries and flatten them before processing. [[1]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaL323-R335) [[2]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR362-R373)

Closes: #806 

使用案例：

```python
import swanlab

swanlab.init(project="dev")

data = {'a': {'b': {'c': 1, 'd': 2}, 'e': 3}, 'f': 4}
swanlab.log(data)
```