### PR TITLE
fix: invalid print

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-swankit==0.1.2b6
+swankit==0.1.3
 swanboard==0.1.7b1
 cos-python-sdk-v5
 urllib3>=1.26.0

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -248,7 +248,7 @@ def should_call_after_init(text):
 
 
 @should_call_after_init("You must call swanlab.init() before using log()")
-def log(data: Dict[str, DataType], step: int = None):
+def log(data: Dict[str, DataType], step: int = None, print_to_console: bool = False):
     """
     Log a row of data to the current run.
     We recommend that you log data by SwanLabRun.log() method, but you can also use this function to log data.
@@ -262,9 +262,12 @@ def log(data: Dict[str, DataType], step: int = None):
     step : int, optional
         The step number of the current data, if not provided, it will be automatically incremented.
         If step is duplicated, the data will be ignored.
+    print_to_console : bool, optional
+        Whether to print the data to the console, the default is False.
     """
     run = get_run()
     ll = run.log(data, step)
+    print_to_console and print(ll)
     return ll
 
 


### PR DESCRIPTION
这个拉取请求对 `swanlab/data/sdk.py` 文件中的 `log` 函数进行了一个小的修改。修改添加了一个可选的参数，用于控制是否将日志数据打印到控制台。

* [`swanlab/data/sdk.py`](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327L251-R251)：添加了 `print_to_console` 参数到 `log` 函数，并更新了文档字符串以包含该参数的描述。如果 `print_to_console` 设置为 `True`，日志数据将打印到控制台。 [[1]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327L251-R251) [[2]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327R265-R270)
* 升级了swankit版本号，修复了metric_info的格式化问题

close #816 
