### PR TITLE
feat(openapi): support dict-style access for object

### DIFF
--- a/swanlab/api/openapi/experiment.py
+++ b/swanlab/api/openapi/experiment.py
@@ -23,7 +23,7 @@ class ExperimentAPI(ApiBase):
             "name": body.get("name") or "",
             "description": body.get("description") or "",
             "state": body.get("state") or "",
-            "show": body.get("show") or "",
+            "show": bool(body.get("show")),
             "createdAt": body.get("createdAt") or "",
             "finishedAt": body.get("finishedAt") or "",
             "user": {

--- a/swanlab/api/openapi/types.py
+++ b/swanlab/api/openapi/types.py
@@ -10,7 +10,12 @@ r"""
 
 from typing import Dict, Generic, List, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel as PydanticBaseModel
+
+
+class BaseModel(PydanticBaseModel):
+    def __getitem__(self, key):
+        return getattr(self, key)
 
 
 class Experiment(BaseModel):

--- a/test/unit/api/openapi/test_types.py
+++ b/test/unit/api/openapi/test_types.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+r"""
+@DATE: 2025/5/14 22:25
+@File: test_types.py
+@IDE: pycharm
+@Description:
+    测试开放API模型定义
+"""
+
+import pytest
+
+import tutils as T
+from swanlab.api.openapi.types import Experiment
+
+
+def test_dict_style_access():
+    """
+    测试字典风格访问对象字段
+    """
+    exp = Experiment.model_validate({
+        "cuid": "test_cuid",
+        "name": "test_experiment",
+        "description": "test_description",
+        "state": "FINISHED",
+        "show": True,
+        "createdAt": "2025-05-14T22:25:00Z",
+        "finishedAt": "2025-05-14T22:30:00Z",
+        "user": {
+            "username": "test_user",
+            "name": "Test User"
+        },
+        "profile": {
+            "requirements": "test_requirements",
+        }
+    })
+    assert exp["cuid"] == "test_cuid"
+    


### PR DESCRIPTION
## Description

This PR enhances the usability of OpenAPI response objects by allowing both attribute-style and dictionary-style access.

### ✨ Feature

Support accessing OpenAPI response object fields via:

- obj.name
- obj.get("name")
- obj["name"]

> ⚠️ Note: The object supports dict-style access but is not a real dictionary.
> To get the actual dictionary representation, use obj.model_dump().

### 🐞 Fix

- Fixed a type error encountered during model conversion when using pydantic models.

---

Closes: #976 
