### PR TITLE
feat: conda env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-swankit==0.1.3
+swankit==0.1.5
 swanboard==0.1.7b1
 cos-python-sdk-v5
 urllib3>=1.26.0

--- a/swanlab/api/upload/__init__.py
+++ b/swanlab/api/upload/__init__.py
@@ -7,11 +7,12 @@ r"""
 @Description:
     上传相关接口
 """
-from ..http import get_http, sync_error_handler
-from .model import ColumnModel, MediaModel, ScalarModel, FileModel
 from typing import List
+
 from swanlab.error import ApiError
 from swanlab.log import swanlog
+from .model import ColumnModel, MediaModel, ScalarModel, FileModel
+from ..http import get_http, sync_error_handler
 
 house_url = '/house/metrics'
 
@@ -21,12 +22,7 @@ def create_data(metrics: List[dict], metrics_type: str) -> dict:
     携带上传日志的指标信息
     """
     http = get_http()
-    return {
-        "projectId": http.proj_id,
-        "experimentId": http.exp_id,
-        "type": metrics_type,
-        "metrics": metrics
-    }
+    return {"projectId": http.proj_id, "experimentId": http.exp_id, "type": metrics_type, "metrics": metrics}
 
 
 @sync_error_handler
@@ -71,7 +67,7 @@ def upload_scalar_metrics(scalar_metrics: List[ScalarModel]):
 _valid_files = {
     'config.yaml': ['config', 'yaml'],
     'requirements.txt': ['requirements', 'txt'],
-    'swanlab-metadata.json': ['metadata', 'json']
+    'swanlab-metadata.json': ['metadata', 'json'],
 }
 """
 支持上传的文件列表，filename: key
@@ -89,6 +85,9 @@ def upload_files(files: List[FileModel]):
     if len(files) == 0:
         return swanlog.warning("No files to upload.")
     file_model = FileModel.create(files)
+    # 如果没有文件需要上传，直接返回
+    if file_model.empty:
+        return
     data = file_model.to_dict()
     http.put(f'/project/{http.groupname}/{http.projname}/runs/{http.exp_id}/profile', data)
 
@@ -117,5 +116,5 @@ __all__ = [
     "upload_column",
     "ScalarModel",
     "MediaModel",
-    "ColumnModel"
+    "ColumnModel",
 ]

--- a/swanlab/api/upload/model.py
+++ b/swanlab/api/upload/model.py
@@ -223,3 +223,10 @@ class FileModel:
             "conda": self.conda,
         }
         return {k: v for k, v in d.items() if v is not None}
+
+    @property
+    def empty(self):
+        """
+        是否为空
+        """
+        return all(getattr(self, attr) is None for attr in ('requirements', 'metadata', 'config', 'conda'))

--- a/swanlab/api/upload/model.py
+++ b/swanlab/api/upload/model.py
@@ -186,15 +186,14 @@ class FileModel:
         requirements: str = None,
         metadata: dict = None,
         config: dict = None,
-        create_time: datetime = None,
+        conda: str = None,
     ):
         self.requirements = requirements
         self.metadata = metadata
         self.config = config
+        self.conda = conda
+        # 主要用于去重，保留最新的文件
         self.create_time = datetime.now()
-        """
-        主要用于去重，保留最新的文件
-        """
 
     @classmethod
     def create(cls, file_models: List["FileModel"]) -> "FileModel":
