### PR TITLE
fix: port number git remote link

### DIFF
--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -65,10 +65,15 @@ def get_remote_url():
 
         # 检查命令是否成功运行
         if result.returncode == 0:
-            url = result.stdout.strip().replace("git@", "https://")
+            url = result.stdout.strip()
+            # Convert SSH to HTTPS
+            if url.startswith("git@"):
+                url = url.replace("git@", "https://", 1)
+                url = replace_second_colon(url, "/")
+            # Remove .git suffix
             if url.endswith(".git"):
                 url = url[:-4]
-            return replace_second_colon(url, "/")
+            return url
         else:
             return None
     except Exception as e:  # noqa
@@ -76,7 +81,7 @@ def get_remote_url():
 
 
 def replace_second_colon(input_string, replacement):
-    """替换字符串中第二个‘:’"""
+    """替换字符串中第二个'：'"""
     first_colon_index = input_string.find(":")
     if first_colon_index != -1:
         second_colon_index = input_string.find(":", first_colon_index + 1)

--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -82,7 +82,7 @@ def parse_git_url(url):
             url = f"https://{host}:{port}/{path}" if port.isdigit() else f"https://{host}/{port}/{path}"
         else:
             url = f"https://{host}/{path}"
-        return url[:-4] if url.endswith(".git") else url
+    return url[:-4] if url.endswith(".git") else url
 
 def replace_second_colon(input_string, replacement):
     """Replace the second colon in a string."""

--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -66,28 +66,29 @@ def get_remote_url():
         # 检查命令是否成功运行
         if result.returncode == 0:
             url = result.stdout.strip()
-            # Convert SSH to HTTPS
-            if url.startswith("git@"):
-                url = url.replace("git@", "https://", 1)
-                url = replace_second_colon(url, "/")
-            # Remove .git suffix
-            if url.endswith(".git"):
-                url = url[:-4]
-            return url
+            return parse_git_url(url)
         else:
             return None
     except Exception as e:  # noqa
         return None
 
+def parse_git_url(url):
+    """Return the remote URL of a git repository."""
+    if url.startswith("git@"):
+        parts = url[4:].split("/", 1)
+        host, path = parts[0], parts[1] if len(parts) > 1 else ""
+        if ":" in host:
+            host, port = host.rsplit(":", 1)
+            url = f"https://{host}:{port}/{path}" if port.isdigit() else f"https://{host}/{port}/{path}"
+        else:
+            url = f"https://{host}/{path}"
+        return url[:-4] if url.endswith(".git") else url
 
 def replace_second_colon(input_string, replacement):
-    """替换字符串中第二个'：'"""
-    first_colon_index = input_string.find(":")
-    if first_colon_index != -1:
-        second_colon_index = input_string.find(":", first_colon_index + 1)
-        if second_colon_index != -1:
-            return input_string[:second_colon_index] + replacement + input_string[second_colon_index + 1 :]
-    return input_string
+    """Replace the second colon in a string."""
+    first_colon = input_string.find(":")
+    second_colon = input_string.find(":", first_colon + 1) if first_colon != -1 else -1
+    return input_string[:second_colon] + replacement + input_string[second_colon + 1:] if second_colon != -1 else input_string
 
 
 def get_git_branch_and_commit():

--- a/test/unit/data/run/metadata/test_runtime.py
+++ b/test/unit/data/run/metadata/test_runtime.py
@@ -1,0 +1,16 @@
+from swanlab.data.run.metadata.runtime import parse_git_url
+
+
+def test_parse_git_url():
+    # ssh
+    assert parse_git_url("git@github.com:swanhubx/swanlab.git") == "https://github.com/swanhubx/swanlab"
+    assert parse_git_url("git@localhost:8000/swanhubx/swanlab.git") == "https://localhost:8000/swanhubx/swanlab"
+    # https
+    assert parse_git_url("https://github.com/swanhubx/swanlab.git") == "https://github.com/swanhubx/swanlab"
+    assert parse_git_url("https://localhost:8000/swanhubx/swanlab.git") == "https://localhost:8000/swanhubx/swanlab"
+    # no .git
+    assert parse_git_url("git@github.com:swanhubx/swanlab") == "https://github.com/swanhubx/swanlab"
+    assert parse_git_url("git@localhost:8000/swanhubx/swanlab") == "https://localhost:8000/swanhubx/swanlab"
+    assert parse_git_url("https://github.com/swanhubx/swanlab") == "https://github.com/swanhubx/swanlab"
+    assert parse_git_url("https://localhost:8000/swanhubx/swanlab") == "https://localhost:8000/swanhubx/swanlab"
+    


### PR DESCRIPTION
## Description

修复了在带端口号的http git链接下，会把端口号的冒号替换成'/'的问题

This pull request includes changes to the `get_remote_url` function in the `swanlab/data/run/metadata/runtime.py` file to improve URL handling for git repositories. The most important changes include modifying the URL conversion logic and updating the `replace_second_colon` function.

Improvements to URL handling:

* [`swanlab/data/run/metadata/runtime.py`](diffhunk://#diff-a66e7f50fd6bebdc5d3832d7405fd0b26c0550189a97c775f6ea9c6f5bed7ee7L68-R84): Modified the `get_remote_url` function to convert SSH URLs to HTTPS and remove the `.git` suffix without calling `replace_second_colon` unnecessarily.
* [`swanlab/data/run/metadata/runtime.py`](diffhunk://#diff-a66e7f50fd6bebdc5d3832d7405fd0b26c0550189a97c775f6ea9c6f5bed7ee7L68-R84): Updated the `replace_second_colon` function's docstring to use the correct character encoding for the colon symbol.
