### PR TITLE
feat(openapi): list projects

### DIFF
--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -9,7 +9,7 @@ r"""
 """
 import json
 from datetime import datetime, timezone
-from typing import Any, Optional, Callable, TypeVar, List
+from typing import Any, Callable, List, Optional
 
 import requests
 from requests.adapters import HTTPAdapter

--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -9,19 +9,18 @@ r"""
 """
 import json
 from datetime import datetime, timezone
-from typing import Optional, Any
+from typing import Any, Optional, Callable, TypeVar, List
 
 import requests
-
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from swanlab.api.http import HTTP
-from swanlab.api.openapi.types import ApiResponse
-from swanlab.package import get_package_version
 from swanlab.api import LoginInfo
 from swanlab.api.auth.login import login_by_key
+from swanlab.api.http import HTTP
+from swanlab.api.openapi.types import ApiResponse
 from swanlab.log.log import SwanLog
+from swanlab.package import get_package_version
 
 _logger: Optional[SwanLog] = None
 
@@ -71,11 +70,11 @@ class ApiHTTP:
         self.__session: requests.Session = self.__init_session()
 
     @property
-    def username(self):
+    def username(self) -> str:
         """
         当前登录的用户名
         """
-        return self.__login_info.username
+        return self.__login_info.username or ""
 
     @property
     def base_url(self):
@@ -84,7 +83,7 @@ class ApiHTTP:
     @property
     def sid_expired_at(self):
         """
-        获取sid的过期时间，字符串格式转时间
+        获取sid的过期时间
         """
         return datetime.strptime(self.__login_info.expired_at, "%Y-%m-%dT%H:%M:%S.%fZ")
 
@@ -125,3 +124,40 @@ class ApiHTTP:
 class ApiBase:
     def __init__(self, http: ApiHTTP):
         self.http: ApiHTTP = http
+
+def fetch_paginated_api(
+    api_func: Callable[..., ApiResponse],  # 分页 API 请求函数
+    page_field: str = "page",
+    size_field: str = "size",
+    page_size: int = 10,
+    *args, **kwargs
+) -> ApiResponse[List]:
+    """
+    通用分页全量拉取函数
+
+    Args:
+        api_func (Callable): 分页 API 请求函数，应返回 ApiResponse[Pagination]
+        page_field (str): 页码参数名，默认为 "page"
+        size_field (str): 每页大小参数名，默认为 "size"
+        page_size (int): 每页条数，默认为 10
+        *args: 传递给 api_func 的位置参数
+        **kwargs: 传递给 api_func 的关键字参数
+
+    Returns:
+        ApiResponse[list]: 返回所有分页数据组成的 ApiResponse
+    """
+    page = 1
+    objs = []
+    while True:
+        kwargs.update({page_field: page, size_field: page_size})
+        resp: ApiResponse = api_func(*args, **kwargs)
+        if resp.errmsg:
+            break
+
+        objs.extend(resp.data.list)
+
+        if len(objs) >= resp.data.total:
+            break
+        page += 1
+
+    return ApiResponse[List](code=resp.code, errmsg=resp.errmsg, data=objs)

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -59,7 +59,7 @@ class ExperimentAPI(ApiBase):
         resp.data = ExperimentAPI.parse(resp.data)
         return resp
 
