### PR TITLE
feat: login with host

### DIFF
--- a/docs/登录认证.md
+++ b/docs/登录认证.md
@@ -1,0 +1,7 @@
+# 认证登录
+
+> 有关这块的更多探索，可查阅issue:
+> [#792](https://github.com/SwanHubX/SwanLab/issues/792) [#797](https://github.com/SwanHubX/SwanLab/issues/797)
+
+对于云端版而言，swanlab需要用户提供api key以完成登录认证，完成云端的鉴权。用户可以在swanlab的 [官网](https://swanlab.cn)
+上注册账号，然后在[个人中心](https://swanlab.cn/space/~/settings)获取api key。本部分主要讲解sdk中登录认证的代码逻辑。

--- a/swanlab/api/info.py
+++ b/swanlab/api/info.py
@@ -11,7 +11,7 @@ from typing import Union
 
 import requests
 
-from swanlab.package import save_key
+from swanlab.package import save_key, fmt_web_host
 
 
 class LoginInfo:
@@ -28,7 +28,7 @@ class LoginInfo:
         """
         如果此属性不为None，username返回此属性
         """
-        self.web_host = web_host
+        self.web_host = fmt_web_host(web_host)
         self.api_host = api_host
 
     @property
@@ -91,7 +91,7 @@ class LoginInfo:
         """
         保存登录信息
         """
-        return save_key("user", self.api_key)
+        return save_key(self.web_host, self.api_key, self.api_host)
 
 
 class ProjectInfo:

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -137,13 +137,14 @@ def save_key(username: str, password: str, host: str = None) -> bool:
     """
     保存key到对应的文件目录下，文件名称为.netrc（basename）
     此函数不考虑上层文件存在的清空，但是会在调用的get_save_dir()函数中进行检查
-    :param username: 保存的用户名
+    :param username: 保存的用户名，默认为user，可选择存储为前端网页ip或者域名
     :param password: 保存的密码
     :param host: 保存的host
     :return: 是否保存，如果已经存在，则不保存
     """
     if host is None:
-        host = get_host_api().rstrip("/api")
+        host = get_host_api()
+    host = host.rstrip("/api")
     path = get_nrc_path()
     if not os.path.exists(path):
         with open(path, "w") as f:

--- a/test/unit/test_env.py
+++ b/test/unit/test_env.py
@@ -12,10 +12,10 @@ import os
 import pytest
 
 import swanlab
-from swanlab.env import SwanLabEnv, is_interactive
+from swanlab.env import SwanLabEnv, is_interactive, get_save_dir
 
 
-def test_default():
+def test_set_default():
     """
     测试获取默认的环境变量
     """
@@ -25,6 +25,22 @@ def test_default():
     swanlab.env.SwanLabEnv.set_default()
     assert swanlab.package.get_host_web() == "https://swanlab.cn"
     assert swanlab.package.get_host_api() == "https://api.swanlab.cn/api"
+    assert os.getenv(SwanLabEnv.RUNTIME.value) == "user"
+
+
+def test_set_by_netrc():
+    """
+    测试通过netrc文件设置环境变量
+    """
+    del os.environ[SwanLabEnv.WEB_HOST.value]
+    del os.environ[SwanLabEnv.API_HOST.value]
+    del os.environ[SwanLabEnv.RUNTIME.value]
+    netrc_path = os.path.join(get_save_dir(), ".netrc")
+    with open(netrc_path, "w") as f:
+        f.write("machine https://example.cn\nlogin test\npassword 123")
+    swanlab.env.SwanLabEnv.set_default()
+    assert swanlab.package.get_host_web() == "https://example.cn"
+    assert swanlab.package.get_host_api() == "https://example.cn/api"
     assert os.getenv(SwanLabEnv.RUNTIME.value) == "user"
 
 

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -138,6 +138,8 @@ class TestSaveKey:
     def get_key(path, host):
         nrc = netrc.netrc(path)
         info = nrc.authenticators(host)
+        if info is None:
+            info = nrc.authenticators(host.rstrip("/api"))
         return info[2]
 
     @staticmethod
@@ -178,7 +180,7 @@ class TestSaveKey:
             assert self.get_key(path, h) == p
             return self.loose_compare(os.path.getmtime(path), c, equal)
 
-        password = nanoid.generate()
+        password = "123456"
         host = P.get_host_api()
         P.save_key("user", password, host=host)
         assert self.get_key(path, host) == password
@@ -186,16 +188,17 @@ class TestSaveKey:
         # 重复保存
         duplicate_save(password, host, equal=True)
         # 再次保存，但是账号不同
-        new_password = nanoid.generate()
+        new_password = "567890"
         duplicate_save(new_password, host, user="user2", equal=False)
         # 再次保存，但是host不同
-        new_host = nanoid.generate()
+        new_host = "example.com"
         duplicate_save(new_password, new_host, equal=False)
         nrc = netrc.netrc(path)
         assert len(nrc.hosts) == 1
+        assert list(nrc.hosts.keys())[0] == new_host
         assert nrc.authenticators(new_host) is not None
         # 再次保存，但是密码又不同了
-        new_password = nanoid.generate()
+        new_password = "abcdef"
         duplicate_save(new_password, new_host, equal=False)
         nrc = netrc.netrc(path)
         assert len(nrc.hosts) == 1

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -110,6 +110,27 @@ class TestGetKey:
         os.environ[SwanLabEnv.API_KEY.value] = key
         assert P.get_key() == key
 
+    def test_compatible(self):
+        """
+        测试向下兼容性，假设有一个带 /api 的host在本地文件中，但是寻找的是不带 /api 的host
+        """
+        self.remove_env_key()
+        file = os.path.join(get_save_dir(), ".netrc")
+        with open(file, "w"):
+            pass
+        nrc = netrc.netrc(file)
+        key = nanoid.generate()
+        host = "https://api.swanlab.cn/api"
+        os.environ[SwanLabEnv.API_HOST.value] = host
+        nrc.hosts[host] = ("user", "", key)
+        with open(file, "w") as f:
+            f.write(repr(nrc))
+        assert P.get_key() == key
+        host = host.rstrip("/api")
+        os.environ[SwanLabEnv.API_HOST.value] = host
+        self.remove_env_key()
+        assert P.get_key() == key
+
 
 class TestSaveKey:
 


### PR DESCRIPTION
本次 Pull Request 包括多项更改，以优化登录认证流程并增强 SwanLab SDK 中主机格式处理的功能。主要更新包括登录逻辑改进 #792  、引入新的 `HostFormatter` 类以及环境变量处理的调整。

### 登录认证改进：
- [`docs/登录认证.md`](diffhunk://#diff-317dd29f5bd964830f571905f1f7df09f9504b6c5468b4343ef84dd6fda1f9f1R1-R7)：新增登录认证文档，并提供相关问题链接以供进一步探索。  
- [`swanlab/api/info.py`](diffhunk://#diff-b18458402c6b61bc7e67220fca1bf765070faf743bcaa788b95d0638f5843c00L14-R14)：更新 `LoginInfo` 类，使用新的 `fmt_web_host` 函数进行 Web 主机格式化，并修改 `save` 方法以保存 Web 主机和 API 主机信息。  

### 主机格式处理增强：
- [`swanlab/data/sdk.py`](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R11)：引入 `HostFormatter` 类，以标准化主机 URL 格式，并更新登录函数以使用该格式器验证并设置主机环境变量。  
- [`swanlab/env.py`](diffhunk://#diff-5fe153a98ec08bba37a638f14053c3cd60760fee2cb2fc5b0d2b206f0f0f84e4R12-R14)：为 `SwanLabEnv` 类新增方法，以验证字符串是否为有效主机名，并更新 `set_default` 方法以支持从 `.netrc` 文件读取主机信息（若存在）。

### 兼容性与测试：
- [`swanlab/package.py`](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8L117-R130)：更新 `get_key` 和 `save_key` 函数，使其能够处理不含 `/api` 后缀的主机 URL，以保持向后兼容。  
- [`test/unit/data/test_sdk.py`](diffhunk://#diff-d1f9e906938529c8b3cfd6cd32be274012116f9fd4f4bd45a30f85fa4a69bff1R309-R327)：新增 `HostFormatter` 类的测试，并更新登录函数测试以涵盖新的主机参数处理。  
- [`test/unit/test_env.py`](diffhunk://#diff-bb8b715afb486b55b516a12b79c25c6bc1fe9514d81fc9b62c88bc15029f4172L15-R18)：新增测试以验证通过 `.netrc` 文件设置环境变量的功能。  
- [`test/unit/test_package.py`](diffhunk://#diff-c97f3cacc647e043e22cb866d8d3e34e199daf602badcf5232cc551ce1cb1b5bR113-R133)：新增测试以确保对包含 `/api` 后缀的主机保持兼容性。  

----

本pr已经能实现`swanlab.login(api_key="xxx", host="xxx")` 的效果，此函数新增两个可选参数：

1. host：后端host，字符串格式为`协议://host:端口号`其中端口号和协议可省略，此时默认https协议。此参数影响登录认证。
2. web_host: 前端host，格式与host相同，如果不传递，并且host传递，默认使用host作为web_host。此参数仅影响命令行显示

命令行相关功能将在下一个pr完成