### PR TITLE
feat(openapi): types

### DIFF
--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -7,6 +7,7 @@ r"""
 @Description:
     SwanLab OpenAPI API基类
 """
+
 from functools import wraps
 
 from swanlab.api import LoginInfo

--- a/swanlab/api/openapi/base.py
+++ b/swanlab/api/openapi/base.py
@@ -7,50 +7,119 @@ r"""
 @Description:
     SwanLab OpenAPI API基类
 """
+import json
+from datetime import datetime, timezone
+from typing import Optional, Any
 
-from functools import wraps
+import requests
 
-from swanlab.api import LoginInfo
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
 from swanlab.api.http import HTTP
-from swanlab.error import ApiError
+from swanlab.api.openapi.types import ApiResponse
+from swanlab.package import get_package_version
+from swanlab.api import LoginInfo
+from swanlab.api.auth.login import login_by_key
+from swanlab.log.log import SwanLog
 
+_logger: Optional[SwanLog] = None
 
-def handle_api_error(func):
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        try:
-            return func(self, *args, **kwargs)
-        except ApiError as e:
-            return {"code": e.resp.status_code, "message": e.message}
+def get_logger(log_level: str = "info") -> SwanLog:
+    global _logger
+    if _logger is None:
+        _logger = SwanLog("swanlab.openapi", log_level)
+    else:
+        _logger.level = log_level
+    return _logger
 
-    return wrapper
+def handle_response(resp: requests.Response) -> ApiResponse:
+    try:
+        data = resp.json()
+    except (json.decoder.JSONDecodeError, requests.JSONDecodeError):
+        return ApiResponse[str](
+            code=resp.status_code,
+            errmsg="sdk decode json error",
+            data=resp.text
+        )
+
+    if not isinstance(data, dict):
+        return ApiResponse[Any](
+            code=resp.status_code,
+            errmsg="sdk decode dict error",
+            data=data
+        )
+
+    code = resp.status_code
+    if 200 <= code < 300:
+        message = ""
+    else:
+        message = f"api error: {resp.reason}. Trace id: {resp.headers.get('traceid')}"
+    return ApiResponse(
+        code=code,
+        errmsg=message,
+        data=data
+    )
 
 
 class ApiHTTP:
+    REFRESH_TIME = HTTP.REFRESH_TIME
+
     def __init__(self, login_info: LoginInfo):
-        self.__http: HTTP = HTTP(login_info)
+        self.__logger = get_logger()
+        self.__login_info: LoginInfo = login_info
+        self.__session: requests.Session = self.__init_session()
 
     @property
     def username(self):
         """
         当前登录的用户名
         """
-        return self.http.username
+        return self.__login_info.username
 
     @property
-    def http(self) -> HTTP:
-        """
-        当前使用的HTTP对象
-        """
-        return self.__http
+    def base_url(self):
+        return self.__login_info.api_host
 
-    @handle_api_error
-    def get(self, url: str, params: dict = None):
-        return self.http.get(url=url, params=params)
+    @property
+    def sid_expired_at(self):
+        """
+        获取sid的过期时间，字符串格式转时间
+        """
+        return datetime.strptime(self.__login_info.expired_at, "%Y-%m-%dT%H:%M:%S.%fZ")
 
-    @handle_api_error
-    def post(self, url: str, data: dict = None):
-        return self.http.post(url=url, data=data)
+    def __init_session(self) -> requests.Session:
+        session = requests.Session()
+        session.mount(
+            prefix="https://",
+            adapter=HTTPAdapter(
+                max_retries=Retry(
+                    total=3,
+                    backoff_factor=0.1,
+                    status_forcelist=[500, 502, 503, 504],
+                    allowed_methods=(["GET", "POST", "PUT", "DELETE", "PATCH"])
+                )
+            )
+        )
+        session.headers["swanlab-sdk"] = get_package_version()
+        session.cookies.update({"sid": self.__login_info.sid})
+        return session
+
+    def __before_request(self):
+        if (self.sid_expired_at - datetime.now(timezone.utc).replace(tzinfo=None)).total_seconds() < self.REFRESH_TIME:
+            self.__logger.debug("Refreshing sid...")
+            self.__login_info = login_by_key(self.__login_info.api_key, save=False)
+            self.__session.headers["cookie"] = f"sid={self.__login_info.sid}"
+
+    def get(self, url: str, params: dict = None) -> ApiResponse:
+        self.__before_request()
+        resp = self.__session.get(self.base_url + url, params=params)
+        return handle_response(resp)
+
+    def post(self, url: str, data: dict = None) -> ApiResponse:
+        self.__before_request()
+        resp = self.__session.post(self.base_url + url, json=data)
+        return handle_response(resp)
 
 
 class ApiBase:

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -7,6 +7,8 @@ r"""
 @Description:
     实验相关的开放API
 """
