### PR TITLE
feat: host params for login cli

### DIFF
--- a/swanlab/cli/commands/auth/login.py
+++ b/swanlab/cli/commands/auth/login.py
@@ -7,11 +7,15 @@ r"""
 @Description:
     登录模块
 """
+import os
+import sys
+
 import click
 from swankit.log import FONT
 
+from swanlab import SwanLabEnv
 from swanlab.api.auth import terminal_login
-from swanlab.package import has_api_key
+from swanlab.package import has_api_key, HostFormatter
 
 
 @click.command()
@@ -30,13 +34,36 @@ from swanlab.package import has_api_key
     help="If you prefer not to engage in commands-line interaction to input the api key, "
     "this will allow automatic login.",
 )
-def login(api_key: str, relogin: bool):
+@click.option(
+    "--host",
+    "-h",
+    default=None,
+    type=str,
+    help="The host of the swanlab server.",
+)
+@click.option(
+    "--web-host",
+    "-w",
+    default=None,
+    type=str,
+    help="The web host of the swanlab cloud front-end.",
+)
+def login(api_key: str, relogin: bool, host: str, web_host: str):
     """Login to the swanlab cloud."""
     if not relogin and has_api_key():
         # 此时代表token已经获取，需要打印一条信息：已经登录
         command = FONT.bold("swanlab login --relogin")
         tip = FONT.swanlab("You are already logged in. Use `" + command + "` to force relogin.")
         return print(tip)
+    # 清除环境变量
+    if relogin:
+        del os.environ[SwanLabEnv.API_HOST.value]
+        del os.environ[SwanLabEnv.WEB_HOST.value]
+    try:
+        HostFormatter(host, web_host)()
+    except ValueError as e:
+        click.BadParameter(str(e))
+        return sys.exit(1)
     # 进行登录，此时将直接覆盖本地token文件
     login_info = terminal_login(api_key)
     print(FONT.swanlab("Login successfully. Hi, " + FONT.bold(FONT.default(login_info.username))) + "!")

--- a/swanlab/cli/commands/auth/login.py
+++ b/swanlab/cli/commands/auth/login.py
@@ -8,13 +8,12 @@ r"""
     登录模块
 """
 import os
-import sys
 
 import click
 from swankit.log import FONT
 
-from swanlab import SwanLabEnv
 from swanlab.api.auth import terminal_login
+from swanlab.env import SwanLabEnv
 from swanlab.package import has_api_key, HostFormatter
 
 
@@ -62,8 +61,7 @@ def login(api_key: str, relogin: bool, host: str, web_host: str):
     try:
         HostFormatter(host, web_host)()
     except ValueError as e:
-        click.BadParameter(str(e))
-        return sys.exit(1)
+        raise click.BadParameter(str(e))
     # 进行登录，此时将直接覆盖本地token文件
     login_info = terminal_login(api_key)
     print(FONT.swanlab("Login successfully. Hi, " + FONT.bold(FONT.default(login_info.username))) + "!")

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -8,7 +8,6 @@ r"""
     在此处封装swanlab在日志记录模式下的各种接口
 """
 import os
-import re
 from typing import Optional, Union, Dict, Tuple, Literal
 
 from swanboard import SwanBoardCallback
@@ -30,7 +29,7 @@ from .run import (
 )
 from .run.helper import SwanLabRunOperator
 from ..error import KeyFileError
-from ..package import get_key, get_host_web
+from ..package import get_key, get_host_web, HostFormatter
 
 
 def _check_proj_name(name: str) -> str:
@@ -58,31 +57,6 @@ def _check_proj_name(name: str) -> str:
     return _name
 
 
-class HostFormatter:
-    def __init__(self):
-        # 定义正则模式，匹配协议、主机、端口三部分
-        self.pattern = re.compile(
-            r'^(?:(https?)://)?'  # 可选协议 http 或 https
-            r'([a-zA-Z0-9.-]+\.[a-zA-Z]{2,63})'  # 必填 主机名必须包含顶级域名（TLD）
-            r'(?::(\d{1,5}))?$'  # 可选端口号（1~5位数字）
-        )
-
-    def __call__(self, input_str: str) -> str:
-        match = self.pattern.match(input_str.rstrip("/"))
-        if match:
-            protocol = match.group(1) or "https"  # 默认协议为 https
-            host = match.group(2)
-            port = match.group(3)
-
-            # 构建标准化的 URL 输出
-            result = f"{protocol}://{host}"
-            if port:
-                result += f":{port}"
-            return result
-        else:
-            raise ValueError("Invalid host format")
-
-
 def login(api_key: str = None, host: str = None, web_host: str = None):
     """
     Login to SwanLab Cloud. If you already have logged in, you can use this function to relogin.
@@ -100,19 +74,9 @@ def login(api_key: str = None, host: str = None, web_host: str = None):
     """
     if SwanLabRun.is_started():
         raise RuntimeError("You must call swanlab.login() before using init()")
