### PR TITLE
feat: add name param

### DIFF
--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -43,6 +43,7 @@ class SwanLabRun:
         log_level: str = None,
         exp_num: int = None,
         operator: SwanLabRunOperator = SwanLabRunOperator(),
+        name: str = None,
     ):
         """
         Initializing the SwanLabRun class involves configuring the settings and initiating other logging processes.
@@ -68,6 +69,8 @@ class SwanLabRun:
             历史实验总数，用于云端颜色与本地颜色的对应
         operator : SwanLabRunOperator, optional
             实验操作员，用于批量处理回调函数的调用，如果不提供此参数(为None)，则会自动生成一个实例
+        name : str, optional
+            实验名称，默认以experiment_name为主，如果experiment_name为None，则以name为主
         """
         if self.is_started():
             raise RuntimeError("SwanLabRun has been initialized")
@@ -103,6 +106,13 @@ class SwanLabRun:
         setattr(config, "_SwanLabConfig__on_setter", self.__operator.on_runtime_info_update)
         self.__config = config
         # ---------------------------------- 注册实验 ----------------------------------
+        # 如果experiment_name和name都提供了，则warning
+        if experiment_name is not None and name is not None:
+            swanlog.warning("The `experiment_name` has been provided, and the `name` will be ignored.")
+        # 如果experiment_name为None，则以name为主
+        elif experiment_name is None and name is not None:
+            experiment_name = name
+            
         self.__exp: SwanLabExp = self.__register_exp(experiment_name, description, num=exp_num)
         # 实验状态标记，如果status不为0，则无法再次调用log方法
         self.__state = SwanLabRunState.RUNNING

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -87,6 +87,7 @@ def init(
     mode: MODES = None,
     load: str = None,
     public: bool = None,
+    name: str = None,
     **kwargs,
 ) -> SwanLabRun:
     """
@@ -143,6 +144,8 @@ def init(
     public : bool, optional
         Whether the project can be seen by anyone, the default is None, which means the project is private.
         Only available in cloud mode while the first time you create the project.
+    name : str, optional
+        The name of the current run, if not provided, it will be the same as the experiment name.
     """
     if SwanLabRun.is_started():
         swanlog.warning("You have already initialized a run, the init function will be ignored")
@@ -158,6 +161,7 @@ def init(
         project = _load_data(load_data, "project", project)
         workspace = _load_data(load_data, "workspace", workspace)
         public = _load_data(load_data, "private", public)
+        name = _load_data(load_data, "name", name)
     project = _check_proj_name(project if project else os.path.basename(os.getcwd()))  # 默认实验名称为当前目录名
     # ---------------------------------- 启动操作员 ----------------------------------
     operator, c = _create_operator(mode, public)
@@ -177,6 +181,7 @@ def init(
         log_level=kwargs.get("log_level", "info"),
         exp_num=exp_num,
         operator=operator,
+        name=name,
     )
     return run
 


### PR DESCRIPTION
## Description

This pull request introduces the `name` parameter to the `SwanLabRun` initialization process in multiple files. The changes ensure that if both `experiment_name` and `name` are provided, a warning is issued, and if `experiment_name` is not provided, `name` is used as the default.

### Enhancements to initialization process:

* [`swanlab/data/run/main.py`](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR46): Added `name` parameter to the `__init__` method and included logic to handle conflicts between `experiment_name` and `name`. [[1]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR46) [[2]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR72-R73) [[3]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR109-R115)
* [`swanlab/data/sdk.py`](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R90): Added `name` parameter to the `init` method and included logic to load and handle the `name` parameter. [[1]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R90) [[2]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R147-R148) [[3]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R164) [[4]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R184)

Closes: #809 
