### PR TITLE
feat: security mask

### DIFF
--- a/swanlab/api/http.py
+++ b/swanlab/api/http.py
@@ -78,6 +78,10 @@ class HTTP:
         return self.__login_info.web_host
 
     @property
+    def api_key(self):
+        return self.__login_info.api_key
+
+    @property
     def web_host(self):
         return self.__login_info.web_host
 

--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -64,6 +64,8 @@ def _get_command() -> str:
         api_key = None
 
         # 尝试从不同来源获取API密钥
+        # 未登录时 get_http 抛出 ValueError，此时需要换用 get_key 继续尝试获取
+        # 未设置环境变量且未找到本地保存的 api key 时， get_key 抛出 KeyFileError，此时 api_key 为 None
         for key_provider in [lambda: get_http().api_key, get_key]:
             try:
                 api_key = key_provider()

--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -44,24 +44,16 @@ def get_python_info():
     }
 
 def _get_command():
-    """
-    获取当前执行的命令行字符串，并可选地屏蔽敏感API密钥
-    - setting.mask_api_key 为 false 时不屏蔽
-    - --swanlab-api-key 值不等于当前使用的 api key 时不屏蔽
-    :return:
-    """
+    """获取当前执行的命令行字符串，并可选地屏蔽敏感API密钥"""
     # 复制一份以免破坏全局
     args = sys.argv.copy()
-    api_arg = "--swanlab-api-key"
     mask = get_settings().security_mask
+    api_key = get_key()
 
     # 不满足屏蔽条件时略过
-    if not mask or api_arg not in args:
+    if not mask or api_key not in args:
         return " ".join(args)
-
-    index = args.index(api_arg) + 1
-    if index < len(args) and args[index] == get_key():
-        args[index] = "****"
+    args[args.index(api_key)] = "****"
     return " ".join(args)
 
 

--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -11,6 +11,7 @@ import socket
 import subprocess
 import sys
 
+from swanlab.api import get_http
 from swanlab.package import get_key
 from swanlab.swanlab_settings import get_settings
 
@@ -48,7 +49,10 @@ def _get_command():
     # 复制一份以免破坏全局
     args = sys.argv.copy()
     mask = get_settings().security_mask
-    api_key = get_key()
+    try:
+        api_key = get_http().api_key
+    except ValueError:
+        api_key = get_key()
 
     # 不满足屏蔽条件时略过
     if not mask or api_key not in args:

--- a/swanlab/data/run/metadata/runtime.py
+++ b/swanlab/data/run/metadata/runtime.py
@@ -11,6 +11,7 @@ import socket
 import subprocess
 import sys
 
+from swanlab.package import get_key
 from swanlab.swanlab_settings import get_settings
 
 
@@ -39,8 +40,29 @@ def get_python_info():
         "python": platform.python_version(),
         "python_verbose": sys.version,
         "executable": sys.executable,
-        "command": " ".join(sys.argv),
+        "command": _get_command(),
     }
+
+def _get_command():
+    """
+    获取当前执行的命令行字符串，并可选地屏蔽敏感API密钥
+    - setting.mask_api_key 为 false 时不屏蔽
+    - --swanlab-api-key 值不等于当前使用的 api key 时不屏蔽
+    :return:
+    """
+    # 复制一份以免破坏全局
+    args = sys.argv.copy()
+    api_arg = "--swanlab-api-key"
+    mask = get_settings().security_mask
+
+    # 不满足屏蔽条件时略过
+    if not mask or api_arg not in args:
+        return " ".join(args)
+
+    index = args.index(api_arg) + 1
+    if index < len(args) and args[index] == get_key():
+        args[index] = "****"
+    return " ".join(args)
 
 
 # ---------------------------------- git信息 ----------------------------------

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -35,6 +35,8 @@ class Settings(BaseModel):
     collect_hardware: StrictBool = True
     # 是否采集运行时信息（暂不支持更精细设置，有需求可以添加）
     collect_runtime: StrictBool = True
+    # 是否需要主动屏蔽启动命令中的 api key 等隐私信息，默认屏蔽
+    security_mask: StrictBool = True
     # ---------------------------------- 其他信息采集 ----------------------------------
     # 是否采集python环境信息
     requirements_collect: StrictBool = True

--- a/test/unit/data/run/metadata/test_runtime.py
+++ b/test/unit/data/run/metadata/test_runtime.py
@@ -22,23 +22,39 @@ def test_parse_git_url():
     assert parse_git_url("https://github.com/swanhubx/swanlab") == "https://github.com/swanhubx/swanlab"
     assert parse_git_url("https://localhost:8000/swanhubx/swanlab") == "https://localhost:8000/swanhubx/swanlab"
 
-def test_mask_api_key():
-    # 1 - 100 之间随机选取数组长度
-    length = random.randint(1, 100)
-    # 生成一个长度为 length 的随机字符串数组
-    args = [nanoid.generate(size=random.randint(1, 20)) for _ in range(length)]
-    sys.argv = args
+def test_mask_no_api_key():
+    """测试没有 api key 的情况下，是否替换"""
+    _mock_args()
     # 不含有 api key，不替换
     cmd = get_python_info()["command"]
     assert ("****" not in cmd) is True