+from typing import Dict, Union, List, Tuple
+
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
 from swanlab.api.openapi.types import Experiment, ExperimentProfile, ApiErrorResponse
 
@@ -41,7 +43,7 @@ class ExperimentAPI(ApiBase):
             "conda": res.get("conda", "")
         }
 
-    def get_exp_state(self, username: str, projname: str, expid: str) -> dict | ApiErrorResponse:
+    def get_exp_state(self, username: str, projname: str, expid: str) -> Union[Dict, ApiErrorResponse]:
         """
         获取实验状态
 
@@ -52,7 +54,7 @@ class ExperimentAPI(ApiBase):
         """
         return self.http.get(f"/project/{username}/{projname}/runs/{expid}/state")
 
-    def get_experiment(self, username: str, projname: str, expid: str) -> Experiment | ApiErrorResponse:
+    def get_experiment(self, username: str, projname: str, expid: str) -> Union[Experiment, ApiErrorResponse]:
         """
         获取实验信息
 
@@ -72,7 +74,7 @@ class ExperimentAPI(ApiBase):
             projname: str,
             page: int = 1,
             size: int = 10
-    ) -> tuple[list[Experiment], int] | ApiErrorResponse:
+    ) -> Union[Tuple[List[Experiment], int], ApiErrorResponse]:
         """
         分页获取项目下的实验列表
 

--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -8,13 +8,40 @@ r"""
     实验相关的开放API
 """
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
+from swanlab.api.openapi.types import Experiment, ExperimentProfile, ApiErrorResponse
 
 
 class ExperimentAPI(ApiBase):
     def __init__(self, http: ApiHTTP):
         super().__init__(http)
 
-    def get_exp_state(self, username: str, projname: str, expid: str):
+    @classmethod
+    def parse(cls, res: dict) -> Experiment:
+        return {
+            "cuid": res.get("cuid", ""),
+            "name": res.get("name", ""),
+            "description": res.get("description", ""),
+            "state": res.get("state", ""),
+            "show": res.get("show", ""),
+            "createdAt": res.get("createdAt", ""),
+            "finishedAt": res.get("finishedAt", ""),
+            "user": {
+                "username": res.get("user").get("username", ""),
+                "name": res.get("user").get("name", ""),
+            },
+            "profile": cls.parse_profile(res.get("profile", {})),
+        }
+
+    @classmethod
+    def parse_profile(cls, res: dict) -> ExperimentProfile:
+        return {
+            "config": res.get("config", {}),
+            "metadata": res.get("metadata", {}),
+            "requirements": res.get("requirements", ""),
+            "conda": res.get("conda", "")
+        }
+
+    def get_exp_state(self, username: str, projname: str, expid: str) -> dict | ApiErrorResponse:
         """
         获取实验状态
 
@@ -25,7 +52,7 @@ class ExperimentAPI(ApiBase):
         """
         return self.http.get(f"/project/{username}/{projname}/runs/{expid}/state")
 