-    # ---------------------------------- 检查host是否合法，并格式化 ----------------------------------
-    formater = HostFormatter()
-    if host:
-        try:
-            os.environ[SwanLabEnv.API_HOST.value] = formater(host) + "/api"
-        except ValueError:
-            raise ValueError("Invalid host: {}".format(host))
-    if web_host:
-        try:
-            os.environ[SwanLabEnv.WEB_HOST.value] = formater(web_host)
-        except ValueError:
-            raise ValueError("Invalid web_host: {}".format(web_host))
-    # ---------------------------------- 登录，初始化http对象 ----------------------------------
+    # 检查host是否合法，并格式化，注入到环境变量中
+    HostFormatter(host, web_host)()
+    # 登录，初始化http对象
     CloudRunCallback.login_info = code_login(api_key) if api_key else CloudRunCallback.create_login_info()
 
 

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -14,6 +14,7 @@ import os
 import re
 import sys
 from typing import List
+from urllib.parse import urlparse
 
 import swankit.env as E
 from swankit.env import SwanLabSharedEnv
@@ -75,14 +76,23 @@ class SwanLabEnv(enum.Enum):
     @staticmethod
     def is_hostname(value: str) -> bool:
         """
-        判断是否为合法的主机名
+        判断是否为合法的主机名（支持 http/https 协议和端口号）
         :param value: 待判断的字符串
         :return: 是否为合法的主机名
         """
-        if bool(re.compile(r'^((25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})(\.|$)){4}$').match(value)):
+        # 解析 URL 以提取主机部分
+        parsed_url = urlparse(value)
+        if parsed_url.scheme in ["http", "https"]:
+            value = parsed_url.hostname  # 只取域名部分
+
+        # 处理 IP 地址
+        if re.fullmatch(r'((25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})(\.|$)){4}', value):
             return True
-        if bool(re.compile(r'^(?!-)([a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,63}$').match(value)):
+
+        # 处理域名（去掉端口）
+        if re.fullmatch(r'^(?!-)([a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,63}$', value):
             return True
+
         return False
 
     @classmethod

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -91,7 +91,7 @@ class HostFormatter:
                 os.environ[SwanLabEnv.API_HOST.value] = self.fmt(self.host) + "/api"
             except ValueError:
                 raise ValueError("Invalid host: {}".format(self.host))
-            self.web_host = self.host
+            self.web_host = self.host if self.web_host is None else self.web_host
         if self.web_host:
             try:
                 os.environ[SwanLabEnv.WEB_HOST.value] = self.fmt(self.web_host)

--- a/test/unit/cli/test_cli_login.py
+++ b/test/unit/cli/test_cli_login.py
@@ -55,4 +55,4 @@ def test_login_host():
     del os.environ[SwanLabEnv.API_HOST.value]  # 删除环境变量
     del os.environ[SwanLabEnv.WEB_HOST.value]  # 删除环境变量
     result = runner.invoke(cli, ["login", "--api-key", T.API_KEY, "--host", "http://wrong-host"])
-    assert result.exit_code == 1
+    assert result.exit_code == 2

--- a/test/unit/cli/test_cli_login.py
+++ b/test/unit/cli/test_cli_login.py
@@ -7,13 +7,17 @@ r"""
 @Description:
     测试命令登录
 """
+import os
+
 import nanoid
-from swanlab.package import get_key
-from click.testing import CliRunner
-from swanlab.cli.main import cli
-from swanlab.error import ValidationError, APIKeyFormatError
-import tutils as T
 import pytest
+from click.testing import CliRunner
+
+import tutils as T
+from swanlab.cli.main import cli
+from swanlab.env import SwanLabEnv
+from swanlab.error import ValidationError, APIKeyFormatError
+from swanlab.package import get_key
 
 
 # noinspection PyTypeChecker
@@ -35,3 +39,20 @@ def test_login_fail():
     result = runner.invoke(cli, ["login", "--api-key", "wrong-key"])
     assert result.exit_code == 1
     assert isinstance(result.exception, APIKeyFormatError)
+
+
+# noinspection PyTypeChecker
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+def test_login_host():
+    """
+    测试登录时指定host
+    """
+    runner = CliRunner()
+    del os.environ[SwanLabEnv.API_HOST.value]  # 删除环境变量
+    del os.environ[SwanLabEnv.WEB_HOST.value]  # 删除环境变量
+    result = runner.invoke(cli, ["login", "--api-key", T.API_KEY, "--host", T.API_HOST.rstrip("/api")])
+    assert result.exit_code == 0
+    del os.environ[SwanLabEnv.API_HOST.value]  # 删除环境变量
+    del os.environ[SwanLabEnv.WEB_HOST.value]  # 删除环境变量
+    result = runner.invoke(cli, ["login", "--api-key", T.API_KEY, "--host", "http://wrong-host"])
+    assert result.exit_code == 1

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -306,25 +306,6 @@ class TestInitLogdir:
         assert run.public.swanlog_dir == logdir
 
 
