### PR TITLE
fix: cat /proc/cpuinfo

### DIFF
--- a/swanlab/data/run/metadata/hardware/cpu.py
+++ b/swanlab/data/run/metadata/hardware/cpu.py
@@ -51,12 +51,11 @@ def get_cpu_brand_windows():
 
 def get_cpu_brand_linux():
     try:
-        # 使用 lscpu 命令获取 CPU 品牌
-        result = subprocess.run(["lscpu"], capture_output=True, text=True)
-        for line in result.stdout.split("\n"):
-            if "Model name:" in line:
-                cpu_brand = line.split(":")[1].strip()
-                return cpu_brand
+        # 使用 cat /proc/cpuinfo 获取CPU品牌
+        with open("/proc/cpuinfo", "r") as f:
+            for line in f:
+                if "model name" in line.lower():
+                    return line.split(":")[1].strip()
         return None
     except Exception:  # noqa
         return None


### PR DESCRIPTION
## Description (tiny fix)

- 在部分中文环境下的 bash 中，`lscpu` 无法正常读取到 cpu brand，这里替换成了直接去 /proc 中读

![demo](https://github.com/user-attachments/assets/26f9b699-1c20-4067-947d-413bbd996a09)

![image](https://github.com/user-attachments/assets/3c8bfcad-47d7-4f10-8d2c-ab707033daa2)

- 测试：
![image](https://github.com/user-attachments/assets/a61ee77e-0037-483f-8510-c64a02ce2a01)

