### PR TITLE
docs: readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@
 [![][github-issues-shield]][github-issues-shield-link]
 [![][github-contributors-shield]][github-contributors-link]
 [![][license-shield]][license-shield-link]  
-[![][swanlab-cloud-shield]][swanlab-cloud-shield-link]
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]
 [![][last-commit-shield]][last-commit-shield-link]
 [![][pypi-version-shield]][pypi-version-shield-link]
 [![][wechat-shield]][wechat-shield-link]
 [![][pypi-downloads-shield]][pypi-downloads-shield-link]
 [![][colab-shield]][colab-shield-link]
+
 
 ![](readme_files/swanlab-overview.png)
 
@@ -326,11 +327,14 @@ swanlab watch ./logs
 
 如果你喜欢在工作中使用 SwanLab，请将 SwanLab 徽章添加到你的 README 中：
 
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]、[![][visualize-swanlab-shield]][visualize-swanlab-shield-link]
 
 ```
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg)](your experiment url)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg)](your experiment url)
 ```
+
+更多设计素材：[assets](https://github.com/SwanHubX/assets)
 
 ### 在论文中引用 SwanLab
 
@@ -353,9 +357,7 @@ swanlab watch ./logs
 
 同时，我们非常欢迎通过社交媒体、活动和会议的分享来支持 SwanLab，衷心感谢！
 
-### 下载 Icon
 
-[SwanLab-Icon-SVG](readme_files/swanlab-logo.svg)
 
 <br>
 
@@ -427,3 +429,9 @@ swanlab watch ./logs
 
 [demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg
+
+[tracking-swanlab-shield-link]:https://swanlab.cn
+[tracking-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg
+
+[visualize-swanlab-shield-link]:https://swanlab.cn
+[visualize-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg

--- a/README_EN.md
+++ b/README_EN.md
@@ -18,7 +18,7 @@ Supports both cloud/offline usage, integrates with 30+ mainstream frameworks, an
 [![][github-issues-shield]][github-issues-shield-link]
 [![][github-contributors-shield]][github-contributors-link]
 [![][license-shield]][license-shield-link]  
-[![][swanlab-cloud-shield]][swanlab-cloud-shield-link]
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]
 [![][last-commit-shield]][last-commit-shield-link]
 [![][pypi-version-shield]][pypi-version-shield-link]
 [![][wechat-shield]][wechat-shield-link]
@@ -316,11 +316,14 @@ Below is a list of frameworks we have integrated. Feel free to submit an [Issue]
 
 If you enjoy using SwanLab in your work, please add the SwanLab badge to your README:
 
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]、[![][visualize-swanlab-shield]][visualize-swanlab-shield-link]
 
 ```
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg)](your experiment url)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg)](your experiment url)
 ```
+
+More design materials: [assets](https://github.com/SwanHubX/assets)
 
 ### Citing SwanLab in Papers
 
@@ -342,10 +345,6 @@ If you find SwanLab helpful in your research journey, please consider citing it 
 Considering contributing to SwanLab? First, take a moment to read the [Contribution Guide](CONTRIBUTING.md).
 
 We also greatly appreciate support through social media, events, and conference sharing. Thank you!
-
-### Download Icon
-
-[SwanLab-Icon-SVG](readme_files/swanlab-logo.svg)
 
 <br>
 
@@ -417,3 +416,9 @@ This repository is licensed under the [Apache 2.0 License](https://github.com/Sw
 
 [demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg
+
+[tracking-swanlab-shield-link]:https://swanlab.cn
+[tracking-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg
+
+[visualize-swanlab-shield-link]:https://swanlab.cn
+[visualize-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg

--- a/README_JP.md
+++ b/README_JP.md
@@ -19,7 +19,7 @@
 [![][github-issues-shield]][github-issues-shield-link]
 [![][github-contributors-shield]][github-contributors-link]
 [![][license-shield]][license-shield-link]  
-[![][swanlab-cloud-shield]][swanlab-cloud-shield-link]
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]
 [![][last-commit-shield]][last-commit-shield-link]
 [![][pypi-version-shield]][pypi-version-shield-link]
 [![][wechat-shield]][wechat-shield-link]
@@ -320,11 +320,14 @@ swanlab watch ./logs
 
 SwanLabを仕事で使用している場合、SwanLabバッジをREADMEに追加してください：
 
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]、[![][visualize-swanlab-shield]][visualize-swanlab-shield-link]
 
 ```
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg)](your experiment url)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg)](your experiment url)
 ```
+
+さらにデザイン素材：[assets](https://github.com/SwanHubX/assets)
 
 ### 論文でSwanLabを引用
 
@@ -346,10 +349,6 @@ SwanLabがあなたの研究の旅に役立った場合は、以下の形式で�
 SwanLabに貢献したいですか？まず、[貢献ガイド](CONTRIBUTING.md)をお読みください。
 
 また、ソーシャルメディア、イベント、カンファレンスでの共有を通じてSwanLabをサポートすることも大歓迎です。心から感謝します！
-
-### アイコンのダウンロード
-
-[SwanLab-Icon-SVG](readme_files/swanlab-logo.svg)
 
 <br>
 
@@ -421,3 +420,9 @@ SwanLabに貢献したいですか？まず、[貢献ガイド](CONTRIBUTING.md)
 
 [demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg
+
+[tracking-swanlab-shield-link]:https://swanlab.cn
+[tracking-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg
+
+[visualize-swanlab-shield-link]:https://swanlab.cn
+[visualize-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg

--- a/README_RU.md
+++ b/README_RU.md
@@ -18,7 +18,7 @@
 [![][github-issues-shield]][github-issues-shield-link]
 [![][github-contributors-shield]][github-contributors-link]
 [![][license-shield]][license-shield-link]  
-[![][swanlab-cloud-shield]][swanlab-cloud-shield-link]
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]
 [![][last-commit-shield]][last-commit-shield-link]
 [![][pypi-version-shield]][pypi-version-shield-link]
 [![][wechat-shield]][wechat-shield-link]
@@ -316,11 +316,14 @@ swanlab watch ./logs
 
 Если вам нравится использовать SwanLab в вашей работе, добавьте значок SwanLab в ваш README:
 
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![][tracking-swanlab-shield]][tracking-swanlab-shield-link]、[![][visualize-swanlab-shield]][visualize-swanlab-shield-link]
 
 ```
-[![swanlab](https://img.shields.io/badge/powered%20by-SwanLab-438440)](https://github.com/swanhubx/swanlab)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg)](your experiment url)
+[![](https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg)](your experiment url)
 ```
+
+Больше дизайнерских материалов：[assets](https://github.com/SwanHubX/assets)
 
 ### Цитирование SwanLab в научных работах
 
@@ -342,10 +345,6 @@ swanlab watch ./logs
 Хотите внести вклад в SwanLab? Сначала ознакомьтесь с [руководством по вкладу](CONTRIBUTING.md).
 
 Мы также приветствуем поддержку через социальные сети, мероприятия и конференции. Спасибо!
-
-### Скачать иконку
-
-[SwanLab-Icon-SVG](readme_files/swanlab-logo.svg)
 
 <br>
 
@@ -417,3 +416,9 @@ swanlab watch ./logs
 
 [demo-qwen2-vl]:https://swanlab.cn/@ZeyiLin/Qwen2-VL-finetune/runs/pkgest5xhdn3ukpdy6kv5/chart
 [demo-qwen2-vl-image]: readme_files/example-qwen2-vl.jpg
+
+[tracking-swanlab-shield-link]:https://swanlab.cn
+[tracking-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge2.svg
+
+[visualize-swanlab-shield-link]:https://swanlab.cn
+[visualize-swanlab-shield]: https://raw.githubusercontent.com/SwanHubX/assets/main/badge1.svg


### PR DESCRIPTION
## Description

更新了徽章，与assets仓库的引导链接

This pull request includes updates to the `README` files in multiple languages to replace the `swanlab-cloud-shield` badge with the `tracking-swanlab-shield` badge and to add new badges for visualizing SwanLab. Additionally, it removes the section for downloading the SwanLab icon and adds links to design materials.

Badge updates:

* Replaced `swanlab-cloud-shield` with `tracking-swanlab-shield` across all `README` files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R28) [[2]](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abL21-R21) [[3]](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25L22-R22) [[4]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L21-R21)
* Added `visualize-swanlab-shield` badge and updated badge links in all `README` files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L329-R338) [[2]](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abL319-R327) [[3]](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25L323-R331) [[4]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L319-R327)

Content updates:

* Removed the section for downloading the SwanLab icon from all `README` files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L356-L358) [[2]](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abL346-L349) [[3]](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25L350-L353) [[4]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L346-L349)
* Added links to design materials in all `README` files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L329-R338) [[2]](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abL319-R327) [[3]](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25L323-R331) [[4]](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989L319-R327)