-    def get_experiment(self, username: str, projname: str, expid: str):
+    def get_experiment(self, username: str, projname: str, expid: str) -> Experiment | ApiErrorResponse:
         """
         获取实验信息
 
@@ -37,22 +64,15 @@ class ExperimentAPI(ApiBase):
         resp = self.http.get(f"/project/{username}/{projname}/runs/{expid}")
         if "code" in resp:
             return resp
-        return {
-            "cuid": resp.get("cuid"),
-            "name": resp.get("name"),
-            "description": resp.get("description"),
-            "state": resp.get("state"),
-            "show": resp.get("show"),
-            "createdAt": resp.get("createdAt"),
-            "finishedAt": resp.get("finishedAt"),
-            "user": {
-                "username": resp.get("user").get("username"),
-                "name": resp.get("user").get("name"),
-            },
-            "profile": resp.get("profile"),
-        }
+        return ExperimentAPI.parse(resp)
 
-    def get_project_exps(self, username: str, projname: str, page: int = 1, size: int = 10):
+    def get_project_exps(
+            self,
+            username: str,
+            projname: str,
+            page: int = 1,
+            size: int = 10
+    ) -> tuple[list[Experiment], int] | ApiErrorResponse:
         """
         分页获取项目下的实验列表
 
@@ -65,23 +85,4 @@ class ExperimentAPI(ApiBase):
         resp = self.http.get(f"/project/{username}/{projname}/runs", params={"page": page, "size": size})
         if "code" in resp:
             return resp
-        return {
-            "total": resp["total"],
-            "exps": [
-                {
-                    "cuid": e.get("cuid"),
-                    "name": e.get("name"),
-                    "description": e.get("description"),
-                    "state": e.get("state"),
-                    "show": e.get("show"),
-                    "createdAt": e.get("createdAt"),
-                    "finishedAt": e.get("finishedAt"),
-                    "user": {
-                        "username": e.get("user").get("username"),
-                        "name": e.get("user").get("name"),
-                    },
-                    "profile": e.get("profile")
-                }
-                for e in resp["list"]
-            ]
-        }
+        return [ExperimentAPI.parse(e) for e in resp.get("list", [])], resp.get("total", 0)

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -7,21 +7,26 @@ r"""
 @Description:
     组织相关的开放API
 """
-from typing import Union, List
 
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
-from swanlab.api.openapi.types import ApiErrorResponse
+from swanlab.api.openapi.types import ApiResponse
 
 
 class GroupAPI(ApiBase):
     def __init__(self, http: ApiHTTP):
         super().__init__(http)
 
-    def list_workspaces(self) -> Union[List, ApiErrorResponse]:
+    def list_workspaces(self) -> ApiResponse[list]:
         resp = self.http.get("/group/")
-        if "code" in resp:
+        if resp.errmsg:
             return resp