-class TestHostFormatter:
-    def test_ok(self):
-        formatter = S.HostFormatter()
-        assert formatter("swanlab.cn") == "https://swanlab.cn"
-        assert formatter("https://swanlab.cn") == "https://swanlab.cn"
-        assert formatter("http://swanlab.cn") == "http://swanlab.cn"  # noqa
-        assert formatter("https://swanlab.cn:8443/") == "https://swanlab.cn:8443"
-        assert formatter("abc.example.com") == "https://abc.example.com"
-
-    def test_value_err(self):
-        formatter = S.HostFormatter()
-        with pytest.raises(ValueError):
-            formatter("test")
-        with pytest.raises(ValueError):
-            formatter("https://test")
-        with pytest.raises(ValueError):
-            formatter("http://test")  # noqa
-
-
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
 class TestLogin:
     """

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -239,3 +239,22 @@ class TestHasApiKey:
         self.save_api_key()
         os.environ[SwanLabEnv.API_HOST.value] = nanoid.generate()
         assert not P.has_api_key()
+
+
+class TestHostFormatter:
+    def test_ok(self):
+        formatter = P.HostFormatter()
+        assert formatter.fmt("swanlab.cn") == "https://swanlab.cn"
+        assert formatter.fmt("https://swanlab.cn") == "https://swanlab.cn"
+        assert formatter.fmt("http://swanlab.cn") == "http://swanlab.cn"  # noqa
+        assert formatter.fmt("https://swanlab.cn:8443/") == "https://swanlab.cn:8443"
+        assert formatter.fmt("abc.example.com") == "https://abc.example.com"
+
+    def test_value_err(self):
+        formatter = P.HostFormatter()
+        with pytest.raises(ValueError):
+            formatter.fmt("test")
+        with pytest.raises(ValueError):
+            formatter.fmt("https://test")
+        with pytest.raises(ValueError):
+            formatter.fmt("http://test")  # noqa

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -258,3 +258,12 @@ class TestHostFormatter:
             formatter.fmt("https://test")
         with pytest.raises(ValueError):
             formatter.fmt("http://test")  # noqa
+
+    def test_env_var(self):
+        """
+        输入正确的host，会自动赋值给空web_host
+        """
+        host = "https://swanlab.cn"
+        P.HostFormatter(host=host)()
+        assert os.environ[SwanLabEnv.WEB_HOST.value] == host
+        assert os.environ[SwanLabEnv.API_HOST.value] == host + "/api"


### PR DESCRIPTION
该拉取请求（Pull Request）对 `swanlab` 项目进行了重要更新，重点涉及 `HostFormatter` 类及其在多个模块中的集成。主要改动包括 `HostFormatter` 类的迁移与增强、登录功能的更新，以及额外的测试以确保系统的健壮性。

### 主要变更：

#### **重构与增强：**
* `HostFormatter` 类已从 `swanlab/data/sdk.py` 移动到 `swanlab/package.py`，并增强了对 `host` 和 `web_host` 参数的处理能力。该类现在负责验证和格式化主机 URL，并设置相关的环境变量。[[1]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327L61-L85) [[2]](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8R58-R101)

#### **登录功能：**
* 更新了 `swanlab/cli/commands/auth/login.py` 中的 `login` 函数，新增 `host` 和 `web_host` 选项，允许用户在登录时指定服务器和 Web 主机。
* 在重新登录时新增逻辑以清除环境变量，并使用 `HostFormatter` 类进行主机地址的验证和格式化。

#### **代码优化：**
* 移除了 `swanlab/data/sdk.py` 中冗余的 `HostFormatter` 类定义，并更新 `login` 函数以使用 `swanlab/package.py` 中的新 `HostFormatter` 类。[[1]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327L61-L85) [[2]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327L103-R79)

#### **测试：**
* 在 `test/unit/cli/test_cli_login.py` 和 `test/unit/test_package.py` 中新增测试用例，以验证 `HostFormatter` 类的功能以及不同主机输入下的登录过程。[[1]](diffhunk://#diff-ace982209179f5fc51fe746cbc91fc638e728133d916aba811f295875b12327dR42-R58) [[2]](diffhunk://#diff-c97f3cacc647e043e22cb866d8d3e34e199daf602badcf5232cc551ce1cb1b5bR242-R260)
* 移除了 `test/unit/data/test_sdk.py` 中针对旧 `HostFormatter` 类的过时测试用例。

### **导入与依赖项：**
* 在多个文件中添加了 `os`、`sys` 和 `re` 模块的必要导入，以支持新功能。[[1]](diffhunk://#diff-da72db98bad169fd2e9579d63e633101fd03ed147b77f10989069f85293c067bR10-R18) [[2]](diffhunk://#diff-158dd8e86f8747fb6fb7b53a3880d678a4916f8b149dc71571ebe6372f300327L11) [[3]](diffhunk://#diff-aabef23bd5d0551b5c6a89b2bd7745b1d3a612652f66946214a7fa16778c0db8R13) [[4]](diffhunk://#diff-ace982209179f5fc51fe746cbc91fc638e728133d916aba811f295875b12327dR10-R20)


----

注意：在交互上，重新登录需要使用`--relogin`参数，此时host也会被重置为官方的。

close #792 