### PR TITLE
fix: resend request when experiment does not exist

### DIFF
--- a/swanlab/api/http.py
+++ b/swanlab/api/http.py
@@ -176,7 +176,7 @@ class HTTP:
 
         self.__session = session
 
-    def post(self, url: str, data: dict | list = None):
+    def post(self, url: str, data: Union[dict, list] = None):
         """
         post请求
         """

--- a/swanlab/api/http.py
+++ b/swanlab/api/http.py
@@ -176,7 +176,7 @@ class HTTP:
 
         self.__session = session
 
-    def post(self, url: str, data: dict = None):
+    def post(self, url: str, data: dict | list = None):
         """
         post请求
         """

--- a/swanlab/api/upload/__init__.py
+++ b/swanlab/api/upload/__init__.py
@@ -118,7 +118,7 @@ def upload_columns(columns: List[ColumnModel], per_request_len: int = 3000):
                 resp = decode_response(e.resp)
                 if isinstance(resp, dict) and resp.get('code') == 'Disabled_Resource':
                     swanlog.warning(f"Experiment {http.exp_id} has been deleted, skipping column upload.")
-                    return None
+                    continue
             raise e
 
 

--- a/swanlab/api/upload/__init__.py
+++ b/swanlab/api/upload/__init__.py
@@ -116,9 +116,10 @@ def upload_columns(columns: List[ColumnModel], per_request_len: int = 3000):
             # 处理实验不存在的异常
             if e.resp.status_code == 404:
                 resp = decode_response(e.resp)
+                # 实验不存在，那么剩下的列也没有必要上传了，直接返回
                 if isinstance(resp, dict) and resp.get('code') == 'Disabled_Resource':
                     swanlog.warning(f"Experiment {http.exp_id} has been deleted, skipping column upload.")
-                    continue
+                    return None
             raise e
 
 


### PR DESCRIPTION
This pull request introduces improvements to the HTTP handling and error management in the `swanlab` API, including enhanced type annotations, better error handling for specific cases, and the addition of a new utility function. The most important changes are grouped below:

### HTTP Handling Enhancements:
* Updated the `post` method in `swanlab/api/http.py` to accept both dictionaries and lists as valid types for the `data` parameter, improving flexibility in HTTP requests. (`[swanlab/api/http.pyL179-R179](diffhunk://#diff-59d6f0332f63c34567b4c6ad36216611d1ec51e7a6f6fc991c360a2736b3f4ecL179-R179)`)

### Error Handling Improvements:
* Enhanced the `upload_columns` function in `swanlab/api/upload/__init__.py` to handle `ApiError` exceptions. Specifically, it now logs a warning and skips uploading columns if the resource is disabled (HTTP 404 with a specific error code). (`[swanlab/api/upload/__init__.pyR113-R122](diffhunk://#diff-7eef39be6eb534f3b784e5d8b8a0ea5882cc017cdc756d4c3ccfb01dde50ec9fR113-R122)`)

### Codebase Organization:
* Added imports for `decode_response` and `ApiError` in `swanlab/api/upload/__init__.py` to support the new error handling logic. (`[swanlab/api/upload/__init__.pyL14-R15](diffhunk://#diff-7eef39be6eb534f3b784e5d8b8a0ea5882cc017cdc756d4c3ccfb01dde50ec9fL14-R15)`)

---


We found that deleting an experiment while it is running causes duplicate error requests from the SDK, hence submitting this PR to fix the issue.