-        return [
-            {"name": item["name"], "username": item["username"], "role": item["role"]}
-            for item in resp.get("list", [])
+        groups = resp.data.get("list", [])
+        resp.data = [
+            {
+                "name": item["name"],
+                "username": item["username"],
+                "role": item["role"]
+            }
+            for item in groups
         ]
+        return resp

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -9,18 +9,18 @@ r"""
 """
 
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
+from swanlab.api.openapi.types import ApiErrorResponse
 
 
 class GroupAPI(ApiBase):
     def __init__(self, http: ApiHTTP):
         super().__init__(http)
 
-    def list_workspaces(self):
+    def list_workspaces(self) -> list | ApiErrorResponse:
         resp = self.http.get("/group/")
-        if isinstance(resp, dict) and "code" not in resp:
-            groups: list = [
-                {"name": item["name"], "username": item["username"], "role": item["role"]}
-                for item in resp.get("list", [])
-            ]
-            return groups
-        return resp
+        if "code" in resp:
+            return resp
+        return [
+            {"name": item["name"], "username": item["username"], "role": item["role"]}
+            for item in resp.get("list", [])
+        ]

--- a/swanlab/api/openapi/group.py
+++ b/swanlab/api/openapi/group.py
@@ -7,6 +7,7 @@ r"""
 @Description:
     组织相关的开放API
 """
+from typing import Union, List
 
 from swanlab.api.openapi.base import ApiBase, ApiHTTP
 from swanlab.api.openapi.types import ApiErrorResponse
@@ -16,7 +17,7 @@ class GroupAPI(ApiBase):
     def __init__(self, http: ApiHTTP):
         super().__init__(http)
 
-    def list_workspaces(self) -> list | ApiErrorResponse:
+    def list_workspaces(self) -> Union[List, ApiErrorResponse]:
         resp = self.http.get("/group/")
         if "code" in resp:
             return resp

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -14,6 +14,7 @@ from swanlab.api.openapi.experiment import ExperimentAPI
 from swanlab.api.openapi.group import GroupAPI
 from swanlab.api import code_login
 from swanlab.api.openapi.project import ProjectAPI
+from swanlab.api.openapi.types import Experiment, ApiErrorResponse
 from swanlab.error import KeyFileError
 from swanlab.log.log import SwanLog
 from swanlab.package import get_key
@@ -50,23 +51,23 @@ class OpenApi:
         """
         return self.__http
 
-    def list_workspaces(self):
+    def list_workspaces(self) -> dict | ApiErrorResponse:
         """
         获取当前用户的所有工作空间(Group)
 
         Returns:
-            list[dict]: 一个列表, 其中每个元素是一个字典, 包含相应工作空间的基础信息:
-                - name (str): 工作空间名称
-                - username (str): 工作空间名(用于组织相关的 URL)
-                - role (str): 用户在该工作空间中的角色，如 'OWNER' 或 'MEMBER'
-
-            若请求失败, 将返回包含以下字段的字典:
-                - code (int): HTTP 错误代码
-                - message (str): 错误信息
+            dict | ApiErrorResponse:
+                - list[dict]: 一个列表, 其中每个元素是一个字典, 包含相应工作空间的基础信息:
+                    - name (str): 工作空间名称
+                    - username (str): 工作空间名(用于组织相关的 URL)
+                    - role (str): 用户在该工作空间中的角色，如 'OWNER' 或 'MEMBER'
+                - ApiErrorResponse: 若请求失败, 将返回包含以下字段的字典:
+                    - code (int): HTTP 错误代码
+                    - message (str): 错误信息
         """
         return self.group.list_workspaces()
 
-    def get_exp_state(self, project: str, exp_cuid: str, username: Optional[str] = None):
+    def get_exp_state(self, project: str, exp_cuid: str, username: Optional[str] = None) -> dict | ApiErrorResponse:
         """
         获取实验状态
 
@@ -76,13 +77,14 @@ class OpenApi:
            username (Optional[str]): 工作空间名, 默认为用户个人空间
 
         Returns:
-            dict: 实验状态的字典, 包含以下字段:
-                - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
-                - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
+            dict | ApiErrorResponse:
+                - dict: 实验状态的字典, 包含以下字段:
+                    - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
+                    - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
+                - ApiErrorResponse: 若请求失败, 返回此包含以下字段的字典:
+                    - code (int): HTTP错误码
+                    - message (str): 错误信息
 
-            若请求失败, 将返回包含以下字段的字典:
-                - code (int): HTTP 错误代码
-                - message (str): 错误信息
         """
         return self.experiment.get_exp_state(
             username=username if username else self.http.username,
@@ -90,7 +92,11 @@ class OpenApi:
             expid=exp_cuid
         )
 
-    def get_experiment(self, project: str, exp_cuid: str, username: Optional[str] = None):
+    def get_experiment(
+            self,project: str,
+            exp_cuid: str,
+            username: Optional[str] = None
+    ) -> Experiment | ApiErrorResponse:
         """
         获取实验信息
 
@@ -100,24 +106,11 @@ class OpenApi:
             username (Optional[str]): 工作空间名, 默认为用户个人空间
 
         Returns:
-            dict: 实验信息的字典, 包含以下字段:
-                - cuid (str): 实验的唯一标识符
-                - name (str): 实验名称
-                - description (str): 实验描述
-                - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
-                - show (bool): 显示状态
-                - createdAt (str): 实验创建时间, 格式如 '2024-11-23T12:28:04.286Z'
-                - finishedAt (str): 实验完成时间（若有）, 格式同上
-                - user (dict): 实验创建者的 'username' 与 'name'
-                - profile (dict): 实验配置文件, 包含以下字段:
-                    - config (dict): 实验的配置参数
-                    - metadata (dict): 实验的元数据
-                    - requirements (str): 实验的依赖项
-                    - conda (str): 实验的 Conda 环境信息
-
-            若请求失败, 将返回包含以下字段的字典:
-                - code (int): HTTP 错误代码
-                - message (str): 错误信息
+            Experiment | ApiErrorResponse:
+                - Experiment: 实验信息的字典, 包含实验信息
+                - ApiErrorResponse: 若请求失败, 返回此包含以下字段的字典:
+                    - code (int): HTTP错误码
+                    - message (str): 错误信息
         """
         return self.experiment.get_experiment(
             username=username if username else self.http.username,
@@ -125,7 +118,13 @@ class OpenApi:
             expid=exp_cuid
         )
 
-    def get_project_exps(self, project: str, page: int = 1, size: int = 10, username: Optional[str] = None):
+    def get_project_exps(
+            self,
+            project: str,
+            page: int = 1,
+            size: int = 10,
+            username: Optional[str] = None
+    ) -> tuple[list[Experiment], int] | ApiErrorResponse:
         """
         获取项目下的实验列表(分页)
 
@@ -136,26 +135,13 @@ class OpenApi:
             size (int): 每页大小, 默认为10
 
         Returns:
-            dict: 实验列表分页信息的字典, 包含以下字段:
-                - total (int): 实验总数
-                - exps (list[dict]): 实验列表, 每个实验包含以下字段:
-                    - cuid (str): 实验cuid
-                    - name (str): 实验名称
-                    - description (str): 实验描述
-                    - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
-                    - show (bool): 显示状态
-                    - createdAt (str): 创建时间, 格式如 '2024-11-23T12:28:04.286Z'
-                    - finishedAt (str): 完成时间（若有）, 格式同上
-                    - user (dict): 实验创建者的 'username' 与 'name'
-                    - profile (dict): 实验配置文件, 包含以下字段:
-                        - config (dict): 实验的配置参数
-                        - metadata (dict): 实验的元数据
-                        - requirements (str): 实验的依赖项
-                        - conda (str): 实验的 Conda 环境信息
-
-            若请求失败, 将返回包含以下字段的字典:
-                - code (int): HTTP 错误代码
-                - message (str): 错误信息
+            tuple[list[Experiment], int] | ApiErrorResponse:
+                - tuple[list[Experiment], int]:
+                    - list[Experiment]: 实验列表, 每个实验的字典包含实验信息
+                    - int: 实验总数
+                - ApiErrorResponse: 若请求失败, 返回此包含以下字段的字典:
+                    - code (int): HTTP错误码
+                    - message (str): 错误信息
         """
         return self.experiment.get_project_exps(
             username=username if username else self.http.username,

--- a/swanlab/api/openapi/main.py
+++ b/swanlab/api/openapi/main.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     SwanLab OpenAPI模块
 """
-from typing import Optional
+from typing import Dict, Optional, Union, Tuple, List
 
 from swanlab.api.openapi.base import ApiHTTP
 from swanlab.api.openapi.experiment import ExperimentAPI
@@ -51,12 +51,12 @@ class OpenApi:
         """
         return self.__http
 
-    def list_workspaces(self) -> dict | ApiErrorResponse:
+    def list_workspaces(self) -> Union[Dict, ApiErrorResponse]:
         """
         获取当前用户的所有工作空间(Group)
 
         Returns:
-            dict | ApiErrorResponse:
+            Union[Dict, ApiErrorResponse]:
                 - list[dict]: 一个列表, 其中每个元素是一个字典, 包含相应工作空间的基础信息:
                     - name (str): 工作空间名称
                     - username (str): 工作空间名(用于组织相关的 URL)
@@ -67,7 +67,12 @@ class OpenApi:
         """
         return self.group.list_workspaces()
 
-    def get_exp_state(self, project: str, exp_cuid: str, username: Optional[str] = None) -> dict | ApiErrorResponse:
+    def get_exp_state(
+            self,
+            project: str,
+            exp_cuid: str,
+            username: Optional[str] = None
+    ) -> Union[Dict, ApiErrorResponse]:
         """
         获取实验状态
 
@@ -77,7 +82,7 @@ class OpenApi:
            username (Optional[str]): 工作空间名, 默认为用户个人空间
 
         Returns:
-            dict | ApiErrorResponse:
+            Union[Dict, ApiErrorResponse]:
                 - dict: 实验状态的字典, 包含以下字段:
                     - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
                     - finishedAt (str): 实验完成时间（若有）, 格式如 '2024-11-23T12:28:04.286Z'
@@ -96,7 +101,7 @@ class OpenApi:
             self,project: str,
             exp_cuid: str,
             username: Optional[str] = None
-    ) -> Experiment | ApiErrorResponse:
+    ) -> Union[Experiment, ApiErrorResponse]:
         """
         获取实验信息
 
@@ -106,7 +111,7 @@ class OpenApi:
             username (Optional[str]): 工作空间名, 默认为用户个人空间
 
         Returns:
-            Experiment | ApiErrorResponse:
+            Union[Experiment, ApiErrorResponse]:
                 - Experiment: 实验信息的字典, 包含实验信息
                 - ApiErrorResponse: 若请求失败, 返回此包含以下字段的字典:
                     - code (int): HTTP错误码
@@ -124,7 +129,7 @@ class OpenApi:
             page: int = 1,
             size: int = 10,
             username: Optional[str] = None
-    ) -> tuple[list[Experiment], int] | ApiErrorResponse:
+    ) -> Union[Tuple[List[Experiment], int], ApiErrorResponse]:
         """
         获取项目下的实验列表(分页)
 
