### PR TITLE
feat: add args for callback

### DIFF
--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,1 +1,1 @@
-swanboard==0.1.7b1
+swanboard==0.1.8b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-swankit==0.1.5
+swankit==0.1.6
 urllib3>=1.26.0
 requests>=2.25.0
 setuptools

--- a/swanlab/data/callbacker/cloud.py
+++ b/swanlab/data/callbacker/cloud.py
@@ -100,7 +100,7 @@ class CloudRunCallback(SwanLabRunCallback):
     def __str__(self):
         return "SwanLabCloudRunCallback"
 
-    def on_init(self, project: str, workspace: str, logdir: str = None, **kwargs) -> int:
+    def on_init(self, project: str, workspace: str, logdir: str = None, *args, **kwargs) -> int:
         try:
             http = get_http()
         except ValueError:
@@ -110,10 +110,10 @@ class CloudRunCallback(SwanLabRunCallback):
         self._get_package_latest_version()
         return http.mount_project(project, workspace, self.public).history_exp_count
 
-    def before_run(self, settings: SwanLabSharedSettings):
+    def before_run(self, settings: SwanLabSharedSettings, *args, **kwargs):
         self.settings = settings
 
-    def on_run(self):
+    def on_run(self, *args, **kwargs):
         swanlog.install()
         http = get_http()
         # 注册实验信息
@@ -140,7 +140,7 @@ class CloudRunCallback(SwanLabRunCallback):
         if in_jupyter():
             show_button_html(experiment_url)
 
-    def on_runtime_info_update(self, r: RuntimeInfo):
+    def on_runtime_info_update(self, r: RuntimeInfo, *args, **kwargs):
         # 添加上传任务到线程池
         rc = r.config.to_dict() if r.config is not None else None
         rr = r.requirements.info if r.requirements is not None else None
@@ -149,7 +149,7 @@ class CloudRunCallback(SwanLabRunCallback):
         f = FileModel(requirements=rr, config=rc, metadata=rm)
         self.pool.queue.put((UploadType.FILE, [f]))
 
-    def on_column_create(self, column_info: ColumnInfo):
+    def on_column_create(self, column_info: ColumnInfo, *args, **kwargs):
         error = None
         if column_info.error is not None:
             error = {"data_class": column_info.error.got, "excepted": column_info.error.expected}
@@ -177,7 +177,7 @@ class CloudRunCallback(SwanLabRunCallback):
         )
         self.pool.queue.put((UploadType.COLUMN, [column]))
 
-    def on_metric_create(self, metric_info: MetricInfo):
+    def on_metric_create(self, metric_info: MetricInfo, *args, **kwargs):
         # 有错误就不上传
         if metric_info.error:
             return
@@ -203,7 +203,7 @@ class CloudRunCallback(SwanLabRunCallback):
         media = MediaModel(metric, key, key_encoded, step, epoch, metric_info.metric_buffers)
         self.pool.queue.put((UploadType.MEDIA_METRIC, [media]))
 
-    def on_stop(self, error: str = None):
+    def on_stop(self, error: str = None, *args, **kwargs):
         # 打印信息
         self._view_web_print()
         run = get_run()

--- a/swanlab/data/callbacker/local.py
+++ b/swanlab/data/callbacker/local.py
@@ -119,12 +119,12 @@ class LocalRunCallback(SwanLabRunCallback):
         # 如果正在运行
         run.finish() if run.running else swanlog.debug("Duplicate finish, ignore it.")
 
-    def on_init(self, proj_name: str, workspace: str, logdir: str = None, **kwargs):
+    def on_init(self, proj_name: str, workspace: str, logdir: str = None, *args, **kwargs):
         self._init_logdir(logdir)
 
         self.board.on_init(proj_name)
 
-    def before_run(self, settings: SwanLabSharedSettings):
+    def before_run(self, settings: SwanLabSharedSettings, *args, **kwargs):
         self.settings = settings
 
     def before_init_experiment(
@@ -134,6 +134,8 @@ class LocalRunCallback(SwanLabRunCallback):
         description: str,
         num: int,
         colors: Tuple[str, str],
+        *args,
+        **kwargs,
     ):
         self.board.before_init_experiment(run_id, exp_name, description, num, colors)
 
@@ -145,7 +147,7 @@ class LocalRunCallback(SwanLabRunCallback):
         self._train_begin_print()
         self._watch_tip_print()
 
