### PR TITLE
添加全局功能开关管理模块

### DIFF
--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -34,6 +34,7 @@ from .utils import (
     should_call_before_init,
 )
 from ..package import HostFormatter
+from swanlab import swanlab_settings
 
 
 @should_call_before_init("After calling swanlab.login(), you can't call it again.")
@@ -88,6 +89,7 @@ class SwanLabInitializer:
         load: str = None,
         public: bool = None,
         callbacks: List[SwanKitCallback] = None,
+        settings: swanlab_settings.Settings = None,
         **kwargs,
     ) -> SwanLabRun:
         """
@@ -147,7 +149,12 @@ class SwanLabInitializer:
         callbacks : Union[SwanKitCallback, List[SwanKitCallback]], optional
             The callback function that will be triggered when the experiment is finished.
             If you provide a list, all the callback functions in the list will be triggered in order.
+        settings: swanlab.swanlab_settings.Settings, optional
+            The settings for the current experiment.
         """
+        # 注册settings
+        swanlab_settings.setup(settings)
+
         if SwanLabRun.is_started():
             swanlog.warning("You have already initialized a run, the init function will be ignored")
             return get_run()

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025-3-18 21:20:13
+@File: swanlab\swanlab_settings.py
+@IDE: pycharm
+@Description:
+    swanlab全局功能开关
+"""
+
+class SettingsState:
+    """单例模式，管理设置状态"""
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(SettingsState, cls).__new__(cls)
+            cls._instance._locked = False
+            cls._instance._settings = {}
+        return cls._instance
+
+    def lock(self):
+        """锁定设置，防止后续修改"""
+        self._locked = True
+
+    @property
+    def is_locked(self):
+        """返回设置是否已锁定"""
+        return self._locked
+
+    def get_settings(self):
+        """获取当前设置"""
+        return self._settings.copy()  # 返回副本防止直接修改
+
+    def update_settings(self, settings):
+        """更新设置，如果已锁定则抛出异常"""
+        if self._locked:
+            raise RuntimeError("Cannot modify settings after swanlab.init() has been called")
+        self._settings.update(settings.__dict__)
+
+
+class Settings:
+    """用户设置类"""
+
+    def __init__(self, hardware_monitor=True, **kwargs):
+        self.hardware_monitor = hardware_monitor
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def merge_settings(settings):
+    """合并用户设置到全局设置"""
+    if not isinstance(settings, Settings):
+        raise TypeError("Expected Settings object")
+
+    state = SettingsState()
+    if state.is_locked:
+        raise RuntimeError("Cannot modify settings after swanlab.init() has been called")
+
+    state.update_settings(settings)
+    return state.get_settings()
+
+
+def init(settings=None):
+    """初始化SwanLab，并锁定设置"""
+    state = SettingsState()
+
+    # 如果传入了新设置，先应用它们
+    if settings is not None:
+        if not isinstance(settings, Settings):
+            raise TypeError("Expected Settings object")
+        state.update_settings(settings)
+
+    # 锁定设置，防止后续修改
+    state.lock()
+
+    # 使用锁定后的设置进行实际初始化
+    current_settings = state.get_settings()
+    print(f"SwanLab initialized with settings: {current_settings}")
+
+    # 这里执行真正的初始化逻辑
+    # ...
+
+    return current_settings

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -2,7 +2,7 @@
 r"""
 @DATE: 2025-3-18 21:20
 @File: swanlab\swanlab_settings.py
-@IDE: vscode
+@IDE: cursor
 @Description:
     SwanLab全局功能开关，用于管理和控制SwanLab的全局设置
 """
@@ -114,5 +114,9 @@ def setup(settings: Settings = None) -> Dict[str, Any]:
     return current_settings
 
 
-# 创建默认设置实例
-settings = Settings()
+def get_current_settings() -> Dict[str, Any]:
+    """
+    获取当前全局设置
+    :return: 当前设置的副本
+    """
+    return SettingsState().get_settings()

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -1,55 +1,89 @@
 #!/usr/bin/env python# -*- coding: utf-8 -*-
 r"""
-@DATE: 2025-3-18 21:20:13
+@DATE: 2025-3-18 21:20
 @File: swanlab\swanlab_settings.py
-@IDE: pycharm
+@IDE: vscode
 @Description:
-    swanlab全局功能开关
+    SwanLab全局功能开关，用于管理和控制SwanLab的全局设置
 """
 
+from typing import Dict, Any
+
+from pydantic import BaseModel
+
+
 class SettingsState:
-    """单例模式，管理设置状态"""
+    """
+    单例模式，管理设置状态。
+    用于确保全局只有一个设置实例，并提供设置的锁定机制。
+    """
+
     _instance = None
     _initialized = False
 
-    def __new__(cls):
+    def __new__(cls) -> 'SettingsState':
         if cls._instance is None:
             cls._instance = super(SettingsState, cls).__new__(cls)
             cls._instance._locked = False
-            cls._instance._settings = {}
+            cls._instance._settings: Dict[str, Any] = {}
         return cls._instance
 
-    def lock(self):
+    def lock(self) -> None:
         """锁定设置，防止后续修改"""
         self._locked = True
 
     @property
-    def is_locked(self):
-        """返回设置是否已锁定"""
+    def is_locked(self) -> bool:
+        """
+        返回设置是否已锁定
+        :return: bool 锁定状态
+        """
         return self._locked
 
-    def get_settings(self):
-        """获取当前设置"""
-        return self._settings.copy()  # 返回副本防止直接修改
+    def get_settings(self) -> Dict[str, Any]:
+        """
+        获取当前设置
+        :return: Dict 当前设置的副本
+        """
+        return self._settings.copy()
 
-    def update_settings(self, settings):
-        """更新设置，如果已锁定则抛出异常"""
+    def update_settings(self, settings: 'Settings') -> None:
+        """
+        更新设置，如果已锁定则抛出异常
+        :param settings: Settings对象，包含新的设置值
+        :raises RuntimeError: 当设置已被锁定时抛出
+        """
         if self._locked:
             raise RuntimeError("Cannot modify settings after swanlab.init() has been called")
         self._settings.update(settings.__dict__)
 
 
-class Settings:
-    """用户设置类"""
+class Settings(BaseModel):
+    """
+    用户设置类，定义SwanLab支持的所有设置项
+    """
 
-    def __init__(self, hardware_monitor=True, **kwargs):
+    hardware_monitor: bool = True
+
+    def __init__(self, hardware_monitor: bool = True, **kwargs):
+        """
+        初始化设置
+        :param hardware_monitor: 是否启用硬件监控
+        :param kwargs: 其他自定义设置项
+        """
         self.hardware_monitor = hardware_monitor
         for key, value in kwargs.items():
             setattr(self, key, value)
 
 
-def merge_settings(settings):
-    """合并用户设置到全局设置"""
+def merge_settings(settings: Settings) -> Dict[str, Any]:
+    """
+    合并用户设置到全局设置
+    :param settings: Settings对象
+    :return: Dict 合并后的设置
+    :raises TypeError: 当输入不是Settings对象时抛出
+    :raises RuntimeError: 当设置已被锁定时抛出
+    """
     if not isinstance(settings, Settings):
         raise TypeError("Expected Settings object")
 
@@ -61,24 +95,27 @@ def merge_settings(settings):
     return state.get_settings()
 
 
-def init(settings=None):
-    """初始化SwanLab，并锁定设置"""
+def setup(settings: Settings = None) -> Dict[str, Any]:
+    """
+    初始化单例SettingsState并锁定设置
+    :param settings: 可选的Settings对象
+    :return: Dict 当前的设置配置
+    :raises TypeError: 当settings不是Settings对象时抛出
+    """
     state = SettingsState()
 
-    # 如果传入了新设置，先应用它们
     if settings is not None:
         if not isinstance(settings, Settings):
             raise TypeError("Expected Settings object")
         state.update_settings(settings)
 
-    # 锁定设置，防止后续修改
     state.lock()
 
-    # 使用锁定后的设置进行实际初始化
     current_settings = state.get_settings()
     print(f"SwanLab initialized with settings: {current_settings}")
 
-    # 这里执行真正的初始化逻辑
-    # ...
-
     return current_settings
+
+
+# 创建默认设置实例
+settings = Settings()

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -64,15 +64,15 @@ class Settings(BaseModel):
     """
 
     hardware_monitor: bool = True
+    model_config = {"extra": "allow"}  # 允许额外字段
 