@@ -135,7 +140,7 @@ class OpenApi:
             size (int): 每页大小, 默认为10
 
         Returns:
-            tuple[list[Experiment], int] | ApiErrorResponse:
+            Union[Tuple[List[Experiment], int], ApiErrorResponse]:
                 - tuple[list[Experiment], int]:
                     - list[Experiment]: 实验列表, 每个实验的字典包含实验信息
                     - int: 实验总数

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/8 14:36
+@File: types.py
+@IDE: pycharm
+@Description:
+    OpenAPI 相关数据结构
+"""
+
+from typing import TypedDict, Optional, Dict
+
+
+class ExperimentProfile(TypedDict):
+    config: Dict        # 实验配置参数
+    metadata: Dict      # 实验元数据
+    requirements: str   # 实验依赖项
+    conda: str          # 实验的 Conda 环境信息
+
+class Experiment(TypedDict):
+    cuid: str   # 实验CUID, 唯一标识符
+    name: str   # 实验名
+    description: str    # 实验描述
+    state: str          # 实验状态, 'FINISHED' 或 'RUNNING'
+    show: str           # 显示状态, 'true' 或 'false'
+    createdAt: str              # e.g., '2024-11-23T12:28:04.286Z'
+    finishedAt: Optional[str]   # e.g., '2024-11-23T12:28:04.286Z', 若不存在则为 None
+    user: Dict[str, str]        # 实验创建者, 包含 'username' 与 'name'
+    profile: ExperimentProfile  # 实验相关配置
+
+class ApiErrorResponse(TypedDict):
+    code: int       # HTTP错误代码
+    message: str    # API错误消息

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -8,26 +8,27 @@ r"""
     OpenAPI 相关数据结构
 """
 
-from typing import TypedDict, Optional, Dict
+from typing import Optional, Dict, TypeVar, Generic, List
+from pydantic import BaseModel
 
-
-class ExperimentProfile(TypedDict):
-    config: Dict        # 实验配置参数
-    metadata: Dict      # 实验元数据
-    requirements: str   # 实验依赖项
-    conda: str          # 实验的 Conda 环境信息
-
-class Experiment(TypedDict):
+class Experiment(BaseModel):
     cuid: str   # 实验CUID, 唯一标识符
     name: str   # 实验名
-    description: str    # 实验描述
+    description: Optional[str]    # 实验描述
     state: str          # 实验状态, 'FINISHED' 或 'RUNNING'
-    show: str           # 显示状态, 'true' 或 'false'
+    show: bool           # 显示状态
     createdAt: str              # e.g., '2024-11-23T12:28:04.286Z'
     finishedAt: Optional[str]   # e.g., '2024-11-23T12:28:04.286Z', 若不存在则为 None
     user: Dict[str, str]        # 实验创建者, 包含 'username' 与 'name'
-    profile: ExperimentProfile  # 实验相关配置
+    profile: Dict  # 实验相关配置
 
-class ApiErrorResponse(TypedDict):
-    code: int       # HTTP错误代码
-    message: str    # API错误消息
+D = TypeVar("D")
+
+class ApiResponse(BaseModel, Generic[D]):
+    code: int       # HTTP状态码
+    errmsg: str    # API错误消息, 只有请求错误时非空
+    data: D  # 返回数据
+
+class Pagination(BaseModel, Generic[D]):
+    total: int  # 总数
+    list: List[D]  # 列表数据，类型为泛型 T

--- a/test/unit/api/openapi/test_experiment.py
+++ b/test/unit/api/openapi/test_experiment.py
@@ -12,6 +12,7 @@ import pytest
 
 import tutils as T
 from swanlab import OpenApi
+from swanlab.api.openapi.types import ApiResponse, Experiment, Pagination
 
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
@@ -21,13 +22,9 @@ def test_get_exp_state():
     """
     api = OpenApi()
     res = api.get_exp_state(project="test_project", exp_cuid="test_cuid", username="test")
