### PR TITLE
fix: can not get pip list

### DIFF
--- a/swanlab/data/run/metadata/requirements.py
+++ b/swanlab/data/run/metadata/requirements.py
@@ -13,16 +13,14 @@ def get_requirements():
     try:
         # 运行uv命令获取当前环境下的环境目录
         result = subprocess.run(["uv", "pip", "list", "--format=freeze"], capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            raise FileNotFoundError("uv command run failed")
+        return result.stdout
+    except FileNotFoundError:
+        # 运行pip命令获取当前环境下的环境目录
+        result = subprocess.run(["pip", "list", "--format=freeze"], stdout=subprocess.PIPE, text=True)
         # 检查命令是否成功运行
         if result.returncode == 0:
             return result.stdout
         else:
-            # 运行pip命令获取当前环境下的环境目录
-            result = subprocess.run(["pip", "list", "--format=freeze"], stdout=subprocess.PIPE, text=True)
-            # 检查命令是否成功运行
-            if result.returncode == 0:
-                return result.stdout
-            else:
-                return None
-    except Exception:  # noqa
-        return None
+            return None

--- a/test/unit/data/run/metadata/test_requirements.py
+++ b/test/unit/data/run/metadata/test_requirements.py
@@ -1,14 +1,16 @@
 """
-@author: KashiwaByte
-@file: test_uv.py
-@time: 2025-04-14 13:28:37
-@description: 测试uv
+@author: cunyue
+@file: test_requirements.py
+@time: 2025/4/25 22:09
+@description: 测试获取python依赖
 """
 
 import subprocess
+import time
 
 import pytest
-import time
+
+from swanlab.data.run.metadata.requirements import get_requirements
 
 try:
     has_uv = subprocess.run(["uv", "--version"], capture_output=True).returncode == 0
@@ -34,3 +36,11 @@ def test_uv():
         assert isinstance(result.stdout, str)
     else:
         assert result.stdout is None
+
+
+def test_get_requirements():
+    """
+    测试获取python依赖
+    正常情况下有python都应该获取成功
+    """
+    assert get_requirements() is not None


### PR DESCRIPTION
This pull request modifies the `get_requirements` function in `swanlab/data/run/metadata/requirements.py` to improve error handling and streamline the logic for retrieving the list of installed Python packages. The most important changes include raising a specific exception when the `uv` command is not found and removing the generic exception handling.

Improvements to error handling:

* The function now raises a `FileNotFoundError` with a clear error message ("uv command run failed") if the `uv` command is not available, instead of silently falling back to `pip`.

Code simplification:

* Removed the generic `Exception` handling block, making the code more explicit and easier to debug.