+
+def test_mask_api_key_with_setting():
+    """
+    测试有 api key 的情况下，是否替换
+    - 设置 security_mask 为 True，替换
+    - 设置 security_mask 为 False，不替换
+    """
+    args = _mock_args()
     with UseSetupHttp() as http:
         api_key = http.api_key
-        # 存在 api key，替换
-        args[random.randint(0, length - 1)] = api_key
+
+        # 隐藏隐私信息
+        args[random.randint(0, len(args) - 1)] = api_key
         cmd = get_python_info()["command"]
         assert ("****" in cmd) is True
+
         # 设置为不主动替换隐私信息，即使有 api key 也不替换
         set_settings(Settings(security_mask=False))
         cmd = get_python_info()["command"]
         assert (api_key in cmd) is True
         assert ("****" not in cmd) is True
+
+def _mock_args():
+    """模拟生成一个随机长度的 args，并替换 sys.argv"""
+    # 1 - 100 之间随机选取数组长度
+    length = random.randint(1, 100)
+    # 生成一个长度为 length 的随机字符串数组
+    args = [nanoid.generate(size=random.randint(1, 20)) for _ in range(length)]
+    sys.argv = args
+    return args

--- a/test/unit/data/run/metadata/test_runtime.py
+++ b/test/unit/data/run/metadata/test_runtime.py
@@ -1,4 +1,12 @@
-from swanlab.data.run.metadata.runtime import parse_git_url
+import sys
+
+from swanlab import Settings
+from swanlab.data.run.metadata.runtime import parse_git_url, get_python_info
+import random
+import nanoid
+
+from swanlab.package import get_key
+from swanlab.swanlab_settings import set_settings
 
 
 def test_parse_git_url():
@@ -13,4 +21,23 @@ def test_parse_git_url():
     assert parse_git_url("git@localhost:8000/swanhubx/swanlab") == "https://localhost:8000/swanhubx/swanlab"
     assert parse_git_url("https://github.com/swanhubx/swanlab") == "https://github.com/swanhubx/swanlab"
     assert parse_git_url("https://localhost:8000/swanhubx/swanlab") == "https://localhost:8000/swanhubx/swanlab"
-    
+
+def test_mask_api_key():
+    # 1 - 100 之间随机选取数组长度
+    length = random.randint(1, 100)
+    api_key = get_key()
+    # 生成一个长度为 length 的随机字符串数组
+    args = [nanoid.generate(size=random.randint(1, 20)) for _ in range(length)]
+    sys.argv = args
+    # 不含有 api key，不替换
+    cmd = get_python_info()["command"]
+    assert ("****" not in cmd) is True
+    # 存在 api key，替换
+    args[random.randint(0, length - 1)] = api_key
+    cmd = get_python_info()["command"]
+    assert ("****" in cmd) is True
+    # 设置为不主动替换隐私信息，即使有 api key 也不替换
+    set_settings(Settings(security_mask=False))
+    cmd = get_python_info()["command"]
+    assert (api_key in cmd) is True
+    assert ("****" not in cmd) is True

--- a/test/unit/data/run/metadata/test_runtime.py
+++ b/test/unit/data/run/metadata/test_runtime.py
@@ -5,8 +5,8 @@ from swanlab.data.run.metadata.runtime import parse_git_url, get_python_info
 import random
 import nanoid
 
-from swanlab.package import get_key
 from swanlab.swanlab_settings import set_settings
+from tutils.setup import UseSetupHttp
 
 
 def test_parse_git_url():
@@ -25,19 +25,20 @@ def test_parse_git_url():
 def test_mask_api_key():
     # 1 - 100 之间随机选取数组长度
     length = random.randint(1, 100)
-    api_key = get_key()
     # 生成一个长度为 length 的随机字符串数组
     args = [nanoid.generate(size=random.randint(1, 20)) for _ in range(length)]
     sys.argv = args
     # 不含有 api key，不替换
     cmd = get_python_info()["command"]
     assert ("****" not in cmd) is True
-    # 存在 api key，替换
-    args[random.randint(0, length - 1)] = api_key
-    cmd = get_python_info()["command"]
-    assert ("****" in cmd) is True
-    # 设置为不主动替换隐私信息，即使有 api key 也不替换
-    set_settings(Settings(security_mask=False))
-    cmd = get_python_info()["command"]
-    assert (api_key in cmd) is True
-    assert ("****" not in cmd) is True
+    with UseSetupHttp() as http:
+        api_key = http.api_key
+        # 存在 api key，替换
+        args[random.randint(0, length - 1)] = api_key
+        cmd = get_python_info()["command"]
+        assert ("****" in cmd) is True
+        # 设置为不主动替换隐私信息，即使有 api key 也不替换
+        set_settings(Settings(security_mask=False))
+        cmd = get_python_info()["command"]
+        assert (api_key in cmd) is True
+        assert ("****" not in cmd) is True


### PR DESCRIPTION
## Description

添加 `swanlab.Settings` 字段 `security_mask`，用以替换隐私信息，如启动命令中的 api key。`security_mask` 默认启用。

Closes: #970 