-    # 仅 404 情况
-    assert isinstance(res, dict)
-    assert "state" in res or "code" in res
-    if "code" in res:
-        assert res["code"] == 404
-    elif "state" in res:
-        assert res["state"] == "FINISHED" or res["state"] == "RUNNING"
+    assert isinstance(res, ApiResponse)
+    if res.code == 200:
+        assert res.state == "FINISHED" or res.state == "RUNNING"
 
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
@@ -38,24 +35,9 @@ def test_get_experiment():
     api = OpenApi()
     exp_cuid = "test_cuid"
     res = api.get_experiment(project="test_project", exp_cuid=exp_cuid, username="test")
-    # 仅 404 情况
-    assert isinstance(res, dict)
-    assert "name" in res or "code" in res
-    if "code" in res:
-        assert res["code"] == 404
-    elif "name" in res:
-        assert res["cuid"] == exp_cuid
-        assert isinstance(res["name"], str)
-        assert isinstance(res["description"], str | None)
-        assert isinstance(res["state"], str)
-        assert isinstance(res["createdAt"], str)
-        assert isinstance(res["finishedAt"], str | None)
-        assert isinstance(res["profile"], dict | None)
-        if res["profile"] is not None:
-            assert isinstance(res["profile"].get("config"), dict | None)
-            assert isinstance(res["profile"].get("metadata"), dict | None)
-            assert isinstance(res["profile"].get("requirements"), str | None)
-            assert isinstance(res["profile"].get("conda"), str | None)
+    assert isinstance(res, ApiResponse)
+    if res.code == 200:
+        assert isinstance(res.data, Experiment)
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
 def test_get_project_exps():
