### PR TITLE
chore: change (max columns)/req

### DIFF
--- a/swanlab/api/upload/__init__.py
+++ b/swanlab/api/upload/__init__.py
@@ -92,7 +92,7 @@ def upload_files(files: List[FileModel]):
     return None
 
 
-MAX_COLUMNS_LENGTH = 3000
+MAX_COLUMNS_LENGTH = 100
 
 
 @sync_error_handler


### PR DESCRIPTION
## Description

Limit the maximum concurrency from 3000 to 100 (the backend may not handle it).
