### PR TITLE
feat(openapi): list workspaces

### DIFF
--- a/docs/开放API.md
+++ b/docs/开放API.md
@@ -1,0 +1,19 @@
+# 开放API
+
+> SwanLab SDK通过**开放API**提供对SwanLab云端服务的访问能力, 允许用户与SwanLab云端进行交互
+> 
+> 例如管理实验或项目, 获取个人资料等
+
+## 用法
+
+要使用开放API, 只需导入`swanlab.openapi`模块
+
+```python
+from swanlab import openapi as api
+
+print(api.list_workspaces())
+```
+
+## 认证
+
+开放API的认证与`swanlab.init()`的认证逻辑一致, 即在终端登录过, 或使用`swanlab.login()`登录

--- a/docs/开放API.md
+++ b/docs/开放API.md
@@ -6,14 +6,21 @@
 
 ## 用法
 
-要使用开放API, 只需导入`swanlab.openapi`模块
+要使用开放API, 只需导入`swanlab.OpenApi`模块
 
 ```python
-from swanlab import openapi as api
+from swanlab import OpenApi
 
-print(api.list_workspaces())
+my_api = OpenApi() # 使用之前的登录信息
+print(my_api.list_workspaces())
+
+other_api = OpenApi(key='other_api_key') # 使用另一个账户的key
+print(other_api.list_workspaces())
 ```
 
 ## 认证
 
-开放API的认证与`swanlab.init()`的认证逻辑一致, 即在终端登录过, 或使用`swanlab.login()`登录
+- 如果显式提供`key`, 则使用该`key`进行认证
+- 否则开放API的认证与`swanlab.init()`的认证逻辑一致, 即
+  - 曾在终端登录过
+  - 显式使用`swanlab.login()`登录

--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -4,7 +4,7 @@ from .env import SwanLabEnv
 from .package import get_package_version
 from .swanlab_settings import Settings
 from .sync import sync_wandb, sync_tensorboardX, sync_tensorboard_torch, sync_mlflow
-from .api import openapi
+from .api.openapi import OpenApi
 
 # 设置默认环境变量
 SwanLabEnv.set_default()
@@ -31,6 +31,6 @@ __all__ = [
     "get_run",
     "get_config",
     "config",
-    "openapi",
+    "OpenApi",
     "__version__",
 ]

--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -4,6 +4,7 @@ from .env import SwanLabEnv
 from .package import get_package_version
 from .swanlab_settings import Settings
 from .sync import sync_wandb, sync_tensorboardX, sync_tensorboard_torch, sync_mlflow
+from .api import openapi
 
 # 设置默认环境变量
 SwanLabEnv.set_default()
@@ -30,5 +31,6 @@ __all__ = [
     "get_run",
     "get_config",
     "config",
+    "openapi",
     "__version__",
 ]

--- a/swanlab/api/openapi/__init__.py
+++ b/swanlab/api/openapi/__init__.py
@@ -5,29 +5,12 @@ r"""
 @File: __init__.py
 @IDE: pycharm
 @Description:
-    SwanLab OpenAPI模块
+    SwanLab OpenAPI包
 """
 
-from swanlab.api import create_http, is_login, code_login
-from swanlab.error import KeyFileError, ValidationError
-from swanlab.log import swanlog
-from swanlab.package import get_key
+from swanlab.api.openapi.main import OpenApi
 
-def pre_login():
-    """检查登录状态, 若未登录，则尝试登录"""
-    if not is_login():
-        try:
-            key = get_key()
-        except KeyFileError as e:
-            swanlog.error("To use SwanLab OpenAPI, please login first.")
-            raise RuntimeError("Not logged in.") from e
-        login_info = code_login(key, False)
-        if login_info.is_fail:
-            raise ValidationError("Login failed: " + str(login_info))
-        create_http(login_info)
 
-pre_login()
-
-from .group import (
-    list_workspaces
-)
+__all__ = [
+    "OpenApi"
+]

