### PR TITLE
feat: add some func for get exp info

### DIFF
--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -11,11 +11,12 @@ from .data import (
     State,
     get_run,
     get_config,
+    config,
+    get_url,
+    get_project_url,
 )
-
-from .data.run.main import config
-from .package import get_package_version
 from .env import SwanLabEnv
+from .package import get_package_version
 from .sync import sync_wandb, sync_tensorboardX, sync_tensorboard_torch
 
 # 设置默认环境变量

--- a/swanlab/data/__init__.py
+++ b/swanlab/data/__init__.py
@@ -12,17 +12,18 @@ from .modules import (
     Image,
     Text,
 )
-
-from .sdk import (
-    login,
-    init,
-    log,
-    finish,
-)
-
 from .run import (
     SwanLabRun as Run,
     SwanLabRunState as State,
     get_run,
     get_config,
+    get_url,
+    get_project_url,
+    config,
+)
+from .sdk import (
+    login,
+    init,
+    log,
+    finish,
 )

--- a/swanlab/data/run/__init__.py
+++ b/swanlab/data/run/__init__.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     在此处导出SwanLabRun类，一次实验运行应该只有一个SwanLabRun实例
 """
-from .main import SwanLabRun, get_run, get_config, SwanLabRunState
+from .main import SwanLabRun, get_run, get_config, SwanLabRunState, get_url, get_project_url, config
 
 
 def register(*args, **kwargs) -> SwanLabRun:

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -443,3 +443,25 @@ def get_config() -> Optional["SwanLabConfig"]:
     """
     global config
     return config
+
+
+def get_url() -> Optional["str"]:
+    """
+    Get the url of the current experiment.
+    NOTE: return None if the experiment has not been initialized or mode is not 'cloud'.
+    """
+    global run
+    if run is None:
+        return None
+    return run.public.cloud.experiment_url
+
+
+def get_project_url() -> Optional["str"]:
+    """
+    Get the url of the current project.
+    NOTE: return None if the experiment has not been initialized or mode is not 'cloud'.
+    """
+    global run
+    if run is None:
+        return None
+    return run.public.cloud.project_url

--- a/swanlab/log/console.py
+++ b/swanlab/log/console.py
@@ -83,6 +83,10 @@ class SwanWriterProxy:
             except UnicodeEncodeError:
                 # 遇到编码问题，直接pass，此时表现为终端不输出
                 pass
+            except ValueError as e:
+                if "I/O operation on closed file" in str(e):
+                    # 遇到文件已关闭问题，直接pass，此时表现为终端不输出
+                    pass
             # 限制上传长度
             message = FONT.clear(message)[:MAX_UPLOAD_LEN]
             self.write_callback and self.write_callback(message)

--- a/test/unit/data/run/test_main.py
+++ b/test/unit/data/run/test_main.py
@@ -17,9 +17,11 @@ import soundfile as sf
 from PIL import Image as PILImage
 from nanoid import generate
 
+import swanlab
+import tutils as T
 from swanlab import Image, Audio, Text
 from swanlab.data.modules import Line
-from swanlab.data.run.main import SwanLabRun, get_run, SwanLabRunState, swanlog
+from swanlab.data.run.main import SwanLabRun, get_run, SwanLabRunState, swanlog, get_url, get_project_url
 from tutils import TEMP_PATH
 
 