-    def __init__(self, hardware_monitor: bool = True, **kwargs):
+    def model_post_init(self, __context):
         """
-        初始化设置
-        :param hardware_monitor: 是否启用硬件监控
-        :param kwargs: 其他自定义设置项
+        初始化后的处理，用于处理额外的设置项
         """
-        self.hardware_monitor = hardware_monitor
-        for key, value in kwargs.items():
+        super().model_post_init(__context)
+        # 保存所有传入的额外参数
+        for key, value in self.model_extra.items():
             setattr(self, key, value)
 
 

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -106,6 +106,7 @@ def setup(settings: Settings = None) -> Dict[str, Any]:
             raise TypeError("Expected Settings object")
         state.update_settings(settings)
 
+    # 锁定设置
     state.lock()
 
     current_settings = state.get_settings()

--- a/test/unit/test_swanlab_settings.py
+++ b/test/unit/test_swanlab_settings.py
@@ -51,10 +51,9 @@ def test_settings_class():
     settings = Settings(hardware_monitor=False)
     assert settings.hardware_monitor is False
 
-    # 测试动态添加设置
-    settings = Settings(hardware_monitor=True, custom_setting="test")
-    assert settings.hardware_monitor is True
-    assert settings.custom_setting == "test"
+    # 测试不允许未定义的字段
+    with pytest.raises(ValueError):
+        Settings(unknown_field="value")
 
 
 def test_merge_settings():
@@ -65,10 +64,9 @@ def test_merge_settings():
     state._locked = False
 
     # 测试合并有效的设置
-    settings = Settings(hardware_monitor=False, custom_setting="test")
+    settings = Settings(hardware_monitor=False)
     result = merge_settings(settings)
     assert result['hardware_monitor'] is False
-    assert result['custom_setting'] == "test"
 
     # 测试无效输入
     with pytest.raises(TypeError):
@@ -98,13 +96,12 @@ def test_setup():
     state._locked = False
 
     # 测试自定义设置
-    custom_settings = Settings(hardware_monitor=False, custom_setting="test")
+    custom_settings = Settings(hardware_monitor=False)
     result = setup(custom_settings)
     assert result['hardware_monitor'] is False
-    assert result['custom_setting'] == "test"
 
     # 测试无效输入
-    with pytest.raises(TypeError):
+    with pytest.raises(RuntimeError):
         setup("invalid")
 
     # 测试重复setup
@@ -137,8 +134,9 @@ def test_settings_initialization():
     assert isinstance(settings.hardware_monitor, bool)
 
     # 测试自定义参数
-    custom_settings = {'hardware_monitor': False, 'log_level': 'DEBUG', 'max_retries': 3}
-    settings = Settings(**custom_settings)
+    settings = Settings(hardware_monitor=False)
     assert settings.hardware_monitor is False
-    assert settings.log_level == 'DEBUG'
-    assert settings.max_retries == 3
+
+    # 测试不允许未定义的字段
+    with pytest.raises(ValueError):
+        Settings(hardware_monitor=True, unknown_field="value")