--- a/swanlab/api/openapi/__init__.py
+++ b/swanlab/api/openapi/__init__.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/4/29 9:40
+@File: __init__.py
+@IDE: pycharm
+@Description:
+    SwanLab OpenAPI模块
+"""
+
+from swanlab.api import create_http, is_login, code_login
+from swanlab.error import KeyFileError, ValidationError
+from swanlab.log import swanlog
+from swanlab.package import get_key
+
+def pre_login():
+    """检查登录状态, 若未登录，则尝试登录"""
+    if not is_login():
+        try:
+            key = get_key()
+        except KeyFileError as e:
+            swanlog.error("To use SwanLab OpenAPI, please login first.")
+            raise RuntimeError("Not logged in.") from e
+        login_info = code_login(key, False)
+        if login_info.is_fail:
+            raise ValidationError("Login failed: " + str(login_info))
+        create_http(login_info)
+
+pre_login()
+
+from .group import (
+    list_workspaces
+)

--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/1 17:36
+@File: base.py
+@IDE: pycharm
+@Description:
+    SwanLab OpenAPI API基类
+"""
+
+from swanlab.api.http import HTTP
+
+
+class ApiBase:
+    def __init__(self, http: HTTP):
+        self.http: HTTP = http

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/1 17:30
+@File: experiment.py
+@IDE: pycharm
+@Description:
+    实验相关的开放API
+"""
+
+from swanlab.api.http import HTTP
+from swanlab.api.openapi.base import ApiBase
+
+
+class ExperimentAPI(ApiBase):
+    def __init__(self, http: HTTP):
+        super().__init__(http)

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -17,19 +17,6 @@ class GroupAPI(ApiBase):
         super().__init__(http)
 
     def list_workspaces(self):
-        """
-        获取当前用户的所有工作空间(Group)
-
-        :return: 一个列表，每个元素是一个字典，包含工作空间的基础信息：
-            [
-                {
-                    "name": str,       # 工作空间名称
-                    "username": str,   # 工作空间唯一标识(用于组织相关的URL)
-                    "role": str        # 用户在该工作空间中的角色，例如 'OWNER' 或 'MEMBER'
-                },
-                ...
-            ]
-        """
         resp = self.http.get("/group/")
         groups: list = [
             {

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -8,31 +8,35 @@ r"""
     组织相关的开放API
 """
 
-from swanlab.api import get_http
+from swanlab.api.http import HTTP
+from swanlab.api.openapi.base import ApiBase
 
-http = get_http()
 
-def list_workspaces():
-    """
-    获取当前用户的所有工作空间(Group)
+class GroupAPI(ApiBase):
+    def __init__(self, http: HTTP):
+        super().__init__(http)
 
-    :return: 一个列表，每个元素是一个字典，包含工作空间的基础信息：
-        [
+    def list_workspaces(self):
+        """
+        获取当前用户的所有工作空间(Group)
+
+        :return: 一个列表，每个元素是一个字典，包含工作空间的基础信息：
+            [
+                {
+                    "name": str,       # 工作空间名称
+                    "username": str,   # 工作空间唯一标识(用于组织相关的URL)
+                    "role": str        # 用户在该工作空间中的角色，例如 'OWNER' 或 'MEMBER'
+                },
+                ...
+            ]
+        """
+        resp = self.http.get("/group/")
+        groups: list = [
             {
-                "name": str,       # 工作空间名称
-                "username": str,   # 工作空间唯一标识(用于组织相关的URL)
-                "role": str        # 用户在该工作空间中的角色，例如 'OWNER' 或 'MEMBER'
-            },
-            ...
+                "name": item["name"],
+                "username": item["username"],
+                "role": item["role"]
+            }
+            for item in resp.get("list", [])
         ]
-    """
-    resp = http.get("/group/")
-    groups: list = [
-        {
-            "name": item["name"],
-            "username": item["username"],
-            "role": item["role"]
-        }
-        for item in resp.get("list", [])
-    ]
-    return groups
+        return groups

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/4/30 12:11
+@File: group.py
+@IDE: pycharm
+@Description:
+    组织相关的开放API
+"""
+
+from swanlab.api import get_http
+
+http = get_http()
+
+def list_workspaces():
+    """
+    获取当前用户的所有工作空间(Group)
+
+    :return: 一个列表，每个元素是一个字典，包含工作空间的基础信息：
+        [
+            {
+                "name": str,       # 工作空间名称
+                "username": str,   # 工作空间唯一标识(用于组织相关的URL)
+                "role": str        # 用户在该工作空间中的角色，例如 'OWNER' 或 'MEMBER'
+            },
+            ...
+        ]
+    """
+    resp = http.get("/group/")
+    groups: list = [
+        {
+            "name": item["name"],
+            "username": item["username"],
+            "role": item["role"]
+        }
+        for item in resp.get("list", [])
+    ]
+    return groups

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -41,4 +41,14 @@ class OpenApi:
         self.project = ProjectAPI(self.http)
 
     def list_workspaces(self):
