### PR TITLE
feat: new env

### DIFF
--- a/swanlab/api/http.py
+++ b/swanlab/api/http.py
@@ -257,10 +257,10 @@ class HTTP:
                     resp = http.get(f"/project/{http.groupname}/{name}")
                 elif e.resp.status_code == 404:
                     # 组织/用户不存在
-                    raise ValueError(f"Entity `{http.groupname}` not found")
+                    raise ValueError(f"Space `{http.groupname}` not found")
                 elif e.resp.status_code == 403:
                     # 权限不足
-                    raise ValueError(f"Entity permission denied: " + http.groupname)
+                    raise ValueError(f"Space permission denied: " + http.groupname)
                 else:
                     raise e
             return ProjectInfo(resp)

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -28,10 +28,11 @@ from .run import (
 from .run.helper import SwanLabRunOperator
 from .utils import (
     _check_proj_name,
-    should_call_after_init,
     _init_config,
-    _load_data,
+    _load_from_dict,
+    _load_from_env,
     _create_operator,
+    should_call_after_init,
     should_call_before_init,
 )
 from ..package import HostFormatter
@@ -171,14 +172,19 @@ class SwanLabInitializer:
         # 从文件中加载数据
         if load:
             load_data = check_load_json_yaml(load, load)
-            experiment_name = _load_data(load_data, "experiment_name", experiment_name)
-            description = _load_data(load_data, "description", description)
-            config = _load_data(load_data, "config", config)
-            logdir = _load_data(load_data, "logdir", logdir)
-            mode = _load_data(load_data, "mode", mode)
-            project = _load_data(load_data, "project", project)
-            workspace = _load_data(load_data, "workspace", workspace)
-            public = _load_data(load_data, "private", public)
+            experiment_name = _load_from_dict(load_data, "experiment_name", experiment_name)
+            description = _load_from_dict(load_data, "description", description)
+            config = _load_from_dict(load_data, "config", config)
+            logdir = _load_from_dict(load_data, "logdir", logdir)
+            mode = _load_from_dict(load_data, "mode", mode)
+            project = _load_from_dict(load_data, "project", project)
+            workspace = _load_from_dict(load_data, "workspace", workspace)
+            public = _load_from_dict(load_data, "private", public)
+        # 从环境变量中加载参数
+        workspace = _load_from_env(SwanLabEnv.WORKSPACE.value, workspace)
+        project = _load_from_env(SwanLabEnv.PROJ_NAME.value, project)
+        experiment_name = _load_from_env(SwanLabEnv.EXP_NAME.value, experiment_name)
+
         # FIXME 没必要多一个函数
         project = _check_proj_name(project if project else os.path.basename(os.getcwd()))  # 默认实验名称为当前目录名
         callbacks = check_callback_format(self.cbs + callbacks)

--- a/swanlab/data/utils.py
+++ b/swanlab/data/utils.py
@@ -156,7 +156,7 @@ def _init_config(config: Union[dict, str]):
     return config
 
 
-def _load_data(load_data: dict, key: str, value):
+def _load_from_dict(load_data: dict, key: str, value):
     """
     从load_data中加载数据，如果value不是None，则直接返回value，如果为None，则返回load_data中的key
     """
@@ -164,6 +164,15 @@ def _load_data(load_data: dict, key: str, value):
         return value
     d = load_data.get(key, None)
     return d
+
+
+def _load_from_env(key: str, value):
+    if value is not None:
+        return value
+    env_value = os.getenv(key)
+    if env_value is not None:
+        os.environ[key] = env_value
+        return env_value
 
 
 def _create_operator(

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -64,6 +64,19 @@ class SwanLabEnv(enum.Enum):
     * 如果login接口传入字符串，此环境变量无效，此时相当于绕过 get_key 接口
     * 如果用户已登录，此环境变量的优先级高于本地存储登录信息
     """
+    WORKSPACE = "SWANLAB_WORKSPACE"
+    """
+    swanlab的工作空间，默认为当前登录用户
+    """
+    PROJ_NAME = "SWANLAB_PROJ_NAME"
+    """
+    swanlab的项目名称
+    """
+    EXP_NAME = "SWANLAB_EXP_NAME"
+    """
+    swanlab的实验名称
+    """
+
     RUNTIME = "SWANLAB_RUNTIME"
     """
     swanlab的运行时环境，"user" "develop" "test" "test-no-cloud"

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -16,6 +16,7 @@ import swanlab.data.sdk as S
 import swanlab.data.utils
 import swanlab.error as Err
 import tutils as T
+from swanlab.api.http import reset_http
 from swanlab.data.run import get_run
 from swanlab.env import SwanLabEnv, get_save_dir
 from swanlab.log import swanlog
@@ -382,3 +383,42 @@ class TestLogin:
         S.login(host=T.API_HOST.rstrip("/api"), web_host=T.WEB_HOST)
         assert os.environ[SwanLabEnv.API_HOST.value] == T.API_HOST
         assert os.environ[SwanLabEnv.WEB_HOST.value] == T.WEB_HOST
+
+
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+class TestInitExpByEnv:
+    """
+    测试通过环境变量创建实验
+    """
+
+    def test_workspace(self):
+        """
+        测试通过环境变量创建实验
+        """
+        os.environ[SwanLabEnv.WORKSPACE.value] = generate()
+        # 随便生成的一个workspace会报错
+        with pytest.raises(ValueError) as e:
+            S.init()
+        assert str(e.value) == 'Space `{}` not found'.format(os.environ[SwanLabEnv.WORKSPACE.value])
+        del os.environ[SwanLabEnv.WORKSPACE.value]
+        reset_http()
+
+    def test_exp_name(self):
+        """
+        测试通过环境变量创建实验
+        """
+        exp_name = generate()
+        os.environ[SwanLabEnv.EXP_NAME.value] = exp_name
+        run = S.init()
+        assert run.public.cloud.experiment_name == exp_name
+        del os.environ[SwanLabEnv.EXP_NAME.value]
+
+    def test_proj_name(self):
+        """
+        测试通过环境变量创建实验
+        """
+        proj_name = generate()
+        os.environ[SwanLabEnv.PROJ_NAME.value] = proj_name
+        run = S.init()
+        assert run.public.cloud.project_name == proj_name
+        del os.environ[SwanLabEnv.PROJ_NAME.value]

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -422,3 +422,13 @@ class TestInitExpByEnv:
         run = S.init()
         assert run.public.cloud.project_name == proj_name
         del os.environ[SwanLabEnv.PROJ_NAME.value]
+
+    def test_env_params_priority(self):
+        """
+        环境变量的优先级低于函数参数
+        """
+        exp_name = generate()
+        os.environ[SwanLabEnv.EXP_NAME.value] = exp_name
+        param_exp_name = generate()
+        run = S.init(experiment_name=param_exp_name)
+        assert run.public.cloud.experiment_name == param_exp_name


### PR DESCRIPTION
新增 `SWANLAB_EXP_NAME` `SWANLAB_WORKSPACE` `SWANLAB_PROJ_NAME`三个环境变量 用于初始化时的参数传递

closes https://github.com/SwanHubX/SwanLab/issues/902