-    def on_runtime_info_update(self, r: RuntimeInfo):
+    def on_runtime_info_update(self, r: RuntimeInfo, *args, **kwargs):
         # 更新运行时信息
         if r.requirements is not None:
             r.requirements.write(self.settings.files_dir)
@@ -157,10 +159,10 @@ class LocalRunCallback(SwanLabRunCallback):
     def on_log(self, *args, **kwargs):
         self.board.on_log(*args, **kwargs)
 
-    def on_column_create(self, column_info: ColumnInfo):
+    def on_column_create(self, column_info: ColumnInfo, *args, **kwargs):
         self.board.on_column_create(column_info)
 
-    def on_metric_create(self, metric_info: MetricInfo):
+    def on_metric_create(self, metric_info: MetricInfo, *args, **kwargs):
         # 出现任何错误直接返回
         if metric_info.error:
             return
@@ -188,7 +190,7 @@ class LocalRunCallback(SwanLabRunCallback):
             with open(os.path.join(path, metric_info.metric["data"][i]), "wb") as f:
                 f.write(r.getvalue())
 
-    def on_stop(self, error: str = None):
+    def on_stop(self, error: str = None, *args, **kwargs):
         """
         训练结束，取消系统回调
         此函数被`run.finish`调用

--- a/swanlab/data/callbacker/local.py
+++ b/swanlab/data/callbacker/local.py
@@ -154,8 +154,8 @@ class LocalRunCallback(SwanLabRunCallback):
         if r.config is not None:
             r.config.write(self.settings.files_dir)
 
-    def on_log(self):
-        self.board.on_log()
+    def on_log(self, *args, **kwargs):
+        self.board.on_log(*args, **kwargs)
 
     def on_column_create(self, column_info: ColumnInfo):
         self.board.on_column_create(column_info)

--- a/swanlab/data/run/helper.py
+++ b/swanlab/data/run/helper.py
@@ -94,8 +94,8 @@ class SwanLabRunOperator(SwanKitCallback):
     def on_runtime_info_update(self, r: RuntimeInfo):
         return self.__run_all("on_runtime_info_update", r)
 
-    def on_log(self):
-        return self.__run_all("on_log")
+    def on_log(self, *args, **kwargs):
+        return self.__run_all("on_log", *args, **kwargs)
 
     def on_metric_create(self, metric_info: MetricInfo):
         return self.__run_all("on_metric_create", metric_info)

--- a/swanlab/data/run/helper.py
+++ b/swanlab/data/run/helper.py
@@ -71,11 +71,18 @@ class SwanLabRunOperator(SwanKitCallback):
             return ret[key]
         return next((v for v in ret.values() if v is not None), None)
 
-    def on_init(self, proj_name: str, workspace: str, logdir: str = None, **kwargs) -> OperatorReturnType:
-        return self.__run_all("on_init", proj_name, workspace, logdir=logdir)
+    def on_init(self, proj_name: str, workspace: str, logdir: str = None, *args, **kwargs) -> OperatorReturnType:
+        return self.__run_all(
+            "on_init",
+            proj_name,
+            workspace,
+            logdir=logdir,
+            *args,
+            **kwargs,
+        )
 
-    def before_run(self, settings: SwanLabSharedSettings):
-        return self.__run_all("before_run", settings)
+    def before_run(self, settings: SwanLabSharedSettings, *args, **kwargs):
+        return self.__run_all("before_run", settings, *args, **kwargs)
 
     def before_init_experiment(
         self,
@@ -84,27 +91,38 @@ class SwanLabRunOperator(SwanKitCallback):
         description: str,
         num: int,
         colors: Tuple[str, str],
+        *args,
+        **kwargs,
     ):
-        return self.__run_all("before_init_experiment", run_id, exp_name, description, num, colors)
+        return self.__run_all(
+            "before_init_experiment",
+            run_id,
+            exp_name,
+            description,
+            num,
+            colors,
+            *args,
+            **kwargs,
+        )
 
-    def on_run(self):
-        self.__run_all("on_run")
+    def on_run(self, *args, **kwargs):
+        self.__run_all("on_run", *args, **kwargs)
         try_send_webhook()
 
-    def on_runtime_info_update(self, r: RuntimeInfo):
-        return self.__run_all("on_runtime_info_update", r)
+    def on_runtime_info_update(self, r: RuntimeInfo, *args, **kwargs):
+        return self.__run_all("on_runtime_info_update", r, *args, **kwargs)
 
     def on_log(self, *args, **kwargs):
         return self.__run_all("on_log", *args, **kwargs)
 
-    def on_metric_create(self, metric_info: MetricInfo):
-        return self.__run_all("on_metric_create", metric_info)
+    def on_metric_create(self, metric_info: MetricInfo, *args, **kwargs):
+        return self.__run_all("on_metric_create", metric_info, *args, **kwargs)
 
-    def on_column_create(self, column_info: ColumnInfo):
-        return self.__run_all("on_column_create", column_info)
+    def on_column_create(self, column_info: ColumnInfo, *args, **kwargs):
+        return self.__run_all("on_column_create", column_info, *args, **kwargs)
 
-    def on_stop(self, error: str = None):
-        r = self.__run_all("on_stop", error)
+    def on_stop(self, error: str = None, *args, **kwargs):
+        r = self.__run_all("on_stop", error, *args, **kwargs)
         # 清空所有注册的回调函数
         self.callbacks.clear()
         return r

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -349,7 +349,7 @@ class SwanLabRun:
         """
         if self.__state != SwanLabRunState.RUNNING:
             raise RuntimeError("After experiment finished, you can no longer log data to the current experiment")