@@ -203,18 +202,24 @@ class FileModel:
         """
         # 按照时间排序，倒叙排列，这意味着最新的排在第一个
         file_models = sorted(file_models, key=lambda x: x.create_time, reverse=True)
-        lr, lm, lc = None, None, None
+        lr, lm, lc, lo = None, None, None, None
         for file_model in file_models:
             lr = file_model.requirements if lr is None else lr
             lm = file_model.metadata if lm is None else lm
             lc = file_model.config if lc is None else lc
-            if lr is not None and lm is not None and lc is not None:
+            lo = file_model.conda if lo is None else lo
+            if lr is not None and lm is not None and lc is not None and lo is not None:
                 break
-        return FileModel(lr, lm, lc)
+        return FileModel(lr, lm, lc, lo)
 
     def to_dict(self):
         """
         序列化，会删除为None的字段
         """
-        d = {"requirements": self.requirements, "metadata": self.metadata, "config": self.config}
+        d = {
+            "requirements": self.requirements,
+            "metadata": self.metadata,
+            "config": self.config,
+            "conda": self.conda,
+        }
         return {k: v for k, v in d.items() if v is not None}

--- a/swanlab/data/callback_cloud.py
+++ b/swanlab/data/callback_cloud.py
@@ -243,10 +243,11 @@ class CloudRunCallback(LocalRunCallback):
         super(CloudRunCallback, self).on_runtime_info_update(r)
         # 添加上传任务到线程池
         rc = r.config.to_dict() if r.config is not None else None
-        rr = r.requirements.info if r.requirements is not None else None
         rm = r.metadata.to_dict() if r.metadata is not None else None
+        rr = r.requirements.dumps() if r.requirements is not None else None
+        ro = r.conda.dumps() if r.conda is not None else None
         # 不需要json序列化，上传时会自动序列化
-        f = FileModel(requirements=rr, config=rc, metadata=rm)
+        f = FileModel(requirements=rr, config=rc, metadata=rm, conda=ro)
         self.pool.queue.put((UploadType.FILE, [f]))
 
     def on_column_create(self, column_info: ColumnInfo):

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -22,6 +22,7 @@ from .config import SwanLabConfig
 from .exp import SwanLabExp
 from .helper import SwanLabRunOperator, RuntimeInfo, SwanLabRunState, MonitorCron, check_log_level
 from .metadata import get_requirements, get_metadata
+from .metadata.conda import get_conda
 from .public import SwanLabPublicConfig
 from ..formatter import check_key_format, check_exp_name_format, check_desc_format
 
@@ -125,6 +126,7 @@ class SwanLabRun:
             RuntimeInfo(
                 requirements=get_requirements(),
                 metadata=metadata,
+                conda=get_conda(),
             )
         )
         # 定时采集系统信息，目前仅cloud模式支持

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -22,7 +22,6 @@ from .config import SwanLabConfig
 from .exp import SwanLabExp
 from .helper import SwanLabRunOperator, RuntimeInfo, SwanLabRunState, MonitorCron, check_log_level
 from .metadata import get_requirements, get_metadata
-from .metadata.conda import get_conda
 from .public import SwanLabPublicConfig
 from ..formatter import check_key_format, check_exp_name_format, check_desc_format
 
@@ -126,9 +125,13 @@ class SwanLabRun:
             RuntimeInfo(
                 requirements=get_requirements(),
                 metadata=metadata,
-                conda=get_conda(),
             )
         )
+        # # 延时采集conda信息，因为conda信息的导出需要的时间会比较多
+        # threading.Timer(
+        #     5,
+        #     lambda: self.__operator.on_runtime_info_update(RuntimeInfo(conda=get_conda())),
+        # ).start()
         # 定时采集系统信息，目前仅cloud模式支持
         self.monitor_cron = None
         if self.mode == "cloud":

--- a/swanlab/data/run/metadata/__init__.py
+++ b/swanlab/data/run/metadata/__init__.py
@@ -7,11 +7,12 @@
 
 from typing import Tuple, List
 
-from swanlab.data.run.metadata.cooperation import get_cooperation_info
-from swanlab.data.run.metadata.hardware import *
-from swanlab.data.run.metadata.requirements import get_requirements
-from swanlab.data.run.metadata.runtime import get_runtime_info
 from swanlab.package import get_package_version
+from .conda import get_conda
+from .cooperation import get_cooperation_info
+from .hardware import *
+from .requirements import get_requirements
+from .runtime import get_runtime_info
 
 
 def get_metadata(logdir: str) -> Tuple[dict, List[HardwareCollector]]:
@@ -37,4 +38,4 @@ def get_metadata(logdir: str) -> Tuple[dict, List[HardwareCollector]]:
     return metadata, monitor_funcs
 
 
-__all__ = ["get_metadata", "get_requirements", "get_cooperation_info", "HardwareInfo", "HardwareMonitorFunc"]
+__all__ = ["get_metadata", "get_requirements", "get_cooperation_info", "HardwareInfo", "HardwareCollector"]

--- a/swanlab/data/run/metadata/__init__.py
+++ b/swanlab/data/run/metadata/__init__.py
@@ -38,4 +38,4 @@ def get_metadata(logdir: str) -> Tuple[dict, List[HardwareCollector]]:
     return metadata, monitor_funcs
 
 
-__all__ = ["get_metadata", "get_requirements", "get_cooperation_info", "HardwareInfo", "HardwareCollector"]
+__all__ = ["get_metadata", "get_requirements", "get_conda", "get_cooperation_info", "HardwareInfo", "HardwareCollector"]

--- a/swanlab/data/run/metadata/conda.py
+++ b/swanlab/data/run/metadata/conda.py
@@ -16,7 +16,7 @@ def get_conda() -> Optional[str]:
     获取conda信息，如果不存在则返回None
     Returns: str
     """
-    result = subprocess.run(["conda env export"], shell=True, capture_output=True, text=True)
+    result = subprocess.run(["conda env export"], shell=True, capture_output=True, text=True, timeout=15)
     if result.returncode != 0:
         return None
     output = result.stdout