@@ -64,10 +46,11 @@ def test_get_project_exps():
     """
     api = OpenApi()
     res = api.get_project_exps(project="test_project", page=1, size=10, username="test")
-    # 仅 404 情况
-    assert isinstance(res, dict)
-    assert "exps" in res or "code" in res
-    if "code" in res:
-        assert res["code"] == 404
-    elif "exps" in res:
-        assert len(res["exps"]) > 0
+    assert isinstance(res, ApiResponse)
+    if res.code == 200:
+        assert isinstance(res.data, Pagination)
+        assert isinstance(res.data.total, int)
+        assert isinstance(res.data.list, list)
+        for item in res.data.list:
+            assert isinstance(item, Experiment)
+

--- a/test/unit/api/openapi/test_experiment.py
+++ b/test/unit/api/openapi/test_experiment.py
@@ -20,7 +20,7 @@ def test_get_exp_state():
     获取一个实验的状态
     """
     api = OpenApi()
-    res = api.get_exp_state(project="test_project", exp_cuid="test_exp_cuid")
+    res = api.get_exp_state(project="test_project", exp_cuid="test_cuid", username="test")
     # 仅 404 情况
     assert isinstance(res, dict)
     assert "state" in res or "code" in res
@@ -36,8 +36,8 @@ def test_get_experiment():
     获取一个实验的详细信息
     """
     api = OpenApi()
-    exp_cuid = "ph3oj1b9of9dqj8e38jzl"
-    res = api.get_experiment(project="istprvdsbzpwmykkmxekb", exp_cuid=exp_cuid)
+    exp_cuid = "test_cuid"
+    res = api.get_experiment(project="test_project", exp_cuid=exp_cuid, username="test")
     # 仅 404 情况
     assert isinstance(res, dict)
     assert "name" in res or "code" in res
@@ -63,7 +63,7 @@ def test_get_project_exps():
     获取一个项目下的实验列表
     """
     api = OpenApi()
