### PR TITLE
feat(openapi): get project exps

### DIFF
--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -44,20 +44,12 @@ class ApiHTTP:
         return self.__http
 
     @handle_api_error
-    def get(self, url: str):
-        try:
-            r = self.http.get(url)
-        except ApiError as e:
-            r = {"code": e.resp.status_code, "message": e.message}
-        return r
+    def get(self, url: str, params: dict = None):
+        return self.http.get(url=url, params=params)
 
     @handle_api_error
-    def post(self, url: str, data: dict):
-        try:
-            r = self.http.post(url, data)
-        except ApiError as e:
-            r = {"code": e.resp.status_code, "message": e.message}
-        return r
+    def post(self, url: str, data: dict = None):
+        return self.http.post(url=url, data=data)
 
 
 class ApiBase:

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -7,7 +7,6 @@ r"""
 @Description:
     实验相关的开放API
 """
-
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
 
 
@@ -24,10 +23,7 @@ class ExperimentAPI(ApiBase):
             projname (str): 项目名
             expid (str): 实验CUID
         """
-        if not projname or not expid:
-            raise ValueError("Project name and experiment ID cannot be empty.")
-        resp = self.http.get(f"/project/{username}/{projname}/runs/{expid}/state")
-        return resp
+        return self.http.get(f"/project/{username}/{projname}/runs/{expid}/state")
 
     def get_experiment(self, username: str, projname: str, expid: str):
         """
@@ -38,18 +34,54 @@ class ExperimentAPI(ApiBase):
             projname (str): 项目名
             expid (str): 实验CUID
         """
-        if not projname or not expid:
-            raise ValueError("Project name and experiment ID cannot be empty.")
         resp = self.http.get(f"/project/{username}/{projname}/runs/{expid}")
-        # choose needed fields
-        if isinstance(resp, dict) and "code" not in resp:
-            resp = {
-                "cuid": resp.get("cuid"),
-                "name": resp.get("name"),
-                "description": resp.get("description"),
-                "state": resp.get("state"),
-                "createdAt": resp.get("createdAt"),
-                "finishedAt": resp.get("finishedAt"),
-                "profile": resp.get("profile"),
-            }
-        return resp
+        if "code" in resp:
+            return resp
+        return {
+            "cuid": resp.get("cuid"),
+            "name": resp.get("name"),
+            "description": resp.get("description"),
+            "state": resp.get("state"),
+            "show": resp.get("show"),
+            "createdAt": resp.get("createdAt"),
+            "finishedAt": resp.get("finishedAt"),
+            "user": {
+                "username": resp.get("user").get("username"),
+                "name": resp.get("user").get("name"),
+            },
+            "profile": resp.get("profile"),
+        }
+
+    def get_project_exps(self, username: str, projname: str, page: int = 1, size: int = 10):
+        """
+        分页获取项目下的实验列表
+
+        Args:
+            username (str): 工作空间名
+            projname (str): 项目名
+            page (int): 页码, 默认为1
+            size (int): 每页大小, 默认为10
+        """
+        resp = self.http.get(f"/project/{username}/{projname}/runs", params={"page": page, "size": size})
+        if "code" in resp:
+            return resp
+        return {
+            "total": resp["total"],
+            "exps": [
+                {
+                    "cuid": e.get("cuid"),
+                    "name": e.get("name"),
+                    "description": e.get("description"),
+                    "state": e.get("state"),
+                    "show": e.get("show"),
+                    "createdAt": e.get("createdAt"),
+                    "finishedAt": e.get("finishedAt"),
+                    "user": {
+                        "username": e.get("user").get("username"),
+                        "name": e.get("user").get("name"),
+                    },
+                    "profile": e.get("profile")
+                }
+                for e in resp["list"]
+            ]
+        }

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -56,13 +56,11 @@ class OpenApi:
 
         Returns:
             list[dict]: 一个列表, 其中每个元素是一个字典, 包含相应工作空间的基础信息:
-
                 - name (str): 工作空间名称
                 - username (str): 工作空间名(用于组织相关的 URL)
                 - role (str): 用户在该工作空间中的角色，如 'OWNER' 或 'MEMBER'
 
             若请求失败, 将返回包含以下字段的字典:
-
                 - code (int): HTTP 错误代码
                 - message (str): 错误信息
         """
@@ -74,23 +72,23 @@ class OpenApi:
 
         Args:
            project (str): 项目名
-           exp_cuid (str): 实验id
+           exp_cuid (str): 实验CUID
            username (Optional[str]): 工作空间名, 默认为用户个人空间
 
         Returns:
             dict: 实验状态的字典, 包含以下字段:
-
                 - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
                 - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
 
             若请求失败, 将返回包含以下字段的字典:
-
                 - code (int): HTTP 错误代码
                 - message (str): 错误信息
         """
-        username = username if username else self.http.username
-        if username:
-            return self.experiment.get_exp_state(username=username, projname=project, expid=exp_cuid)
+        return self.experiment.get_exp_state(
+            username=username if username else self.http.username,
+            projname=project,
+            expid=exp_cuid
+        )
 
     def get_experiment(self, project: str, exp_cuid: str, username: Optional[str] = None):
         """
