### PR TITLE
fix: object3d import error

### DIFF
--- a/swanlab/data/modules/object3d/object3d.py
+++ b/swanlab/data/modules/object3d/object3d.py
@@ -10,8 +10,12 @@ from .point_cloud import Box, PointCloud
 try:
     # noinspection PyPackageRequirements
     import numpy as np
+
+    ndarray = np.ndarray
 except ImportError:
     np = None
+
+    ndarray = None
 
 try:
     from rdkit.Chem import Mol
@@ -26,7 +30,7 @@ class Object3D:
 
     This class provides a unified interface for handling various 3D data formats including:
     - Point clouds from numpy arrays
-    - Point clouds with boxes from {"points": np.ndarray, "boxes": List[Box]}
+    - Point clouds with boxes from {"points": ndarray, "boxes": List[Box]}
     - 3D models from files (.glb)
     - Point cloud files (.swanlab.pts.json)
 
@@ -90,7 +94,7 @@ class Object3D:
 
     def __new__(
         cls,
-        data: Union[np.ndarray, str, Path, Dict, Mol],
+        data: Union[ndarray, str, Path, Dict, Mol],
         *,
         caption: Optional[str] = None,
         **kwargs,
@@ -99,7 +103,7 @@ class Object3D:
 
         kwargs['caption'] = caption
 
-        if isinstance(data, np.ndarray):
+        if isinstance(data, ndarray):
             return cls._handle_ndarray(data, **kwargs)
 
         if isinstance(data, (str, Path)):
@@ -116,7 +120,7 @@ class Object3D:
             raise ImportError("Numpy is required for Object3D class. Please install it with: pip install numpy.")
 
     @classmethod
-    def _handle_ndarray(cls, data: np.ndarray, **kwargs) -> MediaType:
+    def _handle_ndarray(cls, data: ndarray, **kwargs) -> MediaType:
         point_cloud_channel_handlers = {
             3: [PointCloud.from_xyz],  # xyz
             4: [PointCloud.from_xyzc],  # xyzc
@@ -133,9 +137,7 @@ class Object3D:
 
     _FILE_HANDLERS: Dict[str, List[Callable]] = {
         '.swanlab.pts.json': [PointCloud.from_swanlab_pts_json_file],
-
         '.glb': [Model3D.from_glb_file],
-
         '.sd': [Molecule.from_sdf_file],
         '.sdf': [Molecule.from_sdf_file],
         '.mol': [Molecule.from_mol_file],
@@ -202,7 +204,7 @@ class Object3D:
     @classmethod
     def from_point_data(
         cls,
-        points: np.ndarray,
+        points: ndarray,
         *,
         boxes: Optional[List[Box]] = None,
         caption: Optional[str] = None,

--- a/swanlab/data/modules/object3d/point_cloud.py
+++ b/swanlab/data/modules/object3d/point_cloud.py
@@ -44,8 +44,11 @@ from swanlab.data.namer import hex_to_rgb, light_colors
 
 try:
     import numpy as np
+
+    ndarray = np.ndarray
 except ImportError:
     np = None
+    ndarray = None
 
 
 class Box(TypedDict):
@@ -96,7 +99,7 @@ class PointCloud(MediaType):
         >>> pc = PointCloud.from_xyz(points, caption="My Points")  # With caption
     """
 
-    points: np.ndarray  # format xyzrgb
+    points: ndarray  # format xyzrgb
     boxes: List[Box] = field(default_factory=list)
     step: Optional[int] = None
     caption: Optional[str] = None
@@ -116,7 +119,7 @@ class PointCloud(MediaType):
             raise ImportError("Numpy is required for PointCloud class. Please install it with: pip install numpy")
 
     @classmethod
-    def from_xyz(cls, points: np.ndarray, *, caption: Optional[str] = None, **kwargs) -> "PointCloud":
+    def from_xyz(cls, points: ndarray, *, caption: Optional[str] = None, **kwargs) -> "PointCloud":
         """Create PointCloud from XYZ coordinates.
 
         Args:
@@ -143,7 +146,7 @@ class PointCloud(MediaType):
         return cls(xyzrgb, caption=caption, **kwargs)
 
     @classmethod
-    def from_xyzc(cls, points: np.ndarray, *, caption: Optional[str] = None, **kwargs) -> "PointCloud":
+    def from_xyzc(cls, points: ndarray, *, caption: Optional[str] = None, **kwargs) -> "PointCloud":
         """Create PointCloud from XYZC format (XYZ coordinates + category).
 
         Args:
@@ -175,7 +178,7 @@ class PointCloud(MediaType):
         return cls(xyzrgb, caption=caption, **kwargs)
 
     @classmethod
-    def from_xyzrgb(cls, points: np.ndarray, *, caption: Optional[str] = None, **kwargs) -> "PointCloud":
+    def from_xyzrgb(cls, points: ndarray, *, caption: Optional[str] = None, **kwargs) -> "PointCloud":
         """Create PointCloud from XYZRGB format.
 
         Args:
@@ -216,7 +219,7 @@ class PointCloud(MediaType):
         points = data["points"]
         if isinstance(points, list):
             points = np.array(points)  # Convert list to NumPy array
-        elif not isinstance(points, np.ndarray):
+        elif not isinstance(points, ndarray):
             raise TypeError("data['points'] must be a list or a NumPy array")
 
         if points.ndim != 2:


### PR DESCRIPTION
This pull request introduces a refactor to replace direct references to `np.ndarray` with a more flexible alias, `ndarray`, in the `Object3D` and `PointCloud` modules. This change improves maintainability and consistency when handling the optional dependency on NumPy. Additionally, minor formatting adjustments were made to clean up the code.

### Refactor for NumPy Dependency Handling:

* Introduced `ndarray` as an alias for `np.ndarray` in both `object3d.py` and `point_cloud.py`, with fallback to `None` if NumPy is not installed. This ensures better handling of the optional dependency. (`[[1]](diffhunk://#diff-3874055d997b8d0ed7d6824eea827e06d0c153a4b59fcd0030088b6f3bb5316eR13-R19)`, `[[2]](diffhunk://#diff-3612ea6db2beba642c364af801265e0c34db777d5b5149c0d85636de614bd726R47-R51)`)
* Updated type annotations and type checks in methods across `Object3D` and `PointCloud` classes to use `ndarray` instead of `np.ndarray`. (`[[1]](diffhunk://#diff-3874055d997b8d0ed7d6824eea827e06d0c153a4b59fcd0030088b6f3bb5316eL29-R33)`, `[[2]](diffhunk://#diff-3874055d997b8d0ed7d6824eea827e06d0c153a4b59fcd0030088b6f3bb5316eL93-R97)`, `[[3]](diffhunk://#diff-3874055d997b8d0ed7d6824eea827e06d0c153a4b59fcd0030088b6f3bb5316eL102-R106)`, `[[4]](diffhunk://#diff-3874055d997b8d0ed7d6824eea827e06d0c153a4b59fcd0030088b6f3bb5316eL119-R123)`, `Fd202R204`, `[[5]](diffhunk://#diff-3612ea6db2beba642c364af801265e0c34db777d5b5149c0d85636de614bd726L99-R102)`, `[[6]](diffhunk://#diff-3612ea6db2beba642c364af801265e0c34db777d5b5149c0d85636de614bd726L119-R122)`, `[[7]](diffhunk://#diff-3612ea6db2beba642c364af801265e0c34db777d5b5149c0d85636de614bd726L146-R149)`, `[[8]](diffhunk://#diff-3612ea6db2beba642c364af801265e0c34db777d5b5149c0d85636de614bd726L178-R181)`, `[[9]](diffhunk://#diff-3612ea6db2beba642c364af801265e0c34db777d5b5149c0d85636de614bd726L219-R222)`)

### Code Cleanup:

* Removed unnecessary blank lines in the `_FILE_HANDLERS` dictionary for improved readability. (`[swanlab/data/modules/object3d/object3d.pyL136-L138](diffhunk://#diff-3874055d997b8d0ed7d6824eea827e06d0c153a4b59fcd0030088b6f3bb5316eL136-L138)`)