-    res = api.get_project_exps(project="test_project", page=1, size=10)
+    res = api.get_project_exps(project="test_project", page=1, size=10, username="test")
     # 仅 404 情况
     assert isinstance(res, dict)
     assert "exps" in res or "code" in res

--- a/test/unit/api/openapi/test_group.py
+++ b/test/unit/api/openapi/test_group.py
@@ -12,6 +12,7 @@ import pytest
 
 import tutils as T
 from swanlab import OpenApi
+from swanlab.api.openapi.types import ApiResponse
 
 
 @pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
@@ -21,14 +22,7 @@ def test_get_workspaces():
     """
     api = OpenApi()
     r = api.list_workspaces()
+    print(r)
 
-    assert isinstance(r, list)
-    if len(r) > 0:
-        for item in r:
-            assert isinstance(item, dict)
-            assert "name" in item
-            assert "username" in item
-            assert "role" in item
-            assert isinstance(item["name"], str | None)
-            assert isinstance(item["username"], str)
-            assert isinstance(item["role"], str)
+    assert isinstance(r, ApiResponse)
+    assert isinstance(r.data, list)


### PR DESCRIPTION
## Description

为 OpenApi 某些复杂响应添加类型约束, 取代原先的长篇注释, 对IDE提示更友好

现:

```python
from swanlab.api.openapi.types import Experiment, ApiErrorResponse

    def get_project_exps(
            self,
            project: str,
            page: int = 1,
            size: int = 10,
            username: Optional[str] = None
    ) -> tuple[list[Experiment], int] | ApiErrorResponse:
        """
        获取项目下的实验列表(分页)

        Args:
            project (str): 项目名
            username (Optional[str]): 工作空间名, 默认为用户个人空间
            page (int): 页码, 默认为1
            size (int): 每页大小, 默认为10

        Returns:
            tuple[list[Experiment], int] | ApiErrorResponse:
                - tuple[list[Experiment], int]:
                    - list[Experiment]: 实验列表, 每个实验的字典包含实验信息
                    - int: 实验总数
                - ApiErrorResponse: 若请求失败, 返回此包含以下字段的字典:
                    - code (int): HTTP错误码
                    - message (str): 错误信息
        """
        return self.experiment.get_project_exps(
            username=username if username else self.http.username,
            projname=project,
            page=page,
            size=size
        )
```

原:

```python
    def get_project_exps(
            self,
            project: str,
            page: int = 1,
            size: int = 10,
            username: Optional[str] = None
):
        """
        获取项目下的实验列表(分页)
        Args:
            project (str): 项目名
            username (Optional[str]): 工作空间名, 默认为用户个人空间
            page (int): 页码, 默认为1
            size (int): 每页大小, 默认为10

        Returns:
            dict: 实验列表分页信息的字典, 包含以下字段:
                - total (int): 实验总数
                - exps (list[dict]): 实验列表, 每个实验包含以下字段:
                    - cuid (str): 实验cuid
                    - name (str): 实验名称
                    - description (str): 实验描述
                    - state (str): 实验状态, 为 'FINISHED' 或 'RUNNING'
                    - show (bool): 显示状态
                    - createdAt (str): 创建时间, 格式如 '2024-11-23T12:28:04.286Z'
                    - finishedAt (str): 完成时间（若有）, 格式同上
                    - user (dict): 实验创建者的 'username' 与 'name'
                    - profile (dict): 实验配置文件, 包含以下字段:
                        - config (dict): 实验的配置参数
                        - metadata (dict): 实验的元数据
                        - requirements (str): 实验的依赖项
                        - conda (str): 实验的 Conda 环境信息
            若请求失败, 将返回包含以下字段的字典:
                - code (int): HTTP 错误代码
                - message (str): 错误信息
        """
        return self.experiment.get_project_exps(
            username=username if username else self.http.username,
            projname=project,
            page=page,
            size=size
        )
```