### PR TITLE
feat(plugin): support extra discord & slack callback

### DIFF
--- a/swanlab/plugin/notification.py
+++ b/swanlab/plugin/notification.py
@@ -401,6 +401,9 @@ class DiscordCallback(WebhookCallback):
         }
         resp = requests.post(self.bot.webhook_url, json=data)
         resp.raise_for_status()
+        if resp.status_code not in [200, 204]:
+            print(f"❌ DiscordBot sending failed: {resp.text}")
+            return
         print("✅ DiscordBot sending successfully")
 
     def __str__(self):
@@ -429,6 +432,9 @@ class SlackCallback(WebhookCallback):
         }
         resp = requests.post(self.bot.webhook_url, json=data)
         resp.raise_for_status()
+        if resp.status_code not in [200, 204]:
+            print(f"❌ SlackBot sending failed: {resp.text}")
+            return
         print("✅ SlackBot sending successfully")
 
     def __str__(self):

--- a/swanlab/plugin/notification.py
+++ b/swanlab/plugin/notification.py
@@ -405,3 +405,31 @@ class DiscordCallback(WebhookCallback):
 
     def __str__(self):
         return "DiscordBotCallback"
+
+
+class SlackBot:
+    """
+    Slack notification callback with bilingual support.
+    docs: https://api.slack.com/messaging/webhooks
+    """
+
+    def __init__(self, webhook_url: str):
+        self.webhook_url = webhook_url
+
+
+class SlackCallback(WebhookCallback):
+    """Slack notification callback with bilingual support."""
+
+    def _init_bot(self) -> None:
+        self.bot = SlackBot(self.webhook_url)
+
+    def send_msg(self, content: str) -> None:
+        data = {
+            "text": content,
+        }
+        resp = requests.post(self.bot.webhook_url, json=data)
+        resp.raise_for_status()
+        print("✅ SlackBot sending successfully")
+
+    def __str__(self):
+        return "SlackBotCallback"

--- a/swanlab/plugin/notification.py
+++ b/swanlab/plugin/notification.py
@@ -377,3 +377,31 @@ class WXWorkCallback(WebhookCallback):
 
     def __str__(self):
         return "WXWorkBotCallback"
+
+
+class DiscordBot:
+    """
+    Discord notification callback with bilingual support.
+    docs: https://discord.com/developers/docs/resources/webhook
+    """
+
+    def __init__(self, webhook_url: str):
+        self.webhook_url = webhook_url
+
+
+class DiscordCallback(WebhookCallback):
+    """Discord notification callback with bilingual support."""
+
+    def _init_bot(self) -> None:
+        self.bot = DiscordBot(self.webhook_url)
+
+    def send_msg(self, content: str) -> None:
+        data = {
+            "content": content,
+        }
+        resp = requests.post(self.bot.webhook_url, json=data)
+        resp.raise_for_status()
+        print("✅ DiscordBot sending successfully")
+
+    def __str__(self):
+        return "DiscordBotCallback"


### PR DESCRIPTION
## Description

- 添加针对 `Discord` 和 `Slack` 的 webhook callback 支持，无需 `secrets`，_务必保管好自己的 `webhook_url`以避免信息轰炸_
- 扩展：根据 `swanlab/plugin/notification.py` 中 `WebhookCallback` 的抽象基类，任意支持 webhook 功能的IM均可继承，只需要编写不到5行 `Bot` 和 `send_msg` 逻辑即可；
 
- Discord Demo
![image](https://github.com/user-attachments/assets/0415c559-b98d-4033-b94d-3d088a79854d)


- Slack Demo
![image](https://github.com/user-attachments/assets/5ace4e40-06df-4bdf-a2ba-e682cdb5ab02)

关联ISSUE： #909 

