### PR TITLE
feat: convert mlflow

### DIFF
--- a/swanlab/cli/commands/converter/__init__.py
+++ b/swanlab/cli/commands/converter/__init__.py
@@ -66,6 +66,17 @@ import click
     type=str,
     help="The run_id of the wandb run.",
 )
+@click.option(
+    "--mlflow-tracking-uri",
+    type=str,
+    help="The tracking uri of the mlflow runs.",
+)
+@click.option(
+    "--mlflow-experiment",
+    type=str,
+    help="The experiment name or id of the mlflow runs.",
+)
+    
 def convert(
         type: str,
         project: str,
@@ -76,6 +87,8 @@ def convert(
         wb_project: str,
         wb_entity: str,
         wb_runid: str,
+        mlflow_tracking_uri: str,
+        mlflow_experiment: str,
         **kwargs,
 ):
     """Convert the log files of other experiment tracking tools to SwanLab."""
@@ -106,6 +119,21 @@ def convert(
             wb_project=wb_project,
             wb_entity=wb_entity,
             wb_run_id=wb_runid,
+        )
+
+    elif type == "mlflow":
+        from swanlab.converter.mlf import MLFLowConverter
+
+        mlf_converter = MLFLowConverter(
+            project=project,
+            workspace=workspace,
+            cloud=cloud,
+            logdir=logdir,
+        )
+        
+        mlf_converter.run(
+            tracking_uri=mlflow_tracking_uri,
+            experiment=mlflow_experiment,
         )
 
     else:

--- a/swanlab/cli/commands/converter/__init__.py
+++ b/swanlab/cli/commands/converter/__init__.py
@@ -67,12 +67,12 @@ import click
     help="The run_id of the wandb run.",
 )
 @click.option(
-    "--mlflow-tracking-uri",
+    "--mlflow-uri",
     type=str,
     help="The tracking uri of the mlflow runs.",
 )
 @click.option(
-    "--mlflow-experiment",
+    "--mlflow-exp",
     type=str,
     help="The experiment name or id of the mlflow runs.",
 )
@@ -87,8 +87,8 @@ def convert(
         wb_project: str,
         wb_entity: str,
         wb_runid: str,
-        mlflow_tracking_uri: str,
-        mlflow_experiment: str,
+        mlflow_uri: str,
+        mlflow_exp: str,
         **kwargs,
 ):
     """Convert the log files of other experiment tracking tools to SwanLab."""
@@ -132,8 +132,8 @@ def convert(
         )
         
         mlf_converter.run(
-            tracking_uri=mlflow_tracking_uri,
-            experiment=mlflow_experiment,
+            tracking_uri=mlflow_uri,
+            experiment=mlflow_exp,
         )
 
     else:

--- a/swanlab/cli/commands/converter/__init__.py
+++ b/swanlab/cli/commands/converter/__init__.py
@@ -17,7 +17,7 @@ import click
     "--type",
     "-t",
     default="tensorboard",
-    type=click.Choice(["tensorboard", "wandb"]),
+    type=click.Choice(["tensorboard", "wandb", "mlflow"]),
     help="The type of the experiment tracking tool you want to convert to.",
 )
 @click.option(

--- a/swanlab/converter/__init__.py
+++ b/swanlab/converter/__init__.py
@@ -19,8 +19,13 @@ def __getattr__(name):
         from .wb import WandbConverter
 
         return WandbConverter
+    
+    if name == "MLFlowConverter":
+        from .mlf import MLFLowConverter
+        
+        return MLFLowConverter
 
     raise AttributeError(f"module 'convert' has no attribute '{name}'")
 
 
-__all__ = ["TFBConverter", "WandbConverter"]
+__all__ = ["TFBConverter", "WandbConverter", "MLFlowConverter"]

--- a/swanlab/converter/mlf/__init__.py
+++ b/swanlab/converter/mlf/__init__.py
@@ -1,0 +1,1 @@
+from .mlf_converter import MLFLowConverter

--- a/swanlab/converter/mlf/mlf_converter.py
+++ b/swanlab/converter/mlf/mlf_converter.py
@@ -33,10 +33,10 @@ class MLFLowConverter:
                 "MLFlow Converter requires mlflow. Install with 'pip install mlflow'."
             )
 