--- a/swanlab/data/run/metadata/conda.py
+++ b/swanlab/data/run/metadata/conda.py
@@ -1,0 +1,25 @@
+"""
+@author:    cunyue
+@file:      conda.py
+@time:      2025/3/2 00:07
+@description: 收集conda信息
+"""
+
+import subprocess
+from typing import Optional
+
+import yaml
+
+
+def get_conda() -> Optional[str]:
+    """
+    获取conda信息，如果不存在则返回None
+    Returns: str
+    """
+    result = subprocess.run(["conda env export"], shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None
+    output = result.stdout
+    if yaml.safe_load(output):
+        return output
+    return None

--- a/test/unit/api/upload/test_model.py
+++ b/test/unit/api/upload/test_model.py
@@ -43,3 +43,8 @@ class TestFileModel:
         assert file_model.metadata == lm
         assert file_model.config == lc
         assert file_model.conda == lo
+
+    def test_empty(self):
+        assert FileModel().empty is True
+        assert FileModel("1", None, None, None).empty is False
+        assert FileModel(None, {}, None, None).empty is False

--- a/test/unit/api/upload/test_model.py
+++ b/test/unit/api/upload/test_model.py
@@ -8,10 +8,12 @@ r"""
     测试上传的模型类型
 """
 
-from swanlab.api.upload.model import FileModel
-from nanoid import generate
 import random
 import time
+
+from nanoid import generate
+
+from swanlab.api.upload.model import FileModel
 
 
 class TestFileModel:
@@ -25,11 +27,13 @@ class TestFileModel:
         lr = None  # 最后一个requirements, str
         lm = None  # 最后一个metadata, dict
         lc = None  # 最后一个config, dict
+        lo = None  # 最后一个conda str
         for i in range(10):
             lr = generate() if random.random() > 0.5 else lr
             lm = {generate(): generate()} if random.random() > 0.5 else lm
             lc = {generate(): generate()} if random.random() > 0.5 else lc
-            file_models.append(FileModel(lr, lm, lc))
+            lo = generate() if random.random() > 0.5 else lo
+            file_models.append(FileModel(lr, lm, lc, lo))
             time.sleep(0.01)
         # 验证
         # file_models打乱顺序
@@ -38,3 +42,4 @@ class TestFileModel:
         assert file_model.requirements == lr
         assert file_model.metadata == lm
         assert file_model.config == lc
+        assert file_model.conda == lo

--- a/test/unit/data/run/metadata/hardware/test_conda.py
+++ b/test/unit/data/run/metadata/hardware/test_conda.py
@@ -1,0 +1,25 @@
+"""
+@author: cunyue
+@file: test_conda.py
+@time: 2025/3/2 13:08
+@description: 测试conda
+"""
+
+import subprocess
+
+import pytest
+import yaml
+
+from swanlab.data.run.metadata.conda import get_conda
+
+has_conda = subprocess.run(["conda", "--version"], shell=True, capture_output=True).returncode == 0
+
+
+@pytest.mark.skipif(not has_conda, reason="conda is not installed")
+def test_conda():
+    conda_info = get_conda()
+    assert isinstance(conda_info, str)
+    # 可被yaml解析
+    load_conda = yaml.safe_load(conda_info)
+    assert load_conda is not None
+    assert isinstance(load_conda, dict)


### PR DESCRIPTION
此次拉取请求（Pull Request）为 `swanlab` 项目引入了多项更改，主要集中在添加对捕获和处理 Conda 环境信息的支持。这些更改涉及多个文件，包括模型更新、元数据处理以及单元测试。

主要更改包括：

### 模型和元数据更新：
* 在 `swanlab/api/upload/model.py` 中的 `FileModel` 类中添加了一个新的 `conda` 属性，并更新了 `create` 方法以处理这个新属性。[[1]](diffhunk://#diff-2c4391382afbb16619bb2524a64d44751f6eea5c9ddc344038b95759a331f8f9L189-L197) [[2]](diffhunk://#diff-2c4391382afbb16619bb2524a64d44751f6eea5c9ddc344038b95759a331f8f9L206-R224)
* 更新了 `swanlab/data/callback_cloud.py` 中的 `on_runtime_info_update` 方法，使其在创建 `FileModel` 实例时包含 Conda 信息。
* 修改了 `swanlab/data/run/main.py`，以导入并使用新的 `get_conda` 函数来获取 Conda 信息。[[1]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR25) [[2]](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaR129)
* 更新了 `swanlab/data/run/metadata/__init__.py`，以包含新的 `get_conda` 函数，并相应地调整了 `__all__` 列表。[[1]](diffhunk://#diff-077d0a9676eb3e7cdce2dc49813a219fb84580367415c5e8726e0a8df8b34377L10-R15) [[2]](diffhunk://#diff-077d0a9676eb3e7cdce2dc49813a219fb84580367415c5e8726e0a8df8b34377L40-R41)

### 新增功能：
* 新增了 `swanlab/data/run/metadata/conda.py` 文件，其中定义了 `get_conda` 函数，该函数通过子进程和 YAML 解析来收集 Conda 环境信息。

### 单元测试：
* 更新了 `test/unit/api/upload/test_model.py` 中的单元测试，以测试 `FileModel` 类中的新 `conda` 属性。[[1]](diffhunk://#diff-b6a9e15578c35cf107dfd8da5adc4d427e50002513f5b14fd067f71f82d59bc3L11-R17) [[2]](diffhunk://#diff-b6a9e15578c35cf107dfd8da5adc4d427e50002513f5b14fd067f71f82d59bc3R30-R36) [[3]](diffhunk://#diff-b6a9e15578c35cf107dfd8da5adc4d427e50002513f5b14fd067f71f82d59bc3R45)
* 新增了 `test/unit/data/run/metadata/hardware/test_conda.py` 测试文件，用于测试 `get_conda` 函数，确保其正确获取并解析 Conda 环境信息。

----

close #827 