### PR TITLE
chore: revert upload column (#953)

### DIFF
--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -49,7 +49,7 @@ class Settings(BaseModel):
     )
     # ---------------------------------- 日志上传部分 ----------------------------------
     # 日志上传间隔
-    upload_interval: PositiveInt = 3
+    upload_interval: PositiveInt = 1
     # 终端日志上传单行最大字符数
     max_log_length: int = Field(ge=500, le=4096, default=1024)
 


### PR DESCRIPTION
This pull request refactors the column upload functionality and adjusts the default settings for log uploads. The most important changes include simplifying the `upload_column` method to remove batch processing and introducing error handling for individual column uploads. Additionally, the default log upload interval has been reduced.

Due to some issues with the upload column interface, temporarily rolled back to #953.

### Refactoring of column upload functionality:
* [`swanlab/api/upload/__init__.py`](diffhunk://#diff-7eef39be6eb534f3b784e5d8b8a0ea5882cc017cdc756d4c3ccfb01dde50ec9fR12): Removed the `MAX_COLUMNS_LENGTH` constant and the logic for splitting columns into batches. The `upload_column` method now uploads each column individually with error handling using the newly imported `ApiError` class. A warning comment has also been added about avoiding concurrent requests due to a known issue. [[1]](diffhunk://#diff-7eef39be6eb534f3b784e5d8b8a0ea5882cc017cdc756d4c3ccfb01dde50ec9fR12) [[2]](diffhunk://#diff-7eef39be6eb534f3b784e5d8b8a0ea5882cc017cdc756d4c3ccfb01dde50ec9fL95-R108)

### Adjustment of log upload settings:
* [`swanlab/swanlab_settings.py`](diffhunk://#diff-fa067e2bfd18e6dc0ac6ff91ad3e310c33144ccf252dbb7ae343aa1c82a1a5ccL52-R52): Reduced the default `upload_interval` for logs from 3 seconds to 1 second to improve log upload frequency.