### PR TITLE
fix: wandb conver

### DIFF
--- a/swanlab/converter/wb/wb_converter.py
+++ b/swanlab/converter/wb/wb_converter.py
@@ -63,6 +63,11 @@ class WandbConverter:
                 )
             else:
                 swanlab_run = swanlab.get_run()
+                
+            try:
+                wb_run_metadata = {"wandb_metadata": wb_run_metadata}
+            except:
+                wb_run_metadata = None
 
             wb_config = {
                 "wandb_run_id": wb_run.id,
@@ -71,8 +76,8 @@ class WandbConverter:
                 "wandb_user": wb_run.user,
                 "wandb_tags": wb_run.tags,
                 "wandb_url": wb_run.url,
-                "wandb_metadata": wb_run.metadata,
             }
+            wb_config.update(wb_run_metadata)
 
             swanlab_run.config.update(wb_config)
             swanlab_run.config.update(wb_run.config)

--- a/swanlab/converter/wb/wb_converter.py
+++ b/swanlab/converter/wb/wb_converter.py
@@ -31,6 +31,13 @@ class WandbConverter:
             raise TypeError(
                 "Wandb Converter requires wandb. Install with 'pip install wandb'."
             )
+            
+        try:
+            import pandas as pd
+        except ImportError as e:
+            raise TypeError(
+                "Wandb Converter requires pandas when process wandb logs. Install with 'pip install pandas'."
+            )
 
         client = wandb.Api()
 
@@ -51,7 +58,7 @@ class WandbConverter:
                     workspace=self.workspace,
                     experiment_name=wb_run.name,
                     description=wb_run.notes,
-                    mode="cloud" if self.cloud else "local",
+                    cloud=self.cloud,
                     logdir=self.logdir,
                 )
             else:
@@ -73,7 +80,13 @@ class WandbConverter:
             # Get the first history record to extract available keys
             history = wb_run.history(stream="default")
             if len(history) > 0:
-                keys = [key for key in history[0].keys() if not key.startswith("_")]
+                # 检查 history 是否为 DataFrame 类型
+                if isinstance(history, pd.DataFrame):
+                    # 如果是 DataFrame，直接获取列名
+                    keys = [key for key in history.columns if not key.startswith("_")]
+                else:
+                    # 原来的逻辑，假设是字典列表
+                    keys = [key for key in history[0].keys() if not key.startswith("_")]
             else:
                 keys = []
 


### PR DESCRIPTION
## Description

1. Adapt to the API format of the new wandb version
2. Might solve part of issue #852 :)

---

This pull request includes changes to the `parse_wandb_logs` method in the `swanlab/converter/wb/wb_converter.py` file. The updates focus on improving error handling and enhancing the processing of Wandb logs. The most important changes are:

Error handling improvements:
* Added a check to ensure `pandas` is installed when processing Wandb logs, raising a `TypeError` if it is missing.
* Wrapped the metadata extraction in a try-except block to handle potential errors gracefully.

Enhancements to Wandb log processing:
* Modified the assignment of the `cloud` parameter to simplify the configuration.
* Updated the logic to check if the history is a `DataFrame` and extract keys accordingly, improving compatibility with different data formats.
