### PR TITLE
chore: revert upload column again

### DIFF
--- a/swanlab/api/upload/__init__.py
+++ b/swanlab/api/upload/__init__.py
@@ -9,7 +9,6 @@ r"""
 """
 from typing import List
 
-from swanlab.error import ApiError
 from swanlab.log import swanlog
 from .model import ColumnModel, MediaModel, ScalarModel, FileModel
 from ..http import get_http, sync_error_handler
@@ -94,18 +93,23 @@ def upload_files(files: List[FileModel]):
 
 
 @sync_error_handler
-def upload_column(columns: List[ColumnModel]):
+def upload_columns(columns: List[ColumnModel], per_request_len: int = 3000):
     """
-    但是在设计上是聚合上传的，所以在此处需要进行拆分然后分别上传
+    批量上传并创建 columns，每个请求的列长度有一个最大值
     """
     http = get_http()
-    url = f'/experiment/{http.exp_id}/column'
-    # WARNING 这里不能使用并发请求，可见 https://github.com/SwanHubX/SwanLab-Server/issues/113
-    for column in columns:
-        try:
-            http.post(url, column.to_dict())
-        except ApiError as e:
-            swanlog.error(f"Upload column {column.key} failed: {e.resp.status_code}")
+    url = f'/experiment/{http.exp_id}/columns'
+    # 将columns拆分成多个小的列表，每个列表的长度不能超过单个请求的最大长度
+    columns_list = []
+    columns_count = len(columns)
+    for i in range(0, columns_count, per_request_len):
+        columns_list.append([columns[i + j].to_dict() for j in range(min(per_request_len, columns_count - i))])
+    # 上传每个列表
+    for columns in columns_list:
+        # 如果列表长度为0，则跳过
+        if len(columns) == 0:
+            continue
+        http.post(url, columns)
 
 
 __all__ = [
@@ -113,7 +117,7 @@ __all__ = [
     "upload_media_metrics",
     "upload_scalar_metrics",
     "upload_files",
-    "upload_column",
+    "upload_columns",
     "ScalarModel",
     "MediaModel",
     "ColumnModel",

--- a/swanlab/data/cloud/task_types.py
+++ b/swanlab/data/cloud/task_types.py
@@ -13,6 +13,7 @@ r"""
 在本模块针对上述四种方式定义不同的类和不同的处理方式，每种类型对应一个数据上传接口
 """
 from enum import Enum
+
 from swanlab.api.upload import *
 
 
@@ -20,6 +21,7 @@ class UploadType(Enum):
     """
     上传类型枚举，在此处定义不同的处理方式
     """
+
     LOG = {
         "upload": upload_logs,
     }
@@ -50,7 +52,7 @@ class UploadType(Enum):
 
     COLUMN = {
         # 一次只能上传一个列，所以函数名不带s
-        "upload": upload_column,
+        "upload": upload_columns,
     }
     """
     上传列信息

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -49,7 +49,7 @@ class Settings(BaseModel):
     )
     # ---------------------------------- 日志上传部分 ----------------------------------
     # 日志上传间隔
-    upload_interval: PositiveInt = 1
+    upload_interval: PositiveInt = 3
     # 终端日志上传单行最大字符数
     max_log_length: int = Field(ge=500, le=4096, default=1024)
 


### PR DESCRIPTION
This pull request introduces a batch processing mechanism for column uploads, updates related references, and adjusts a default setting for log uploads. The most important changes are grouped and summarized below:

### Batch Processing for Column Uploads
* Modified `upload_column` to `upload_columns` in `swanlab/api/upload/__init__.py`, enabling batch uploads with a configurable maximum length per request (`per_request_len`). Columns are split into smaller lists and uploaded sequentially.
* Updated the `UploadType.COLUMN` configuration in `swanlab/data/cloud/task_types.py` to reference the new `upload_columns` function.

### Code Cleanup
* Removed the unused `ApiError` import from `swanlab/api/upload/__init__.py`.

### Log Upload Settings Adjustment
* Changed the default `upload_interval` in `swanlab/swanlab_settings.py` from 1 second to 3 seconds, increasing the interval between log uploads.

--- 

We will allow the concurrent creation of columns to reach 3000 per request.

closes #888 