### PR TITLE
docs: dashboard install

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ pip install -e .
 
 </details>
 
+<details><summary>离线看板拓展安装</summary>
+
+[离线看板文档](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)
+
+```bash
+pip install 'swanlab[dashboard]'
+```
+
+</details>
+
+
 ### 2.登录并获取 API Key
 
 1. 免费[注册账号](https://swanlab.cn)

--- a/README_EN.md
+++ b/README_EN.md
@@ -187,6 +187,16 @@ pip install -e .
 
 </details>
 
+<details><summary>Dashboard Extension Installation</summary>
+
+[Dashboard Extension Documentation](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)
+
+```bash
+pip install 'swanlab[dashboard]'
+```
+
+</details>
+
 ### 2. Login and Get API Key
 
 1. Register for free at [SwanLab](https://swanlab.cn).

--- a/README_JP.md
+++ b/README_JP.md
@@ -189,6 +189,16 @@ pip install -e .
 
 </details>
 
+<details><summary>ダッシュボード拡張機能のインストール</summary>
+
+[ダッシュボード拡張機能ドキュメント](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)
+
+```bash
+pip install 'swanlab[dashboard]'
+```
+
+</details>
+
 ### 2.ログインしてAPIキーを取得
 
 1. 無料で[アカウント登録](https://swanlab.cn)

--- a/README_RU.md
+++ b/README_RU.md
@@ -187,6 +187,16 @@ pip install -e .
 
 </details>
 
+<details><summary>Установка расширения панели управления</summary>
+
+[Документация по расширению панели управления](https://docs.swanlab.cn/guide_cloud/self_host/offline-board.html)
+
+```bash
+pip install 'swanlab[dashboard]'
+```
+
+</details>
+
 ### 2. Вход и получение API Key
 
 1. Бесплатная [регистрация аккаунта](https://swanlab.cn)

--- a/swanlab/data/callbacker/local.py
+++ b/swanlab/data/callbacker/local.py
@@ -11,12 +11,14 @@ from swankit.callback import ColumnInfo
 try:
     # noinspection PyPackageRequirements
     import swanboard
-    from importlib.metadata import version
-    package_version = version("swanboard")
-    if package_version != "0.1.8b1":
-        raise ImportError
 except ImportError:
-    raise ImportError("Please install swanboard to use 'local' mode: `pip install swanlab[dashboard]`")
+    raise ImportError("Please install swanboard to use 'local' mode: pip install 'swanlab[dashboard]'")
+
+from importlib.metadata import version
+package_version = version("swanboard")
+if package_version != "0.1.8b1":
+    raise ImportError("Your swanboard version does not match, please use this command to install the matching version: pip install 'swanlab[dashboard]'")
+
 
 import json
 import os

--- a/swanlab/data/callbacker/local.py
+++ b/swanlab/data/callbacker/local.py
@@ -11,9 +11,12 @@ from swankit.callback import ColumnInfo
 try:
     # noinspection PyPackageRequirements
     import swanboard
+    from importlib.metadata import version
+    package_version = version("swanboard")
+    if package_version != "0.1.8b1":
+        raise ImportError
 except ImportError:
-    raise ImportError("Please install swanboard to use 'local' mode: `pip install swanboard`")
-
+    raise ImportError("Please install swanboard to use 'local' mode: `pip install swanlab[dashboard]`")
 
 import json
 import os


### PR DESCRIPTION
This pull request includes updates to the `README` files in multiple languages to add instructions for installing the dashboard extension.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R197-R207): Added a section with instructions for installing the dashboard extension and a link to the relevant documentation.
* [`README_EN.md`](diffhunk://#diff-cd16b6fe8b71c753765db6d9a05343a02db0fd5f4e0fa195969d2b6f923505abR190-R199): Added a section with instructions for installing the dashboard extension and a link to the relevant documentation.
* [`README_JP.md`](diffhunk://#diff-3629b3e65246c37e96658c8e152222668d9313279ba005aee3f37b2c2afeef25R192-R201): Added a section with instructions for installing the dashboard extension and a link to the relevant documentation.
* [`README_RU.md`](diffhunk://#diff-60c6c6575afc9f0439fc54f56d4d2814b6242d34d8170554cab8c75354f06989R190-R199): Added a section with instructions for installing the dashboard extension and a link to the relevant documentation.