### PR TITLE
fix: only all and stderr can upload error info

### DIFF
--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -221,6 +221,8 @@ class SwanLabRun:
         """
         if self.monitor_cron is not None:
             self.monitor_cron.cancel()
+        if get_settings().log_proxy_type not in ['stderr', 'all']:
+            error = None
         self.__operator.on_stop(error)
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description

This PR fix a bug from #988 , now only `all` and `stderr` can upload error info