-    def get_project_exps(
+    def list_project_exps(
             self,
             username: str,
             projname: str,

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -9,7 +9,7 @@ r"""
 """
 
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
-from swanlab.api.openapi.types import Experiment, ApiResponse, Pagination
+from swanlab.api.openapi.types import ApiResponse, Experiment, Pagination
 
 
 class ExperimentAPI(ApiBase):
@@ -19,18 +19,18 @@ class ExperimentAPI(ApiBase):
     @classmethod
     def parse(cls, body: dict) -> Experiment:
         return Experiment.model_validate({
-            "cuid": body.get("cuid", ""),
-            "name": body.get("name", ""),
-            "description": body.get("description", ""),
-            "state": body.get("state", ""),
-            "show": body.get("show", ""),
-            "createdAt": body.get("createdAt", ""),
-            "finishedAt": body.get("finishedAt", ""),
+            "cuid": body.get("cuid") or "",
+            "name": body.get("name") or "",
+            "description": body.get("description") or "",
+            "state": body.get("state") or "",
+            "show": body.get("show") or "",
+            "createdAt": body.get("createdAt") or "",
+            "finishedAt": body.get("finishedAt") or "",
             "user": {
-                "username": body.get("user").get("username", ""),
-                "name": body.get("user").get("name", ""),
+                "username": (body.get("user") or {}).get("username") or "",
+                "name": (body.get("user") or {}).get("name") or "",
             },
-            "profile": body.get("profile", {})
+            "profile": body.get("profile") or {}
         })
 
     def get_exp_state(self, username: str, projname: str, expid: str) -> ApiResponse[dict]:

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -65,12 +65,7 @@ class OpenApi:
         """
         return self.group.list_workspaces()
 
-    def get_exp_state(
-            self,
-            project: str,
-            exp_cuid: str,
-            username: str = ""
-    ) -> ApiResponse[dict]:
+    def get_exp_state(self, project: str, exp_cuid: str, username: str = "") -> ApiResponse[dict]:
         """
         获取实验状态
 
@@ -88,16 +83,10 @@ class OpenApi:
                     - finishedAt (str): 实验完成时间(若有), 格式如 '2024-11-23T12:28:04.286Z'
         """
         return self.experiment.get_exp_state(
-            username=username if username else self.http.username,
-            projname=project,
-            expid=exp_cuid
+            username=username if username else self.http.username, projname=project, expid=exp_cuid
         )
 
-    def get_experiment(
-            self,project: str,
-            exp_cuid: str,
-            username: str = ""
-    ) -> ApiResponse[Experiment]:
+    def get_experiment(self, project: str, exp_cuid: str, username: str = "") -> ApiResponse[Experiment]:
         """
         获取实验信息
 
@@ -113,17 +102,11 @@ class OpenApi:
                 - data (dict): 实验信息的字典, 包含实验信息
         """
         return self.experiment.get_experiment(
-            username=username if username else self.http.username,
-            projname=project,
-            expid=exp_cuid
+            username=username if username else self.http.username, projname=project, expid=exp_cuid
         )
 
     def get_project_exps(
-            self,
-            project: str,
-            page: int = 1,
-            size: int = 10,
-            username: str = ""
+        self, project: str, page: int = 1, size: int = 10, username: str = ""
     ) -> ApiResponse[Pagination[Experiment]]:
         """
         获取项目下的实验列表(分页)
@@ -144,8 +127,46 @@ class OpenApi:
                         - 此实验的 profile 只包含 config (实验自定义配置)
         """
         return self.experiment.get_project_exps(
-            username=username if username else self.http.username,
-            projname=project,
-            page=page,
-            size=size
+            username=username if username else self.http.username, projname=project, page=page, size=size
         )
+
+    def list_projects(self, username: Optional[str] = None, detail: Optional[bool] = None):
+        """
+        列出一个 workspace 下的所有项目
+
+        Args:
+            username (Optional[str]): 工作空间名, 默认为用户个人空间
+            detail (Optional[bool]): 是否包含项目下实验的相关信息，默认为 True
+
+        Returns:
+            dict: 项目列表信息的字典, 包含以下字段:
+
+                - total (int): 项目总数
+                - list (List[dict]): 项目列表, 每个项目包含以下字段:
+
+                    - cuid (str): 项目的唯一标识符
+                    - name (str): 项目名称
+                    - description (str): 项目描述
+                    - visibility (str): 项目可见性, 如 'PUBLIC' 或 'PRIVATE'
+                    - createdAt (str): 项目创建时间, 格式如 '2025-01-06T14:25:29.075Z'
+                    - updatedAt (str): 项目更新时间, 格式如 '2025-02-21T09:31:11.473Z'
+                    - path (str): 项目路径
+                    - group (dict): 项目所属组信息, 包含以下字段:
+
+                        - type (str): 组类型, 如 'PERSON' 或 'TEAM'
+                        - username (str): 组用户名
+                        - name (str): 组名称(可能为null)
+
+                    - _count (dict): 仅当detail=True时返回, 包含以下字段:
+
+                        - experiments (int): 项目中的实验数量
+                        - contributors (int): 项目贡献者数量
+                        - children (int): 子项目数量
+                        - runningExps (int): 正在运行的实验数量
+        """
+        username = username or self.http.username
+        detail = bool(detail) if detail is not None else True
+        if not username:
+            return None
+
+        return self.project.list_projects(username=username, detail=detail)

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -7,14 +7,14 @@ r"""
 @Description:
     SwanLab OpenAPI模块
 """
-from typing import List, Dict
+from typing import Dict, List
 
 from swanlab.api import code_login
-from swanlab.api.openapi.base import ApiHTTP, get_logger, fetch_paginated_api
+from swanlab.api.openapi.base import ApiHTTP, fetch_paginated_api, get_logger
 from swanlab.api.openapi.experiment import ExperimentAPI
 from swanlab.api.openapi.group import GroupAPI
 from swanlab.api.openapi.project import ProjectAPI
-from swanlab.api.openapi.types import ApiResponse, Experiment, Pagination, Project
+from swanlab.api.openapi.types import ApiResponse, Experiment, Project
 from swanlab.error import KeyFileError
 from swanlab.log.log import SwanLog
 from swanlab.package import get_key

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -13,7 +13,7 @@ from swanlab.api.openapi.experiment import ExperimentAPI
 from swanlab.api.openapi.group import GroupAPI
 from swanlab.api import code_login
 from swanlab.api.openapi.project import ProjectAPI
-from swanlab.api.openapi.types import ApiResponse, Experiment, Pagination
+from swanlab.api.openapi.types import ApiResponse, Experiment, Pagination, Project
 from swanlab.error import KeyFileError
 from swanlab.log.log import SwanLog
 from swanlab.package import get_key
@@ -83,7 +83,7 @@ class OpenApi:
                     - finishedAt (str): 实验完成时间(若有), 格式如 '2024-11-23T12:28:04.286Z'
         """
         return self.experiment.get_exp_state(
-            username=username if username else self.http.username, projname=project, expid=exp_cuid
+            username=username if username else self.http.username, projname=project, expid=exp_cuid  # type: ignore
         )
 
     def get_experiment(self, project: str, exp_cuid: str, username: str = "") -> ApiResponse[Experiment]:
@@ -102,7 +102,7 @@ class OpenApi:
                 - data (dict): 实验信息的字典, 包含实验信息
         """
         return self.experiment.get_experiment(
-            username=username if username else self.http.username, projname=project, expid=exp_cuid
+            username=username if username else self.http.username, projname=project, expid=exp_cuid  # type: ignore
         )
 
     def get_project_exps(
@@ -127,46 +127,29 @@ class OpenApi:
                         - 此实验的 profile 只包含 config (实验自定义配置)
         """
         return self.experiment.get_project_exps(
-            username=username if username else self.http.username, projname=project, page=page, size=size
+            username=username if username else self.http.username, projname=project, page=page, size=size  # type: ignore
         )
 
-    def list_projects(self, username: Optional[str] = None, detail: Optional[bool] = None):
+    def list_projects(
+        self, username: str = "", detail: bool = True, page: int = 1, size: int = 20
+    ) -> ApiResponse[Pagination[Project]]:
         """
         列出一个 workspace 下的所有项目
 
         Args:
-            username (Optional[str]): 工作空间名, 默认为用户个人空间
-            detail (Optional[bool]): 是否包含项目下实验的相关信息，默认为 True
+            username (str): 工作空间名, 默认为用户个人空间
+            detail (bool): 是否包含项目下实验的相关信息，默认为 True
+            page (int): 页码, 默认为 1
+            size (int): 每页大小, 默认为 20
 
         Returns:
             dict: 项目列表信息的字典, 包含以下字段:
-
-                - total (int): 项目总数
-                - list (List[dict]): 项目列表, 每个项目包含以下字段:
-
-                    - cuid (str): 项目的唯一标识符
-                    - name (str): 项目名称
-                    - description (str): 项目描述
-                    - visibility (str): 项目可见性, 如 'PUBLIC' 或 'PRIVATE'
-                    - createdAt (str): 项目创建时间, 格式如 '2025-01-06T14:25:29.075Z'
-                    - updatedAt (str): 项目更新时间, 格式如 '2025-02-21T09:31:11.473Z'
-                    - path (str): 项目路径
-                    - group (dict): 项目所属组信息, 包含以下字段:
-
-                        - type (str): 组类型, 如 'PERSON' 或 'TEAM'
-                        - username (str): 组用户名
-                        - name (str): 组名称(可能为null)
-
-                    - _count (dict): 仅当detail=True时返回, 包含以下字段:
-
-                        - experiments (int): 项目中的实验数量
-                        - contributors (int): 项目贡献者数量
-                        - children (int): 子项目数量
-                        - runningExps (int): 正在运行的实验数量
+                - code (int): HTTP 错误代码
+                - errmsg (str): 错误信息, 仅在请求有错误时非空
+                - data (Pagination[Project]): 项目列表, 包含以下字段:
+                    - total (int): 指定工作空间下的项目总数
+                    - list (list[Project]): 项目列表, 每个元素都是项目信息的字典, 包含项目信息
         """
-        username = username or self.http.username
-        detail = bool(detail) if detail is not None else True
-        if not username:
-            return None
+        username = username or self.http.username  # type: ignore
 
-        return self.project.list_projects(username=username, detail=detail)
+        return self.project.list_projects(username=username, detail=detail, page=page, size=size)

--- a/swanlab/api/openapi/project.py
+++ b/swanlab/api/openapi/project.py
@@ -15,3 +15,39 @@ from swanlab.api.openapi.base import ApiBase, ApiHTTP
 class ProjectAPI(ApiBase):
     def __init__(self, http: ApiHTTP):
         super().__init__(http)
+
+
+    def list_projects(self, username: str, detail: bool):
+        """
+        列出一个 workspace 下的所有项目
+
+        Args:
+            username (str): 工作空间名, 默认为用户个人空间
+            detail (bool): 是否返回实验详细信息，默认传入 True
+        """
+        base_url = f"/project/{username}?detail={detail}"
+        
+        result = {
+            'total': 0,
+            'list': []
+        }
+
+        raw_resp = self.http.get(base_url)
+        if not isinstance(raw_resp, dict):
+            return result
+        
+        result['total'] = raw_resp.get('total', 0)
+        
+        page_count = raw_resp.get('pages', 1)
+        # 分页获取 
+        for page in range(1, page_count + 1):
+            page_url = f"{base_url}&page={page}"
+            page_resp = self.http.get(page_url)
+            
+            # 移除avatar字段
+            for item in page_resp.get('list', []):
+                if item.get('group') and 'avatar' in item['group']:
+                    del item['group']['avatar']
+                result['list'].append(item)
+        
+        return result

--- a/swanlab/api/openapi/project.py
+++ b/swanlab/api/openapi/project.py
@@ -44,8 +44,13 @@ class ProjectAPI(ApiBase):
         列出一个 workspace 下的所有项目
 
         Args:
-            username (str): 工作空间名, 默认为用户个人空间
-            detail (bool): 是否返回实验详细信息，默认传入 True
+            username: 工作空间名, 默认为用户个人空间
+            detail: 是否返回实验详细信息，默认为True
+            page: 页码，默认为1
+            size: 每页数量，默认为20
+
+        Returns:
+            ApiResponse: 包含项目分页数据的响应
         """
         base_url = f"/project/{username}"
         params = {"detail": detail, "page": page, "size": size}
@@ -54,11 +59,7 @@ class ProjectAPI(ApiBase):
         if resp.errmsg:
             return resp
 
-        projects = []
-        for item in resp.data.get("list", []):
-            project = ProjectAPI.parse(item, detail=detail)
-            projects.append(project)
-        print(projects[0])
+        projects = [ProjectAPI.parse(item, detail=detail) for item in resp.data.get("list", [])]
         resp.data = Pagination[Project].model_validate({"total": resp.data.get("total", 0), "list": projects})
 
         return resp

--- a/swanlab/api/openapi/project.py
+++ b/swanlab/api/openapi/project.py
@@ -9,7 +9,7 @@ r"""
 """
 
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
-from swanlab.api.openapi.types import Project, ApiResponse, Pagination
+from swanlab.api.openapi.types import ApiResponse, Pagination, Project
 
 
 class ProjectAPI(ApiBase):
@@ -17,22 +17,22 @@ class ProjectAPI(ApiBase):
         super().__init__(http)
 
     @classmethod
-    def parse(cls, body: dict, detail = True) -> Project:
+    def parse(cls, body: dict, detail=True) -> Project:
         project_parser = {
-            "cuid": body.get("cuid", ""),
-            "name": body.get("name", ""),
-            "description": body.get("description", ""),
-            "visibility": body.get("visibility", ""),
-            "createdAt": body.get("createdAt", ""),
-            "updatedAt": body.get("updatedAt", ""),
+            "cuid": body.get("cuid") or "",
+            "name": body.get("name") or "",
+            "description": body.get("description") or "",
+            "visibility": body.get("visibility") or "",
+            "createdAt": body.get("createdAt") or "",
+            "updatedAt": body.get("updatedAt") or "",
             "group": {
-                "type": body.get("group", {}).get("type", ""),
-                "username": body.get("group", {}).get("username", ""),
-                "name": body.get("group", {}).get("name", ""),
+                "type": (body.get("group") or {}).get("type") or "",
+                "username": (body.get("group") or {}).get("username") or "",
+                "name": (body.get("group") or {}).get("name") or "",
             },
         }
         if detail:
-            project_parser["count"] = body.get("_count")
+            project_parser["count"] = body.get("_count") or {}
         return Project.model_validate(project_parser)
 
     def list_projects(

--- a/swanlab/api/openapi/project.py
+++ b/swanlab/api/openapi/project.py
@@ -23,7 +23,7 @@ class ProjectAPI(ApiBase):
             "cuid": body.get("cuid", ""),
             "name": body.get("name", ""),
             "description": body.get("description", ""),
-            "visbility": body.get("visbility", ""),
+            "visibility": body.get("visibility", ""),
             "createdAt": body.get("createdAt", ""),
             "updatedAt": body.get("updatedAt", ""),
             "path": body.get("path", ""),

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -31,12 +31,8 @@ class Project(BaseModel):
     visibility: str  # 可见性, 'PUBLIC' 或 'PRIVATE'
     createdAt: str  # e.g., '2024-11-23T12:28:04.286Z'
     updatedAt: str  # e.g., '2024-11-23T12:28:04.286Z'
-    path: str  # 项目路径, e.g., '/project/username/project_name'
-    group: Dict[str, Any]  # 工作空间信息, 包含 'type', 'username', 'name'
-
-    _count: Optional[Dict[str, Any]]  # 仅当 detail=True 时返回, 包含项目的详细信息
-
-    model_config = ConfigDict(extra='allow', validate_assignment=True)  # 显式处理 _count 字段
+    group: Dict[str, str]  # 工作空间信息, 包含 'type', 'username', 'name'
+    count: Optional[Dict[str, int]]  # 仅当 detail=True 时返回, 包含项目的详细信息
 
 
 D = TypeVar("D")

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -28,7 +28,7 @@ class Project(BaseModel):
     cuid: str  # 项目CUID, 唯一标识符
     name: str  # 项目名
     description: Optional[str]  # 项目描述
-    visbility: str  # 可见性, 'PUBLIC' 或 'PRIVATE'
+    visibility: str  # 可见性, 'PUBLIC' 或 'PRIVATE'
     createdAt: str  # e.g., '2024-11-23T12:28:04.286Z'
     updatedAt: str  # e.g., '2024-11-23T12:28:04.286Z'
     path: str  # 项目路径, e.g., '/project/username/project_name'

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -8,26 +8,45 @@ r"""
     OpenAPI 相关数据结构
 """
 
-from typing import Optional, Dict, TypeVar, Generic, List
-from pydantic import BaseModel
+from typing import Optional, Dict, TypeVar, Generic, List, Any
+from pydantic import BaseModel, ConfigDict
+
 
 class Experiment(BaseModel):
-    cuid: str   # 实验CUID, 唯一标识符
-    name: str   # 实验名
-    description: Optional[str]    # 实验描述
-    state: str          # 实验状态, 'FINISHED' 或 'RUNNING'
-    show: bool           # 显示状态
-    createdAt: str              # e.g., '2024-11-23T12:28:04.286Z'
-    finishedAt: Optional[str]   # e.g., '2024-11-23T12:28:04.286Z', 若不存在则为 None
-    user: Dict[str, str]        # 实验创建者, 包含 'username' 与 'name'
+    cuid: str  # 实验CUID, 唯一标识符
+    name: str  # 实验名
+    description: Optional[str]  # 实验描述
+    state: str  # 实验状态, 'FINISHED' 或 'RUNNING'
+    show: bool  # 显示状态
+    createdAt: str  # e.g., '2024-11-23T12:28:04.286Z'
+    finishedAt: Optional[str]  # e.g., '2024-11-23T12:28:04.286Z', 若不存在则为 None
+    user: Dict[str, str]  # 实验创建者, 包含 'username' 与 'name'
     profile: Dict  # 实验相关配置
+
+
+class Project(BaseModel):
+    cuid: str  # 项目CUID, 唯一标识符
+    name: str  # 项目名
+    description: Optional[str]  # 项目描述
+    visbility: str  # 可见性, 'PUBLIC' 或 'PRIVATE'
+    createdAt: str  # e.g., '2024-11-23T12:28:04.286Z'
+    updatedAt: str  # e.g., '2024-11-23T12:28:04.286Z'
+    path: str  # 项目路径, e.g., '/project/username/project_name'
+    group: Dict[str, Any]  # 工作空间信息, 包含 'type', 'username', 'name'
+
+    _count: Optional[Dict[str, Any]]  # 仅当 detail=True 时返回, 包含项目的详细信息
+
+    model_config = ConfigDict(extra='allow', validate_assignment=True)  # 显式处理 _count 字段
+
 
 D = TypeVar("D")
 
+
 class ApiResponse(BaseModel, Generic[D]):
-    code: int       # HTTP状态码
-    errmsg: str    # API错误消息, 只有请求错误时非空
+    code: int  # HTTP状态码
+    errmsg: str  # API错误消息, 只有请求错误时非空
     data: D  # 返回数据
+
 
 class Pagination(BaseModel, Generic[D]):
     total: int  # 总数

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -8,42 +8,43 @@ r"""
     OpenAPI 相关数据结构
 """
 
-from typing import Optional, Dict, TypeVar, Generic, List, Any
-from pydantic import BaseModel, ConfigDict
+from typing import Dict, Generic, List, TypeVar
+
+from pydantic import BaseModel
 
 
 class Experiment(BaseModel):
-    cuid: str  # 实验CUID, 唯一标识符
-    name: str  # 实验名
-    description: Optional[str]  # 实验描述
-    state: str  # 实验状态, 'FINISHED' 或 'RUNNING'
-    show: bool  # 显示状态
-    createdAt: str  # e.g., '2024-11-23T12:28:04.286Z'
-    finishedAt: Optional[str]  # e.g., '2024-11-23T12:28:04.286Z', 若不存在则为 None
-    user: Dict[str, str]  # 实验创建者, 包含 'username' 与 'name'
-    profile: Dict  # 实验相关配置
+    cuid: str               # 实验CUID, 唯一标识符
+    name: str               # 实验名
+    description: str = ""   # 实验描述
+    state: str              # 实验状态, 'FINISHED' 或 'RUNNING'
+    show: bool              # 显示状态
+    createdAt: str          # e.g., '2024-11-23T12:28:04.286Z'
+    finishedAt: str = ""    # e.g., '2024-11-23T12:28:04.286Z', 若不存在则为 None
+    user: Dict[str, str]    # 实验创建者, 包含 'username' 与 'name'
+    profile: Dict           # 实验相关配置
 
 
 class Project(BaseModel):
-    cuid: str  # 项目CUID, 唯一标识符
-    name: str  # 项目名
-    description: Optional[str]  # 项目描述
-    visibility: str  # 可见性, 'PUBLIC' 或 'PRIVATE'
-    createdAt: str  # e.g., '2024-11-23T12:28:04.286Z'
-    updatedAt: str  # e.g., '2024-11-23T12:28:04.286Z'
-    group: Dict[str, str]  # 工作空间信息, 包含 'type', 'username', 'name'
-    count: Optional[Dict[str, int]]  # 仅当 detail=True 时返回, 包含项目的详细信息
+    cuid: str                   # 项目CUID, 唯一标识符
+    name: str                   # 项目名
+    description: str = ""       # 项目描述
+    visibility: str             # 可见性, 'PUBLIC' 或 'PRIVATE'
+    createdAt: str              # e.g., '2024-11-23T12:28:04.286Z'
+    updatedAt: str              # e.g., '2024-11-23T12:28:04.286Z'
+    group: Dict[str, str]       # 工作空间信息, 包含 'type', 'username', 'name'
+    count: Dict[str, int] = {}  # 仅当 detail=True 时返回, 包含项目的详细信息
 
 
 D = TypeVar("D")
 
 
 class ApiResponse(BaseModel, Generic[D]):
-    code: int  # HTTP状态码
+    code: int    # HTTP状态码
     errmsg: str  # API错误消息, 只有请求错误时非空
-    data: D  # 返回数据
+    data: D      # 返回数据
 
 
 class Pagination(BaseModel, Generic[D]):
-    total: int  # 总数
-    list: List[D]  # 列表数据，类型为泛型 T
+    total: int      # 总数
+    list: List[D]   # 列表数据，泛型

--- a/test/unit/api/openapi/test_experiment.py
+++ b/test/unit/api/openapi/test_experiment.py
@@ -21,7 +21,7 @@ def test_get_exp_state():
     获取一个实验的状态
     """
     api = OpenApi()
-    res = api.get_exp_state(project="test_project", exp_cuid="test_cuid", username="test")
+    res = api.get_exp_state(project="test_project", exp_cuid="test_cuid")
     assert isinstance(res, ApiResponse)
     if res.code == 200:
         assert res.state == "FINISHED" or res.state == "RUNNING"
@@ -34,23 +34,21 @@ def test_get_experiment():
     """
     api = OpenApi()
     exp_cuid = "test_cuid"
-    res = api.get_experiment(project="test_project", exp_cuid=exp_cuid, username="test")
+    res = api.get_experiment(project="test_project", exp_cuid=exp_cuid)
     assert isinstance(res, ApiResponse)
     if res.code == 200:
         assert isinstance(res.data, Experiment)
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
-def test_get_project_exps():
+def test_list_project_exps():
     """
     获取一个项目下的实验列表
     """
     api = OpenApi()
-    res = api.get_project_exps(project="test_project", page=1, size=10, username="test")
+    res = api.list_project_exps(project="SwanLab")
     assert isinstance(res, ApiResponse)
     if res.code == 200:
-        assert isinstance(res.data, Pagination)
-        assert isinstance(res.data.total, int)
-        assert isinstance(res.data.list, list)
-        for item in res.data.list:
+        assert isinstance(res.data, list)
+        for item in res.data:
             assert isinstance(item, Experiment)
 

--- a/test/unit/api/openapi/test_group.py
+++ b/test/unit/api/openapi/test_group.py
@@ -22,7 +22,6 @@ def test_get_workspaces():
     """
     api = OpenApi()
     r = api.list_workspaces()
-    print(r)
 
     assert isinstance(r, ApiResponse)
     assert isinstance(r.data, list)

--- a/test/unit/api/openapi/test_project.py
+++ b/test/unit/api/openapi/test_project.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/8 16:14
+@File: test_project.py
+@IDE: VSCode
+@Description:
+    测试开放API的项目相关接口
+"""
+
+import pytest
+
+import tutils as T
+from swanlab import OpenApi
+
+
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+def test_list_projects():
+    """
+    测试列出一个 workspace 下的所有项目
+    """
+    api = OpenApi()
+    res = api.list_projects(detail=False)
+    assert isinstance(res, dict)
+    assert "total" in res
+    assert "list" in res
+    assert isinstance(res["total"], int)
+    assert isinstance(res["list"], list)
+    assert len(res["list"]) == res["total"]
+
+

--- a/test/unit/api/openapi/test_project.py
+++ b/test/unit/api/openapi/test_project.py
@@ -24,8 +24,6 @@ def test_list_projects():
     resp = api.list_projects(detail=False)
     assert isinstance(resp, ApiResponse)
     if resp.code == 200:
-        assert isinstance(resp.data, Pagination)
-        assert isinstance(resp.data.total, int)
-        assert isinstance(resp.data.list, list)
-        for item in resp.data.list:
+        assert isinstance(resp.data, list)
+        for item in resp.data:
             assert isinstance(item, Project)

--- a/test/unit/api/openapi/test_project.py
+++ b/test/unit/api/openapi/test_project.py
@@ -12,6 +12,7 @@ import pytest
 
 import tutils as T
 from swanlab import OpenApi
+from swanlab.api.openapi.types import ApiResponse, Project, Pagination
 
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
@@ -20,12 +21,11 @@ def test_list_projects():
     测试列出一个 workspace 下的所有项目
     """
     api = OpenApi()
-    res = api.list_projects(detail=False)
-    assert isinstance(res, dict)
-    assert "total" in res
-    assert "list" in res
-    assert isinstance(res["total"], int)
-    assert isinstance(res["list"], list)
-    assert len(res["list"]) == res["total"]
-
-
+    resp = api.list_projects(detail=False)
+    assert isinstance(resp, ApiResponse)
+    if resp.code == 200:
+        assert isinstance(resp.data, Pagination)
+        assert isinstance(resp.data.total, int)
+        assert isinstance(resp.data.list, list)
+        for item in resp.data.list:
+            assert isinstance(item, Project)


### PR DESCRIPTION
## 获取1个workspace下的project列表
- API 文档：https://github.com/SwanHubX/SwanLab-Server/blob/main/docs/api/project.md#%E5%88%97%E5%87%BA%E7%BB%84%E7%BB%87%E6%89%80%E6%9C%89%E9%A1%B9%E7%9B%AE


## 请求与响应：
```
列出一个 workspace 下的所有项目

Args:
    username (str): 工作空间名, 默认为用户个人空间
    detail (bool): 是否包含项目下实验的相关信息，默认为 True
    page (int): 页码, 默认为 1
    size (int): 每页大小, 默认为 20

Returns:
    dict: 项目列表信息的字典, 包含以下字段:
        - code (int): HTTP 错误代码
        - errmsg (str): 错误信息, 仅在请求有错误时非空
        - data (Pagination[Project]): 项目列表, 包含以下字段:
            - total (int): 指定工作空间下的项目总数
            - list (list[Project]): 项目列表, 每个元素都是项目信息的字典, 包含项目信息 （list 长度与 p对应page页的size 一致）

Project 包括如下字段信息:
     - cuid (str): 项目的唯一标识符
     - name (str): 项目名称
     - description (str): 项目描述
     - visibility (str): 项目可见性, 如 'PUBLIC' 或 'PRIVATE'
     - createdAt (str): 项目创建时间, 格式如 '2025-01-06T14:25:29.075Z'
     - updatedAt (str): 项目更新时间, 格式如 '2025-02-21T09:31:11.473Z'
     - path (str): 项目路径
     - group (dict): 项目所属组信息, 包含以下字段:
         - type (str): 组类型, 如 'PERSON' 或 'TEAM'
         - username (str): 组用户名
         - name (str): 组名称(可能为null)
                    
     - _count (dict): 仅当detail=True时返回, 包含以下字段:
                    
         - experiments (int): 项目中的实验数量
         - contributors (int): 项目贡献者数量
         - children (int): 子项目数量
         - runningExps (int): 正在运行的实验数量
```

## Note
- 采用分页查询，默认按照 `page_size = 20` 逐页请求，响应合并到一个大数组中

关联ISSUE：
#960 