### PR TITLE
feature: get experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ playground/
 # python
 __pycache__
 .pytest_cache/
+uv.lock
 
 # test-integration-ultralytics
 yolov8n-cls.pt

--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -13,6 +13,7 @@ from swanlab.api import LoginInfo
 from swanlab.api.http import HTTP
 from swanlab.error import ApiError
 
+
 def handle_api_error(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -20,7 +21,9 @@ def handle_api_error(func):
             return func(self, *args, **kwargs)
         except ApiError as e:
             return {"code": e.resp.status_code, "message": e.message}
+
     return wrapper
+
 
 class ApiHTTP:
     def __init__(self, login_info: LoginInfo):
@@ -45,16 +48,17 @@ class ApiHTTP:
         try:
             r = self.http.get(url)
         except ApiError as e:
-            r = { "code": e.resp.status_code, "message": e.message }
+            r = {"code": e.resp.status_code, "message": e.message}
         return r
 
     @handle_api_error
-    def post(self, url: str, data: dict = None):
+    def post(self, url: str, data: dict):
         try:
             r = self.http.post(url, data)
         except ApiError as e:
-            r = { "code": e.resp.status_code, "message": e.message }
+            r = {"code": e.resp.status_code, "message": e.message}
         return r
+
 
 class ApiBase:
     def __init__(self, http: ApiHTTP):

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -28,3 +28,28 @@ class ExperimentAPI(ApiBase):
             raise ValueError("Project name and experiment ID cannot be empty.")
         resp = self.http.get(f"/project/{username}/{projname}/runs/{expid}/state")
         return resp
+
+    def get_experiment(self, username: str, projname: str, expid: str):
+        """
+        获取实验信息
+
+        Args:
+            username (str): 工作空间名
+            projname (str): 项目名
+            expid (str): 实验CUID
+        """
+        if not projname or not expid:
+            raise ValueError("Project name and experiment ID cannot be empty.")
+        resp = self.http.get(f"/project/{username}/{projname}/runs/{expid}")
+        # choose needed fields
+        if isinstance(resp, dict) and "code" not in resp:
+            resp = {
+                "cuid": resp.get("cuid"),
+                "name": resp.get("name"),
+                "description": resp.get("description"),
+                "state": resp.get("state"),
+                "createdAt": resp.get("createdAt"),
+                "finishedAt": resp.get("finishedAt"),
+                "profile": resp.get("profile"),
+            }
+        return resp

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -17,12 +17,9 @@ class GroupAPI(ApiBase):
 
     def list_workspaces(self):
         resp = self.http.get("/group/")
-        groups: list = [
-            {
-                "name": item["name"],
-                "username": item["username"],
-                "role": item["role"]
-            }
-            for item in resp.get("list", [])
-        ]
-        return groups
+        if isinstance(resp, dict):
+            groups: list = [
+                {"name": item["name"], "username": item["username"], "role": item["role"]}
+                for item in resp.get("list", [])
+            ]
+            return groups

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -17,9 +17,10 @@ class GroupAPI(ApiBase):
 
     def list_workspaces(self):
         resp = self.http.get("/group/")
-        if isinstance(resp, dict):
+        if isinstance(resp, dict) and "code" not in resp:
             groups: list = [
                 {"name": item["name"], "username": item["username"], "role": item["role"]}
                 for item in resp.get("list", [])
             ]
             return groups
+        return resp

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -20,7 +20,7 @@ from swanlab.package import get_key
 
 
 class OpenApi:
-    def __init__(self, key: str = None, log_level: str = "info"):
+    def __init__(self, key: Optional[str] = None, log_level: str = "info"):
         self.__logger: SwanLog = SwanLog("swanlab.openapi", log_level)
 
         if key is not None:
@@ -88,7 +88,40 @@ class OpenApi:
                 - code (int): HTTP 错误代码
                 - message (str): 错误信息
         """
+        username = username if username else self.http.username
         if username:
             return self.experiment.get_exp_state(username=username, projname=project, expid=exp_cuid)
-        else:
-            return self.experiment.get_exp_state(username=self.http.username, projname=project, expid=exp_cuid)
+
+    def get_experiment(self, project: str, exp_cuid: str, username: Optional[str] = None):
+        """
+        获取实验信息
+
+        Args:
+            project (str): 项目名
+            exp_cuid (str): 实验id
+            username (Optional[str]): 工作空间名, 默认为用户个人空间
+
+        Returns:
+            dict: 实验信息的字典, 包含以下字段:
+
+                - cuid (str): 实验的唯一标识符
+                - name (str): 实验名称
+                - description (str): 实验描述
+                - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
+                - createdAt (str): 实验创建时间, 格式如 '2024-11-23T12:28:04.286Z'
+                - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
+                - profile (dict): 实验配置文件, 包含以下字段:
+
+                    - config (dict): 实验的配置参数
+                    - metadata (dict): 实验的元数据
+                    - requirements (str): 实验的依赖项
+                    - conda (str): 实验的 Conda 环境信息
+
+            若请求失败, 将返回包含以下字段的字典:
+
+                - code (int): HTTP 错误代码
+                - message (str): 错误信息
+        """
+        username = username if username else self.http.username
+        if username:
+            return self.experiment.get_experiment(username=username, projname=project, expid=exp_cuid)

--- a/test/unit/api/openapi/test_experiment.py
+++ b/test/unit/api/openapi/test_experiment.py
@@ -17,7 +17,7 @@ from swanlab import OpenApi
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
 def test_get_exp_state():
     """
-        获取一个实验的状态
+    获取一个实验的状态
     """
     api = OpenApi()
     res = api.get_exp_state(project="test_project", exp_cuid="test_exp_cuid")
@@ -30,3 +30,29 @@ def test_get_exp_state():
         assert res["state"] == "FINISHED" or res["state"] == "RUNNING"
 
 
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+def test_get_experiment():
+    """
+    获取一个实验的详细信息
+    """
+    api = OpenApi()
+    exp_cuid = "ph3oj1b9of9dqj8e38jzl"
+    res = api.get_experiment(project="istprvdsbzpwmykkmxekb", exp_cuid=exp_cuid)
+    # 仅 404 情况
+    assert isinstance(res, dict)
+    assert "name" in res or "code" in res
+    if "code" in res:
+        assert res["code"] == 404
+    elif "name" in res:
+        assert res["cuid"] == exp_cuid
+        assert isinstance(res["name"], str)
+        assert isinstance(res["description"], str | None)
+        assert isinstance(res["state"], str)
+        assert isinstance(res["createdAt"], str)
+        assert isinstance(res["finishedAt"], str | None)
+        assert isinstance(res["profile"], dict | None)
+        if res["profile"] is not None:
+            assert isinstance(res["profile"].get("config"), dict | None)
+            assert isinstance(res["profile"].get("metadata"), dict | None)
+            assert isinstance(res["profile"].get("requirements"), str | None)
+            assert isinstance(res["profile"].get("conda"), str | None)

--- a/test/unit/api/openapi/test_group.py
+++ b/test/unit/api/openapi/test_group.py
@@ -13,6 +13,7 @@ import pytest
 import tutils as T
 from swanlab import OpenApi
 
+
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
 def test_get_workspaces():
     """
@@ -22,13 +23,12 @@ def test_get_workspaces():
     r = api.list_workspaces()
 
     assert isinstance(r, list)
-
     if len(r) > 0:
         for item in r:
             assert isinstance(item, dict)
             assert "name" in item
             assert "username" in item
             assert "role" in item
-            assert isinstance(item["name"], str)
+            assert isinstance(item["name"], str | None)
             assert isinstance(item["username"], str)
             assert isinstance(item["role"], str)


### PR DESCRIPTION
## Description

通过 OpenAPI 开放获取实验信息接口。

1. 该方法所需用户指定的参数有项目名称与实验唯一 cuid (目前 cuid 只能从前端的 url 中拿到)
3. 该方法输出包含如下参数：

```python
"""
Args:
    project (str): 项目名
    exp_cuid (str): 实验id
    username (Optional[str]): 工作空间名, 默认为用户个人空间

Returns:
dict: 实验信息的字典, 包含以下字段:

    - cuid (str): 实验的唯一标识符
    - name (str): 实验名称
    - description (str): 实验描述
    - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
    - createdAt (str): 实验创建时间, 格式如 '2024-11-23T12:28:04.286Z'
    - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
    - profile (dict): 实验配置文件, 包含以下字段:

        - config (dict): 实验的配置参数
        - metadata (dict): 实验的元数据
        - requirements (str): 实验的依赖项
        - conda (str): 实验的 Conda 环境信息

若请求失败, 将返回包含以下字段的字典:

    - code (int): HTTP 错误代码
    - message (str): 错误信息
"""
```