### PR TITLE
feat: env add gpu nvidia architecture and cudacores

### DIFF
--- a/swanlab/data/run/metadata/hardware/gpu/nvidia.py
+++ b/swanlab/data/run/metadata/hardware/gpu/nvidia.py
@@ -14,10 +14,23 @@ from ..type import HardwareFuncResult, HardwareCollector, HardwareInfoList, Hard
 from ..utils import generate_key, HardwareConfig, random_index
 
 
+NVIDIA_GPU_ARCHITECTURE = {
+    pynvml.NVML_DEVICE_ARCH_KEPLER: "Kepler",
+    pynvml.NVML_DEVICE_ARCH_MAXWELL: "Maxwell",
+    pynvml.NVML_DEVICE_ARCH_PASCAL: "Pascal",
+    pynvml.NVML_DEVICE_ARCH_VOLTA: "Volta",
+    pynvml.NVML_DEVICE_ARCH_TURING: "Turing",
+    pynvml.NVML_DEVICE_ARCH_AMPERE: "Ampere",
+    pynvml.NVML_DEVICE_ARCH_ADA: "Ada",
+    pynvml.NVML_DEVICE_ARCH_HOPPER: "Hopper",
+    pynvml.NVML_DEVICE_ARCH_UNKNOWN: "Unknown",
+}
+
+
 def get_nvidia_gpu_info() -> HardwareFuncResult:
     """获取 GPU 信息"""
 
-    info = {"driver": None, "cores": None, "type": [], "memory": [], "cuda": None}
+    info = {"driver": None, "cores": None, "type": [], "memory": [], "cuda": None, "architecture": [], "cudacores": []}
     max_gpu_mem_mb = 0
     try:
         pynvml.nvmlInit()
@@ -47,6 +60,11 @@ def get_nvidia_gpu_info() -> HardwareFuncResult:
             total_memory = pynvml.nvmlDeviceGetMemoryInfo(handle).total >> 20  # MB
             max_gpu_mem_mb = max(max_gpu_mem_mb, total_memory)
             info["memory"].append(round(total_memory / 1024))  # GB
+            # 获取 GPU 架构
+            info["architecture"].append(NVIDIA_GPU_ARCHITECTURE[pynvml.nvmlDeviceGetArchitecture(handle)])
+            # 获取 GPU 的CUDA核心数
+            info["cudacores"].append(pynvml.nvmlDeviceGetNumGpuCores(handle))
+            
     except UnicodeDecodeError:  # 部分GPU型号无法解码
         return None, None
     except pynvml.NVMLError:

--- a/swanlab/data/run/metadata/hardware/gpu/nvidia.py
+++ b/swanlab/data/run/metadata/hardware/gpu/nvidia.py
@@ -15,14 +15,14 @@ from ..utils import generate_key, HardwareConfig, random_index
 
 
 NVIDIA_GPU_ARCHITECTURE = {
-    pynvml.NVML_DEVICE_ARCH_KEPLER: "Kepler",
-    pynvml.NVML_DEVICE_ARCH_MAXWELL: "Maxwell",
-    pynvml.NVML_DEVICE_ARCH_PASCAL: "Pascal",
-    pynvml.NVML_DEVICE_ARCH_VOLTA: "Volta",
-    pynvml.NVML_DEVICE_ARCH_TURING: "Turing",
-    pynvml.NVML_DEVICE_ARCH_AMPERE: "Ampere",
-    pynvml.NVML_DEVICE_ARCH_ADA: "Ada",
-    pynvml.NVML_DEVICE_ARCH_HOPPER: "Hopper",
+    pynvml.NVML_DEVICE_ARCH_KEPLER: "Kepler",  # example: GeForce GTX 680, GeForce GTX 780, Tesla K80
+    pynvml.NVML_DEVICE_ARCH_MAXWELL: "Maxwell", # example: GeForce GTX 750 Ti, GeForce GTX 980, Tesla M40
+    pynvml.NVML_DEVICE_ARCH_PASCAL: "Pascal", # example: GeForce GTX 1080 Ti, GeForce GTX 1060, Tesla P100
+    pynvml.NVML_DEVICE_ARCH_VOLTA: "Volta", # example: Tesla V100, Titan V
+    pynvml.NVML_DEVICE_ARCH_TURING: "Turing", # example: GeForce RTX 2080 Ti, GeForce GTX 1660 Ti, Tesla T4
+    pynvml.NVML_DEVICE_ARCH_AMPERE: "Ampere", # example: GeForce RTX 3080, GeForce RTX 3060, A100
+    pynvml.NVML_DEVICE_ARCH_ADA: "Ada", # example: GeForce RTX 4090, GeForce RTX 4080, L40
+    pynvml.NVML_DEVICE_ARCH_HOPPER: "Hopper", # example: H100, H800
     pynvml.NVML_DEVICE_ARCH_UNKNOWN: "Unknown",
 }
 


### PR DESCRIPTION
## Description

This pull request includes updates to the `swanlab/data/run/metadata/hardware/gpu/nvidia.py` file to enhance the functionality of the `get_nvidia_gpu_info` function. The key changes involve adding support for retrieving GPU architecture and CUDA core count information.

Enhancements to GPU information retrieval:

* Added a dictionary `NVIDIA_GPU_ARCHITECTURE` to map NVIDIA GPU architecture codes to their respective architecture names.
* Updated the `info` dictionary in the `get_nvidia_gpu_info` function to include `architecture` and `cudacores` fields.
* Modified the `get_nvidia_gpu_info` function to retrieve and append GPU architecture and CUDA core count information to the `info` dictionary.