@@ -147,7 +149,13 @@ class TestSwanLabRunLog:
         使用Line类型log，本质上应该与数字类型一样，数字类型是Line类型的语法糖
         """
         run = SwanLabRun()
-        data = {"a": Line(1), "b": Line(0.1), "c": {"d": Line(2)}, "math.nan": Line(math.nan), "math.inf": Line(math.inf)}
+        data = {
+            "a": Line(1),
+            "b": Line(0.1),
+            "c": {"d": Line(2)},
+            "math.nan": Line(math.nan),
+            "math.inf": Line(math.inf),
+        }
         ll = run.log(data)
         assert len(ll) == 5
         # line(1)和[line(1)]是一样的
@@ -288,3 +296,56 @@ class TestSwanLabRunLog:
         self.check_image(ll, "a")
 
     # 其他类似...
+
+
+class TestGetUrl:
+
+    @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+    def test_ok(self):
+        """
+        初始化一个实验
+        """
+        exp_name = generate()
+        project_name = generate()
+        swanlab.init(project=project_name, experiment_name=exp_name, mode="cloud")
+        assert get_url() is not None and get_url() != ""
+
+    def test_local(self):
+        """
+        本地模式
+        """
+        swanlab.init(mode="local")
+        assert get_url() is None
+
+    def test_before_init(self):
+        """
+        未初始化
+        """
+        assert get_url() is None
+
+
+class TestGetProjectUrl:
+
+    @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+    def test_ok(self):
+        """
+        初始化一个实验
+        """
+        exp_name = generate()
+        project_name = generate()
+        swanlab.init(project=project_name, experiment_name=exp_name, mode="cloud")
+        assert get_project_url() is not None and get_project_url() != ""
+        assert get_project_url().endswith(project_name)
+
+    def test_local(self):
+        """
+        本地模式
+        """
+        swanlab.init(mode="local")
+        assert get_project_url() is None
+
+    def test_before_init(self):
+        """
+        未初始化
+        """
+        assert get_project_url() is None

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -366,7 +366,7 @@ class TestLogin:
         os.environ[SwanLabEnv.API_KEY.value] = T.API_KEY
         S.login(host=T.API_HOST.rstrip("/api"))
         assert os.environ[SwanLabEnv.API_HOST.value] == T.API_HOST
-        assert os.environ.get(SwanLabEnv.WEB_HOST.value) is None
+        assert os.environ.get(SwanLabEnv.WEB_HOST.value) == T.API_HOST.rstrip("/api")
         S.login(host=T.API_HOST.rstrip("/api"), web_host=T.WEB_HOST)
         assert os.environ[SwanLabEnv.API_HOST.value] == T.API_HOST
         assert os.environ[SwanLabEnv.WEB_HOST.value] == T.WEB_HOST


### PR DESCRIPTION
这段拉取请求包括对`swanlab`包的几项更改，以增加新功能和改善代码组织。最重要的更改包括添加新函数以检索URL，重新组织导入，以及增强错误处理和测试。

### 新功能：
* 在`swanlab/data/run/main.py`中添加了`get_url()`和`get_project_url()`函数，分别用于检索当前实验和项目的URL。

### 代码重组：
* 在`swanlab/__init__.py`和`swanlab/data/__init__.py`中重新组织了导入，包括`config`，`get_url`和`get_project_url`。[[1]](diffhunk://#diff-efa5d30597fa2ff8419efa65d5225bc4a5b86483333f4e43bd08edc5a37d3640R14-R19) [[2]](diffhunk://#diff-7ccd7e0b5499fb7aabef90fde0a625461376cad79d2f7aa3052d5094f13e1e87L15-R28)
* 更新了`swanlab/data/run/__init__.py`中的导入语句，以包含新函数。

### 错误处理：
* 在`swanlab/log/console.py`中增强了错误处理，以捕获在关闭的文件上尝试进行I/O操作时的`ValueError`。

### 测试：
* 在`test/unit/data/run/test_main.py`中为`get_url()`和`get_project_url()`函数添加了单元测试。[[1]](diffhunk://#diff-e448823e4559913f29ee14a5cdee9b99576080f5dde72cf7fef270c9bdee29d8R20-R24) [[2]](diffhunk://#diff-e448823e4559913f29ee14a5cdee9b99576080f5dde72cf7fef270c9bdee29d8L150-R158) [[3]](diffhunk://#diff-e448823e4559913f29ee14a5cdee9b99576080f5dde72cf7fef270c9bdee29d8R299-R351)
* 更新了`test/unit/data/test_sdk.py`中的测试，以断言`WEB_HOST`环境变量的正确值。