-        client = mlflow.tracking.client.MlflowClient(tracking_uri=tracking_uri)
+        client = mlflow.MlflowClient(tracking_uri=tracking_uri)
 
         if experiment is None:
-            experiments = client.list_experiments()
+            experiments = client.search_experiments()
         else:
             try:
                 ex = client.get_experiment(experiment)
@@ -46,6 +46,12 @@ class MLFLowConverter:
                 print(f'Error: could not find experiment with id or name "{experiment}"')
                 return
             experiments = (ex,)
+
+        # Reverse the order of experiments
+        if isinstance(experiments, tuple):
+            experiments = experiments[::-1]
+        else:
+            experiments = list(experiments)[::-1]
 
         for ex in experiments:
             runs = client.search_runs(ex.experiment_id)

--- a/swanlab/converter/mlf/mlf_converter.py
+++ b/swanlab/converter/mlf/mlf_converter.py
@@ -1,0 +1,88 @@
+"""
+------example.py------
+from swanlab.converter import MLFlowConverter
+
+mlf_converter = MLFlowConverter()
+mlf_converter.run(tracking_uri="MLFLOW_TRACKING_URL", experiment=0)
+"""
+import swanlab
+from swanlab.log import swanlog as swl
+
+class MLFLowConverter:
+    def __init__(
+        self,
+        project: str = None,
+        workspace: str = None,
+        cloud: bool = True,
+        logdir: str = None,
+        
+        **kwargs,
+    ):
+        
+        self.project = project
+        self.workspace = workspace
+        self.cloud = cloud
+        self.logdir = logdir
+    
+    def parse_mlflow_logs(self, tracking_uri:str, experiment:int = None):
+    
+        try:
+            import mlflow
+        except ImportError as e:
+            raise TypeError(
+                "MLFlow Converter requires mlflow. Install with 'pip install mlflow'."
+            )
+
+        client = mlflow.tracking.client.MlflowClient(tracking_uri=tracking_uri)
+
+        if experiment is None:
+            experiments = client.list_experiments()
+        else:
+            try:
+                ex = client.get_experiment(experiment)
+            except mlflow.exceptions.MlflowException:
+                ex = client.get_experiment_by_name(experiment)
+            if not ex:
+                print(f'Error: could not find experiment with id or name "{experiment}"')
+                return
+            experiments = (ex,)
+
+        for ex in experiments:
+            runs = client.search_runs(ex.experiment_id)
+            for run in runs:
+                run_id = run.info.run_id
+                mlflow_run_name = run.data.tags.get('mlflow.runName')
+                
+                if swanlab.get_run() is None:
+                    swanlab_run = swanlab.init(
+                        project=self.project,
+                        workspace=self.workspace,
+                        experiment_name=mlflow_run_name,
+                        mode="cloud" if self.cloud else "local",
+                        logdir=self.logdir,
+                        description=run.data.tags.get('mlflow.note.content'),
+                    )
+                else:
+                    swanlab_run = swanlab.get_run()
+                
+                swanlab_run.config.update(dict(
+                    mlflow_run_id=run.info.run_id,
+                    mlflow_run_name=mlflow_run_name,
+                    mlflow_run_description=run.data.tags.get('mlflow.note.content'),
+                    mlflow_run_params=run.data.params,
+                    mlflow_run_tags={k: v for k, v in run.data.tags.items() if not k.startswith('mlflow')},
+                ))
+                
+                for key in run.data.metrics.keys():
+                    for m in client.get_metric_history(run_id, key):
+                        swanlab_run.log({m.key: m.value}, step=m.step)
+                
+                swanlab_run.finish()
+                
+    def run(self, tracking_uri: str, experiment: int = None):
+        swl.info("Start converting MLFlow Runs to SwanLab...")
+        self.parse_mlflow_logs(
+            tracking_uri=tracking_uri,
+            experiment=experiment,
+        )
+        swl.info("Finished converting MLFlow Runs to SwanLab.")

--- a/swanlab/converter/tfb/tfb_converter.py
+++ b/swanlab/converter/tfb/tfb_converter.py
@@ -51,7 +51,7 @@ class TFBConverter:
                         experiment_name=f"{dir}/{filename}",
                         workspace=self.workspace,
                         config={"tfevent_path": path},
-                        cloud=self.cloud,
+                        mode="cloud" if self.cloud else "local",
                         logdir=self.logdir,
                     )
 