@@ -98,30 +96,70 @@ class OpenApi:
 
         Args:
             project (str): 项目名
-            exp_cuid (str): 实验id
+            exp_cuid (str): 实验CUID
             username (Optional[str]): 工作空间名, 默认为用户个人空间
 
         Returns:
             dict: 实验信息的字典, 包含以下字段:
-
                 - cuid (str): 实验的唯一标识符
                 - name (str): 实验名称
                 - description (str): 实验描述
                 - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
+                - show (bool): 显示状态
                 - createdAt (str): 实验创建时间, 格式如 '2024-11-23T12:28:04.286Z'
-                - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
+                - finishedAt (str): 实验完成时间（若有）, 格式同上
+                - user (dict): 实验创建者的 'username' 与 'name'
                 - profile (dict): 实验配置文件, 包含以下字段:
-
                     - config (dict): 实验的配置参数
                     - metadata (dict): 实验的元数据
                     - requirements (str): 实验的依赖项
                     - conda (str): 实验的 Conda 环境信息
 
             若请求失败, 将返回包含以下字段的字典:
-
                 - code (int): HTTP 错误代码
                 - message (str): 错误信息
         """
-        username = username if username else self.http.username
-        if username:
-            return self.experiment.get_experiment(username=username, projname=project, expid=exp_cuid)
+        return self.experiment.get_experiment(
+            username=username if username else self.http.username,
+            projname=project,
+            expid=exp_cuid
+        )
+
+    def get_project_exps(self, project: str, page: int = 1, size: int = 10, username: Optional[str] = None):
+        """
+        获取项目下的实验列表(分页)
+
+        Args:
+            project (str): 项目名
+            username (Optional[str]): 工作空间名, 默认为用户个人空间
+            page (int): 页码, 默认为1
+            size (int): 每页大小, 默认为10
+
+        Returns:
+            dict: 实验列表分页信息的字典, 包含以下字段:
+                - total (int): 实验总数
+                - exps (list[dict]): 实验列表, 每个实验包含以下字段:
+                    - cuid (str): 实验cuid
+                    - name (str): 实验名称
+                    - description (str): 实验描述
+                    - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
+                    - show (bool): 显示状态
+                    - createdAt (str): 创建时间, 格式如 '2024-11-23T12:28:04.286Z'
+                    - finishedAt (str): 完成时间（若有）, 格式同上
+                    - user (dict): 实验创建者的 'username' 与 'name'
+                    - profile (dict): 实验配置文件, 包含以下字段:
+                        - config (dict): 实验的配置参数
+                        - metadata (dict): 实验的元数据
+                        - requirements (str): 实验的依赖项
+                        - conda (str): 实验的 Conda 环境信息
+
+            若请求失败, 将返回包含以下字段的字典:
+                - code (int): HTTP 错误代码
+                - message (str): 错误信息
+        """
+        return self.experiment.get_project_exps(
+            username=username if username else self.http.username,
+            projname=project,
+            page=page,
+            size=size
+        )

--- a/test/unit/api/openapi/test_experiment.py
+++ b/test/unit/api/openapi/test_experiment.py
@@ -56,3 +56,18 @@ def test_get_experiment():
             assert isinstance(res["profile"].get("metadata"), dict | None)
             assert isinstance(res["profile"].get("requirements"), str | None)
             assert isinstance(res["profile"].get("conda"), str | None)
+
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+def test_get_project_exps():
+    """
+    获取一个项目下的实验列表
+    """
+    api = OpenApi()
+    res = api.get_project_exps(project="test_project", page=1, size=10)
+    # 仅 404 情况
+    assert isinstance(res, dict)
+    assert "exps" in res or "code" in res
+    if "code" in res:
+        assert res["code"] == 404
+    elif "exps" in res:
+        assert len(res["exps"]) > 0


### PR DESCRIPTION
## Description

        获取项目下的实验列表(分页)

        Args:
            project (str): 项目名
            username (Optional[str]): 工作空间名, 默认为用户个人空间
            page (int): 页码, 默认为1
            size (int): 每页大小, 默认为10

        Returns:
            dict: 实验列表分页信息的字典, 包含以下字段:
                - total (int): 实验总数
                - exps (list[dict]): 实验列表, 每个实验包含以下字段:
                    - cuid (str): 实验cuid
                    - name (str): 实验名称
                    - description (str): 实验描述
                    - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
                    - show (bool): 显示状态
                    - createdAt (str): 创建时间, 格式如 '2024-11-23T12:28:04.286Z'
                    - finishedAt (str): 完成时间（若有）, 格式同上
                    - user (dict): 实验创建者的 'username' 与 'name'
                    - profile (dict): 实验配置文件, 包含以下字段:
                        - config (dict): 实验的配置参数
                        - metadata (dict): 实验的元数据
                        - requirements (str): 实验的依赖项
                        - conda (str): 实验的 Conda 环境信息

            若请求失败, 将返回包含以下字段的字典:
                - code (int): HTTP 错误代码
                - message (str): 错误信息