-        self.__operator.on_log()
+        self.__operator.on_log(data=data, step=step)
 
         if not isinstance(data, dict):
             return swanlog.error(


### PR DESCRIPTION
This pull request includes updates to the `swanlab` project, focusing on enhancing the flexibility of various callback methods by adding support for additional arguments. Additionally, there is a minor update to the `swanboard` dependency version.

Enhancements to callback methods:

* [`swanlab/data/callbacker/cloud.py`](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L103-R103): Updated several methods (`on_init`, `before_run`, `on_run`, `on_runtime_info_update`, `on_column_create`, `on_metric_create`, `on_stop`) to accept additional arguments (`*args, **kwargs`). [[1]](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L103-R103) [[2]](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L113-R116) [[3]](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L143-R143) [[4]](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L152-R152) [[5]](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L180-R180) [[6]](diffhunk://#diff-733d6742a0ed52a329f3872a2f17de48637ce80a1af7f2a7a41a975d1d858972L206-R206)
* [`swanlab/data/callbacker/local.py`](diffhunk://#diff-7044b26107bc0f6a35bff2f331d0f3a685dfc7959626efb71136147af28c0798L122-R127): Updated methods (`on_init`, `before_run`, `before_init_experiment`, `on_runtime_info_update`, `on_log`, `on_column_create`, `on_metric_create`, `on_stop`) to accept additional arguments (`*args, **kwargs`). [[1]](diffhunk://#diff-7044b26107bc0f6a35bff2f331d0f3a685dfc7959626efb71136147af28c0798L122-R127) [[2]](diffhunk://#diff-7044b26107bc0f6a35bff2f331d0f3a685dfc7959626efb71136147af28c0798R137-R138) [[3]](diffhunk://#diff-7044b26107bc0f6a35bff2f331d0f3a685dfc7959626efb71136147af28c0798L148-R150) [[4]](diffhunk://#diff-7044b26107bc0f6a35bff2f331d0f3a685dfc7959626efb71136147af28c0798L157-R165) [[5]](diffhunk://#diff-7044b26107bc0f6a35bff2f331d0f3a685dfc7959626efb71136147af28c0798L191-R193)
* [`swanlab/data/run/helper.py`](diffhunk://#diff-20f9a19f79fbe048d5c9b15587ec46d5841e4ed8f17607fc7e6791b738425f9aL74-R85): Updated methods (`on_init`, `before_run`, `before_init_experiment`, `on_run`, `on_runtime_info_update`, `on_log`, `on_metric_create`, `on_column_create`, `on_stop`) to accept additional arguments (`*args, **kwargs`). [[1]](diffhunk://#diff-20f9a19f79fbe048d5c9b15587ec46d5841e4ed8f17607fc7e6791b738425f9aL74-R85) [[2]](diffhunk://#diff-20f9a19f79fbe048d5c9b15587ec46d5841e4ed8f17607fc7e6791b738425f9aR94-R125)
* [`swanlab/data/run/main.py`](diffhunk://#diff-716884b2803891f14f0e31a96ce3c380a52b38283304a509d29b4caa9d9abceaL352-R352): Modified `log` method to pass additional arguments (`data`, `step`) to the `on_log` method.

Dependency update:

* [`requirements-dashboard.txt`](diffhunk://#diff-da0f255e673a312ddc2f3c83bfda4803eae690fe2b4aff7f08f98f082225de16L1-R1): Updated `swanboard` dependency from version `0.1.7b1` to `0.1.8b0`.


---

提升callback接口适配性，for #865 