--- a/test/unit/test_swanlab_settings.py
+++ b/test/unit/test_swanlab_settings.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025-3-20
+@File: test\test_swanlab_settings.py
+@IDE: vscode
+@Description:
+    SwanLab settings module unit tests
+"""
+
+import pytest
+from swanlab.swanlab_settings import SettingsState, Settings, merge_settings, setup
+
+
+def test_settings_state_singleton():
+    """测试SettingsState的单例模式"""
+    # 创建两个实例，应该是同一个对象
+    state1 = SettingsState()
+    state2 = SettingsState()
+    assert state1 is state2
+
+    # 确保设置是共享的
+    state1._settings['test'] = 'value'
+    assert state2._settings['test'] == 'value'
+
+
+def test_settings_state_lock():
+    """测试SettingsState的锁定机制"""
+    state = SettingsState()
+    state._settings.clear()  # 清除之前测试可能留下的设置
+
+    # 测试锁定前可以更新设置
+    settings = Settings(hardware_monitor=True)
+    state.update_settings(settings)
+    assert state._settings['hardware_monitor'] is True
+
+    # 锁定后不能更新设置
+    state.lock()
+    assert state.is_locked is True
+
+    with pytest.raises(RuntimeError):
+        state.update_settings(settings)
+
+
+def test_settings_class():
+    """测试Settings类的基本功能"""
+    # 测试默认值
+    settings = Settings()
+    assert settings.hardware_monitor is True
+
+    # 测试自定义值
+    settings = Settings(hardware_monitor=False)
+    assert settings.hardware_monitor is False
+
+    # 测试动态添加设置
+    settings = Settings(hardware_monitor=True, custom_setting="test")
+    assert settings.hardware_monitor is True
+    assert settings.custom_setting == "test"
+
+
+def test_merge_settings():
+    """测试merge_settings函数"""
+    # 重置SettingsState
+    state = SettingsState()
+    state._settings.clear()
+    state._locked = False
+
+    # 测试合并有效的设置
+    settings = Settings(hardware_monitor=False, custom_setting="test")
+    result = merge_settings(settings)
+    assert result['hardware_monitor'] is False
+    assert result['custom_setting'] == "test"
+
+    # 测试无效输入
+    with pytest.raises(TypeError):
+        merge_settings("invalid")
+
+    # 测试锁定后的合并
+    state.lock()
+    with pytest.raises(RuntimeError):
+        merge_settings(settings)
+
+
+def test_setup():
+    """测试setup函数"""
+    # 重置SettingsState
+    state = SettingsState()
+    state._settings.clear()
+    state._locked = False
+
+    # 测试默认设置
+    result = setup()
+    assert isinstance(result, dict)
+    assert 'hardware_monitor' in result
+    assert result['hardware_monitor'] is True
+
+    # 重置状态
+    state._settings.clear()
+    state._locked = False
+
+    # 测试自定义设置
+    custom_settings = Settings(hardware_monitor=False, custom_setting="test")
+    result = setup(custom_settings)
+    assert result['hardware_monitor'] is False
+    assert result['custom_setting'] == "test"
+
+    # 测试无效输入
+    with pytest.raises(TypeError):
+        setup("invalid")
+
+    # 测试重复setup
+    with pytest.raises(RuntimeError):
+        setup(custom_settings)
+
+
+def test_settings_copy():
+    """测试设置的复制机制"""
+    state = SettingsState()
+    state._settings.clear()
+    state._locked = False
+
+    # 设置初始值
+    settings = Settings(hardware_monitor=True)
+    state.update_settings(settings)
+
+    # 获取设置的副本
+    settings_copy = state.get_settings()
+
+    # 修改副本不应影响原始设置
+    settings_copy['hardware_monitor'] = False
+    assert state._settings['hardware_monitor'] is True
+
+
+def test_settings_initialization():
+    """测试Settings的初始化和验证"""
+    # 测试基本初始化
+    settings = Settings()
+    assert isinstance(settings.hardware_monitor, bool)
+
+    # 测试自定义参数
+    custom_settings = {'hardware_monitor': False, 'log_level': 'DEBUG', 'max_retries': 3}
+    settings = Settings(**custom_settings)
+    assert settings.hardware_monitor is False
+    assert settings.log_level == 'DEBUG'
+    assert settings.max_retries == 3

--- a/test/unit/test_swanlab_settings.py
+++ b/test/unit/test_swanlab_settings.py
@@ -2,7 +2,7 @@
 r"""
 @DATE: 2025-3-20
 @File: test\test_swanlab_settings.py
-@IDE: vscode
+@IDE: cursor
 @Description:
     SwanLab settings module unit tests
 """


### PR DESCRIPTION
## Description

Closes: #883 

This pull request implements a global function switch manager for SwanLab. The feature provides a centralized way to manage and control global settings throughout the SwanLab environment.

Key components:
- Implemented `SettingsState` singleton to ensure global settings consistency
- Created `Settings` class using Pydantic for type validation and schema enforcement
- Added utility functions for settings management (merge, setup, get_current)
- Built locking mechanism to prevent settings modification after initialization

**Important**: Once `swanlab.init()` is called, all settings become immutable to ensure consistent behavior throughout the application lifecycle.

## Tests

The file `test/unit/test_swanlab_settings.py` contains two test classes:
- `TestSwanlabSettingsBasics`: Tests for basic functionality of each component
- `TestSwanlabSettings`: Integration tests for the settings module as a user would interact with it