### PR TITLE
fix(test): merge  lscpu

### DIFF
--- a/swanlab/data/run/metadata/hardware/cpu.py
+++ b/swanlab/data/run/metadata/hardware/cpu.py
@@ -54,7 +54,7 @@ def get_cpu_brand_linux():
     # lscpu 命令获取 CPU 品牌
     cpu_brand = None
     try:
-        result = subprocess.run(["lscpu"], env={"LANG": "en_US.UTF-8", **os.environ}, capture_output=True, text=True)
+        result = subprocess.run(["lscpu"], capture_output=True, text=True)
         for line in result.stdout.split("\n"):
             if "model name" in line.lower():
                 cpu_brand = line.split(":")[1].strip()

--- a/swanlab/data/run/metadata/hardware/cpu.py
+++ b/swanlab/data/run/metadata/hardware/cpu.py
@@ -10,6 +10,7 @@ import platform
 import subprocess
 
 import psutil
+import os
 from swankit.env import is_macos
 
 from swanlab.data.run.metadata.hardware.type import HardwareFuncResult, HardwareCollector, HardwareInfoList
@@ -50,15 +51,27 @@ def get_cpu_brand_windows():
 
 
 def get_cpu_brand_linux():
+    # lscpu 命令获取 CPU 品牌
+    cpu_brand = None
     try:
-        # 使用 cat /proc/cpuinfo 获取CPU品牌
-        with open("/proc/cpuinfo", "r") as f:
-            for line in f:
-                if "model name" in line.lower():
-                    return line.split(":")[1].strip()
-        return None
+        result = subprocess.run(["lscpu"], env={"LANG": "en_US.UTF-8", **os.environ}, capture_output=True, text=True)
+        for line in result.stdout.split("\n"):
+            if "model name" in line.lower():
+                cpu_brand = line.split(":")[1].strip()
+                break
     except Exception:  # noqa
-        return None
+        pass
+    if cpu_brand is None:
+        try:
+            # 使用 cat /proc/cpuinfo 获取CPU品牌
+            with open("/proc/cpuinfo", "r") as f:
+                for line in f:
+                    if "model name" in line.lower():
+                        cpu_brand = line.split(":")[1].strip()
+                        break
+        except Exception:  # noqa
+            pass
+    return cpu_brand
 
 
 class CpuCollector(HardwareCollector, C):

--- a/test/unit/data/run/metadata/hardware/gpu/test_nvidia.py
+++ b/test/unit/data/run/metadata/hardware/gpu/test_nvidia.py
@@ -45,10 +45,20 @@ class TestGpuCollector:
         # 获取handle
         idx = 0
         mem = self.collector.get_gpu_mem_pct(idx=idx)
-        assert mem['name'] == "GPU 0 Utilization (%)"
+        assert mem['name'] == "GPU 0 Memory Allocated (%)"
         assert mem['config'].y_range == (0, 100)
         assert mem['config'].metric_name == "GPU 0"
         assert 100 >= mem['value'] >= 0
+
+    @pytest.mark.skipif(count == 0, reason="No NVIDIA GPU found")
+    def test_get_utils(self):
+        # 获取handle
+        idx = 0
+        utils = self.collector.get_gpu_util(idx=idx)
+        assert utils['name'] == "GPU 0 Utilization (%)"
+        assert utils['config'].y_range == (0, 100)
+        assert utils['config'].metric_name == "GPU 0"
+        assert 100 >= utils['value'] >= 0
 
     @pytest.mark.skipif(count == 0, reason="No NVIDIA GPU found")
     def test_get_temp(self):

--- a/test/unit/data/run/metadata/hardware/test_cpu.py
+++ b/test/unit/data/run/metadata/hardware/test_cpu.py
@@ -1,0 +1,43 @@
+"""
+@author: nexisato
+@file: test_cpu.py
+@time: 2025-02-28 21:22:50
+@description: 测试CPU信息采集
+"""
+
+import pytest
+import platform
+from swanlab.data.run.metadata.hardware.cpu import (
+    get_cpu_brand_windows,
+    get_cpu_brand_linux,
+    get_cpu_info,
+    CpuCollector,
+)
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Linux only")
+def test_get_cpu_brand_linux():
+    """
+    获取不同linux系统 + 不同语言环境下的cpu品牌
+    - Debian/Ubuntu/EulerOS
+    """
+    assert get_cpu_brand_linux() is not None
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+def test_get_cpu_brand_windows():
+    """
+    获取不同windows系统 + 不同语言环境下的cpu品牌
+    - Windows 10/11
+    """
+    assert get_cpu_brand_windows() is not None
+
+
+@pytest.mark.skipif(platform.system() != "Linux" or platform.system() != "Windows", reason="Linux or Windows only")
+def test_get_cpu_info():
+    """
+    获取cpu信息
+    """
+    info, _ = get_cpu_info()
+    assert info is not None and info["cores"] > 0
+    assert info["brand"] is not None


### PR DESCRIPTION
## Description （bad case）
- 在 EulerOS 上 `cat /proc/cpuinfo` 没有 model name... 需要跟 `lscpu` merge 一下
- ~~考虑到 locale 问题，subprocess 子进程中临时使用 `en_US.UTF-8`，防止中文 bash 影响~~ （没用，写在 `/usr/bin` 里救不了）
- fix：test_nvidia.py 成员函数引错导致单测没通过