+        """
+        获取当前用户的所有工作空间(Group)
+
+        Returns:
+            list[dict]: 每个元素是一个字典, 包含工作空间的基础信息:
+
+                - name: str, 工作空间名称
+                - username: str, 工作空间唯一标识(用于组织相关的 URL)
+                - role: str, 用户在该工作空间中的角色，如 'OWNER' 或 'MEMBER'
+        """
         return self.group.list_workspaces()

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/1 17:00
+@File: main.py
+@IDE: pycharm
+@Description:
+    SwanLab OpenAPI模块
+"""
+from swanlab.api.openapi.experiment import ExperimentAPI
+from swanlab.api.openapi.group import GroupAPI
+from swanlab.api import code_login
+from swanlab.api.http import HTTP
+from swanlab.api.openapi.project import ProjectAPI
+from swanlab.error import KeyFileError
+from swanlab.log.log import SwanLog
+from swanlab.package import get_key
+
+class OpenApi:
+    def __init__(self, key: str = None, log_level: str = "info"):
+        self.__logger: SwanLog = SwanLog("swanlab.openapi", log_level)
+
+        if key is not None:
+            self.__logger.debug("Using API key", key)
+            self.__key = key
+            self.login_info = code_login(self.__key, False)
+        else:
+            self.__logger.debug("Using existing key")
+            try:
+                self.__key = get_key()
+            except KeyFileError as e:
+                self.__logger.error("To use SwanLab OpenAPI, please login first.")
+                raise RuntimeError("Not logged in.") from e
+            self.login_info = code_login(self.__key, False)
+
+        self.username = self.login_info.username
+        self.http: HTTP = HTTP(self.login_info)
+
+        self.group = GroupAPI(self.http)
+        self.experiment = ExperimentAPI(self.http)
+        self.project = ProjectAPI(self.http)
+
+    def list_workspaces(self):
+        return self.group.list_workspaces()

--- a/swanlab/api/openapi/project.py
+++ b/swanlab/api/openapi/project.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/1 17:30
+@File: project.py
+@IDE: pycharm
+@Description:
+    项目相关的开放API
+"""
+
+from swanlab.api.http import HTTP
+from swanlab.api.openapi.base import ApiBase
+
+
+class ProjectAPI(ApiBase):
+    def __init__(self, http: HTTP):
+        super().__init__(http)

--- a/test/unit/api/openapi/test_group.py
+++ b/test/unit/api/openapi/test_group.py
@@ -11,23 +11,25 @@ r"""
 import pytest
 
 import tutils as T
-from swanlab import openapi
+from swanlab import OpenApi
+
+api = OpenApi()
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
 def test_get_workspaces():
     """
     获取用户的所有工作空间
     """
-    r = openapi.list_workspaces()
+    r = api.list_workspaces()
 
     assert isinstance(r, list)
-    assert len(r) > 0
 
-    for item in r:
-        assert isinstance(item, dict)
-        assert "name" in item
-        assert "username" in item
-        assert "role" in item
-        assert isinstance(item["name"], str)
-        assert isinstance(item["username"], str)
-        assert isinstance(item["role"], str)
+    if len(r) > 0:
+        for item in r:
+            assert isinstance(item, dict)
+            assert "name" in item
+            assert "username" in item
+            assert "role" in item
+            assert isinstance(item["name"], str)
+            assert isinstance(item["username"], str)
+            assert isinstance(item["role"], str)

--- a/test/unit/api/openapi/test_group.py
+++ b/test/unit/api/openapi/test_group.py
@@ -13,13 +13,12 @@ import pytest
 import tutils as T
 from swanlab import OpenApi
 
-api = OpenApi()
-
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
 def test_get_workspaces():
     """
     获取用户的所有工作空间
     """
+    api = OpenApi()
     r = api.list_workspaces()
 
     assert isinstance(r, list)

--- a/test/unit/api/openapi/test_group.py
+++ b/test/unit/api/openapi/test_group.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2024/4/30 21:16
+@File: test_group.py
+@IDE: pycharm
+@Description:
+    测试开放API的组织相关接口
+"""
+
+import pytest
+
+import tutils as T
+from swanlab import openapi
+
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+def test_get_workspaces():
+    """
+    获取用户的所有工作空间
+    """
+    r = openapi.list_workspaces()
+
+    assert isinstance(r, list)
+    assert len(r) > 0
+
+    for item in r:
+        assert isinstance(item, dict)
+        assert "name" in item
+        assert "username" in item
+        assert "role" in item
+        assert isinstance(item["name"], str)
+        assert isinstance(item["username"], str)
+        assert isinstance(item["role"], str)


### PR DESCRIPTION
## Description

实现`OpenAPI`功能, 添加第一个开放API: `list_workspaces()`

```python
from swanlab import OpenApi

# 使用之前的登录信息(.netrc)
my_api = OpenApi()
my_workspaces = my_api.list_workspaces()

# 使用另一个账户的key
other_api = OpenApi(key='other_api_key')
print(other_api.list_workspaces())
```

可得到`my_workspaces`(Python列表)

```text
[{
	'name': 'workspace1',
	'username': 'kites-test3',
	'role': 'OWNER'
},
{
	'name': 'hello-openapi',
	'username': 'kites-test2',
	'role': 'MEMBER'
},
...
]
```

## 认证

- 如果显式提供`key`, 则使用该`key`进行认证
- 否则开放API的认证与`swanlab.init()`的认证逻辑一致, 即
  - 曾在终端登录过
  - 显式使用`swanlab.login()`登录

## 🎯 PRs Should Target Issues

https://github.com/SwanHubX/SwanLab/issues/960#issue-3031431009