--- a/swanlab/converter/wb/wb_converter.py
+++ b/swanlab/converter/wb/wb_converter.py
@@ -29,7 +29,7 @@ class WandbConverter:
             import wandb
         except ImportError as e:
             raise TypeError(
-                "Wandb Converter requires wandb when process tfevents file. Install with 'pip install wandb'."
+                "Wandb Converter requires wandb. Install with 'pip install wandb'."
             )
 
         client = wandb.Api()
@@ -51,7 +51,7 @@ class WandbConverter:
                     workspace=self.workspace,
                     experiment_name=wb_run.name,
                     description=wb_run.notes,
-                    cloud=self.cloud,
+                    mode="cloud" if self.cloud else "local",
                     logdir=self.logdir,
                 )
             else:


### PR DESCRIPTION
## Description

Integrated the conversion functionality for [MLflow](https://github.com/mlflow/mlflow), using the same CLI + Python code approach as TensorBoard and W&B.

Use:

```bash
swanlab convert -t mlflow --mlflow-uri http://127.0.0.1:8081
```

---

This pull request adds support for converting MLFlow experiment tracking logs to SwanLab, alongside existing support for TensorBoard and WandB. The key changes include updates to the CLI options, the converter logic, and the addition of a new `MLFlowConverter` class.

### CLI Updates:
* [`swanlab/cli/commands/converter/__init__.py`](diffhunk://#diff-1cc6aec796e3093f591d1c0f26a1a163e14da5f4c492d85e19f491d4e509cfb9L20-R20): Added new CLI options `--mlflow-uri` and `--mlflow-exp` to support MLFlow conversion. Updated the `--type` option to include "mlflow". [[1]](diffhunk://#diff-1cc6aec796e3093f591d1c0f26a1a163e14da5f4c492d85e19f491d4e509cfb9L20-R20) [[2]](diffhunk://#diff-1cc6aec796e3093f591d1c0f26a1a163e14da5f4c492d85e19f491d4e509cfb9R69-R79)

### Converter Logic:
* [`swanlab/cli/commands/converter/__init__.py`](diffhunk://#diff-1cc6aec796e3093f591d1c0f26a1a163e14da5f4c492d85e19f491d4e509cfb9R90-R91): Updated the `convert` function to handle MLFlow conversion by calling the new `MLFlowConverter` class. [[1]](diffhunk://#diff-1cc6aec796e3093f591d1c0f26a1a163e14da5f4c492d85e19f491d4e509cfb9R90-R91) [[2]](diffhunk://#diff-1cc6aec796e3093f591d1c0f26a1a163e14da5f4c492d85e19f491d4e509cfb9R124-R138)
* [`swanlab/converter/__init__.py`](diffhunk://#diff-1519f6cc22643fd753d3829f9f86fa144a54b19c1a041104984eaaf5efbc9ab3R23-R31): Updated the `__getattr__` function and `__all__` list to include `MLFlowConverter`.

### New MLFlow Converter:
* [`swanlab/converter/mlf/__init__.py`](diffhunk://#diff-b432a5dd5172627d1f445b132a6c5ea651fa69831c8472cec3f9398ce1e94f3aR1): Added import for `MLFLowConverter`.
* [`swanlab/converter/mlf/mlf_converter.py`](diffhunk://#diff-4ab0bfc716536ee004ccb44d9463c88d34dc1c1169a545ec278e6d658820e5d1R1-R94): Introduced `MLFLowConverter` class to handle the conversion of MLFlow logs to SwanLab format.

### Minor Updates:
* [`swanlab/converter/tfb/tfb_converter.py`](diffhunk://#diff-0396353a61d7f7ccf36b6e14b38f5ee67092b4c44197c6fa217dcd2c1c970ad0L54-R54): Updated to use `mode="cloud"` or `mode="local"` instead of `cloud` parameter directly.
* [`swanlab/converter/wb/wb_converter.py`](diffhunk://#diff-ac550d69729058f018b3dd93f8f5e69f9de497bf4db4452b29fa1f07a45b6848L54-R54): Updated to use `mode="cloud"` or `mode="local"` instead of `cloud` parameter directly.
* [`swanlab/converter/wb/wb_converter.py`](diffhunk://#diff-ac550d69729058f018b3dd93f8f5e69f9de497bf4db4452b29fa1f07a45b6848L32-R32): Simplified the error message for missing `wandb` dependency.