### PR TITLE
feat: support DCU monitor

### DIFF
--- a/swanlab/data/run/metadata/hardware/__init__.py
+++ b/swanlab/data/run/metadata/hardware/__init__.py
@@ -12,7 +12,7 @@ from .disk import get_disk_info
 from .dcu.hygon import get_hygon_dcu_info
 from .gpu.nvidia import get_nvidia_gpu_info
 from .gpu.metax import get_metax_gpu_info
-from .gpu.moorethread import get_mtt_gpu_info
+from .gpu.moorethreads import get_moorethreads_gpu_info
 from .memory import get_memory_size
 from .mlu.cambricon import get_cambricon_mlu_info
 from .xpu.kunlunxin import get_kunlunxin_xpu_info
@@ -31,7 +31,7 @@ def get_hardware_info() -> Tuple[Optional[Any], List[HardwareCollector]]:
     monitor_funcs = []
     # 我们希望计算芯片的信息放在最前面，前端展示用
     nvidia = dec_hardware_func(get_nvidia_gpu_info, monitor_funcs)
-    moorethread = dec_hardware_func(get_mtt_gpu_info, monitor_funcs)
+    moorethreads = dec_hardware_func(get_moorethreads_gpu_info, monitor_funcs)
     ascend = dec_hardware_func(get_ascend_npu_info, monitor_funcs)
     cambricon = dec_hardware_func(get_cambricon_mlu_info, monitor_funcs)
     apple = dec_hardware_func(get_apple_chip_info, monitor_funcs)
@@ -57,8 +57,8 @@ def get_hardware_info() -> Tuple[Optional[Any], List[HardwareCollector]]:
     }
     if nvidia is not None:
         info["gpu"]["nvidia"] = nvidia
-    if moorethread is not None:
-        info["gpu"]["moorethread"] = moorethread
+    if moorethreads is not None:
+        info["gpu"]["moorethreads"] = moorethreads
     if metax is not None:
         info["gpu"]["metax"] = metax
     if ascend is not None:

--- a/swanlab/data/run/metadata/hardware/__init__.py
+++ b/swanlab/data/run/metadata/hardware/__init__.py
@@ -9,6 +9,7 @@ from typing import Callable, List, Any, Optional, Tuple
 
 from .cpu import get_cpu_info
 from .disk import get_disk_info
+from .dcu.hygon import get_hygon_dcu_info
 from .gpu.nvidia import get_nvidia_gpu_info
 from .gpu.metax import get_metax_gpu_info
 from .gpu.moorethread import get_mtt_gpu_info
@@ -36,6 +37,7 @@ def get_hardware_info() -> Tuple[Optional[Any], List[HardwareCollector]]:
     apple = dec_hardware_func(get_apple_chip_info, monitor_funcs)
     kunlunxin = dec_hardware_func(get_kunlunxin_xpu_info, monitor_funcs)
     metax = dec_hardware_func(get_metax_gpu_info, monitor_funcs)
+    hygon = dec_hardware_func(get_hygon_dcu_info, monitor_funcs)
     c = dec_hardware_func(get_cpu_info, monitor_funcs)
     m = dec_hardware_func(get_memory_size, monitor_funcs)
     d = dec_hardware_func(get_disk_info, monitor_funcs)
@@ -51,6 +53,7 @@ def get_hardware_info() -> Tuple[Optional[Any], List[HardwareCollector]]:
         "mlu": {},
         "xpu": {},
         "soc": {},
+        "dcu": {},
     }
     if nvidia is not None:
         info["gpu"]["nvidia"] = nvidia
@@ -66,6 +69,8 @@ def get_hardware_info() -> Tuple[Optional[Any], List[HardwareCollector]]:
         info["mlu"]["cambricon"] = cambricon
     if kunlunxin is not None:
         info["xpu"]["kunlunxin"] = kunlunxin
+    if hygon is not None:
+        info["dcu"]["hygon"] = hygon
     return filter_none(info, fallback={}), monitor_funcs
 
 

--- a/swanlab/data/run/metadata/hardware/dcu/hygon.py
+++ b/swanlab/data/run/metadata/hardware/dcu/hygon.py
@@ -1,0 +1,250 @@
+"""
+@author: caddiesnew
+@file: hygon.py
+@time: 2025-06-04 12:08:51
+@description: Hygon DCU 信息采集
+"""
+
+import json
+import math
+import platform
+import subprocess
+from typing import Optional, Tuple
+
+from ..type import HardwareCollector as H
+from ..type import HardwareConfig, HardwareFuncResult, HardwareInfoList
+from ..utils import generate_key, random_index
+
+
+def get_hygon_dcu_info() -> HardwareFuncResult:
+    """
+    获取 Hygon DCU信息，包括驱动版本、设备信息等
+    """
+    # Hygon DCU默认为Linux系统
+    if platform.system() != "Linux":
+        return None, None
+
+    info = {"driver": None, "dcu": None}
+    collector = None
+    try:
+        driver, dcu_map = map_hygon_dcu()
+        info["driver"] = driver
+        info["dcu"] = dcu_map
+        collector = DCUCollector(dcu_map)
+    except Exception:  # noqa
+        if all(v is None for v in info.values()):
+            return None, None
+    return info, collector
+
+
+def map_hygon_dcu() -> Tuple[Optional[str], dict]:
+    """
+    获取 Hygon DCU 信息，包括驱动版本、设备信息等，例如：
+    Driver Version: 6.2.28
+    {'0': {'name': 'K500SM_AI', 'memory': '64GB'}, '1': {'name': 'K500SM_AI', 'memory': '64GB',...}}
+    """
+    driver_info = subprocess.run(["hy-smi", "--showdriverversion"], capture_output=True, check=True, text=True).stdout
+    driver_version = None
+    for line in driver_info.split("\n"):
+        if "Driver Version" in line:
+            driver_version = line.split(":")[-1]
+            break
+
+    dcu_product_map_str = subprocess.run(
+        ["hy-smi", "--showproductname", "--json"],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    dcu_product_map = json.loads(dcu_product_map_str)
+
+    dcu_available_mem_str = subprocess.run(
+        ["hy-smi", "--showmemavailable", "--json"],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    dcu_available_mem_map = json.loads(dcu_available_mem_str)
+
+    dcu_map = {}
+    for idx, device_id in enumerate(dcu_product_map.keys()):
+        product_info = dcu_product_map.get(device_id, {})
+        device_name = product_info.get("Card Series", "Unknown")
+
+        available_info = dcu_available_mem_map.get(device_id, {})
+        available_mem = available_info.get("Available memory size (MiB)", "0")
+
+        try:
+            total_mem_gb = round(int(available_mem) / 1024)
+            mem_str = f"{total_mem_gb}GB"
+        except (ValueError, TypeError):
+            mem_str = "0GB"
+
+        dcu_map[str(idx)] = {"name": device_name, "memory": mem_str}
+    return driver_version, dcu_map
+
+
+class DCUCollector(H):
+    def __init__(self, dcu_map):
+        super().__init__()
+        self.dcu_map = dcu_map
+
+        # DCU Utilization (%)
+        self.util_key = generate_key("dcu.{dcu_index}.pct")
+        util_config = HardwareConfig(
+            y_range=(0, 100),
+            chart_index=random_index(),
+            chart_name="DCU Utilization (%)",
+        )
+        self.per_util_configs = {}
+
+        # DCU Memory Allocated (%)
+        self.memory_key = generate_key("dcu.{dcu_index}.mem.pct")
+        memory_config = HardwareConfig(
+            y_range=(0, 100),
+            chart_index=random_index(),
+            chart_name="DCU Memory Allocated (%)",
+        )
+        self.per_memory_configs = {}
+
+        # DCU Temperature (°C)
+        self.temp_key = generate_key("dcu.{dcu_index}.temp")
+        temp_config = HardwareConfig(
+            y_range=(0, None),
+            chart_index=random_index(),
+            chart_name="DCU Temperature (°C)",
+        )
+        self.per_temp_configs = {}
+
+        # DCU Power (W)
+        self.power_key = generate_key("dcu.{dcu_index}.power")
+        power_config = HardwareConfig(
+            y_range=(0, None),
+            chart_index=random_index(),
+            chart_name="DCU Power (W)",
+        )
+        self.per_power_configs = {}
+
+        for dcu_id in self.dcu_map:
+            metric_name = f"DCU {dcu_id}"
+            self.per_util_configs[metric_name] = util_config.clone(metric_name=metric_name)
+            self.per_memory_configs[metric_name] = memory_config.clone(metric_name=metric_name)
+            self.per_temp_configs[metric_name] = temp_config.clone(metric_name=metric_name)
+            self.per_power_configs[metric_name] = power_config.clone(metric_name=metric_name)
+
+    def collect(self) -> HardwareInfoList:
+        result: HardwareInfoList = []
+        usage_methods = [
+            self.get_utilization_usage,
+            self.get_memory_usage,
+            self.get_temperature_usage,
+            self.get_power_usage,
+        ]
+
+        for method in usage_methods:
+            result.extend(method().values())
+        return result
+
+    def get_utilization_usage(self) -> dict:
+        """
+        获取指定DCU设备的利用率
+        """
+        output_str = subprocess.run(
+            ["hy-smi", "--showuse", "--json"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        output_json = json.loads(output_str)
+        util_infos = {}
+        for idx, (dcu_key, dcu_info) in enumerate(output_json.items()):
+            dcu_id = str(idx)
+
+            util_infos[dcu_id] = {
+                "key": self.util_key.format(dcu_index=dcu_id),
+                "name": f"DCU {dcu_id} Utilization (%)",
+                "value": math.nan,
+                "config": self.per_util_configs[f"DCU {dcu_id}"],
+            }
+            dcu_utilization = dcu_info["DCU use (%)"]
+            util_infos[dcu_id]["value"] = float(dcu_utilization)
+        return util_infos
+
+    def get_memory_usage(self) -> dict:
+        """
+        获取指定DCU设备的内存占用率
+        """
+        output_str = subprocess.run(
+            ["hy-smi", "--showmemuse", "--json"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        output_json = json.loads(output_str)
+        mem_infos = {}
+
+        for idx, (dcu_key, dcu_info) in enumerate(output_json.items()):
+            dcu_id = str(idx)
+            mem_infos[dcu_id] = {
+                "key": self.memory_key.format(dcu_index=dcu_id),
+                "name": f"DCU {dcu_id} Memory Allocated (%)",
+                "value": math.nan,
+                "config": self.per_memory_configs[f"DCU {dcu_id}"],
+            }
+
+            dcu_mem_use = dcu_info["DCU memory use (%)"]
+            mem_infos[dcu_id]["value"] = float(dcu_mem_use)
+        return mem_infos
+
+    def get_temperature_usage(self) -> dict:
+        """
+        获取指定DCU设备的温度(°C) (默认采集显存温度）
+        {
+          "card0": {
+            "Temperature (Sensor edge) (C)": "52.0",
+            "Temperature (Sensor junction) (C)": "51.0",
+            "Temperature (Sensor mem) (C)": "52.0" // collected
+          }
+        }
+        """
+        output_str = subprocess.run(
+            ["hy-smi", "--showtemp", "--json"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        output_json = json.loads(output_str)
+        temp_infos = {}
+        for idx, (dcu_key, dcu_info) in enumerate(output_json.items()):
+            dcu_id = str(idx)
+
+            temp_infos[dcu_id] = {
+                "key": self.temp_key.format(dcu_index=dcu_id),
+                "name": f"DCU {dcu_id} Temperature (°C)",
+                "value": math.nan,
+                "config": self.per_temp_configs[f"DCU {dcu_id}"],
+            }
+            dcu_temp = dcu_info["Temperature (Sensor mem) (C)"]
+            temp_infos[dcu_id]["value"] = float(dcu_temp)
+        return temp_infos
+
+    def get_power_usage(self) -> dict:
+        """
+        获取指定DCUhy-smi --设备的功耗(W)
+        """
+        output_str = subprocess.run(
+            ["hy-smi", "--showpower", "--json"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        output_json = json.loads(output_str)
+        power_infos = {}
+        for idx, (dcu_key, dcu_info) in enumerate(output_json.items()):
+            dcu_id = str(idx)
+
+            power_infos[dcu_id] = {
+                "key": self.power_key.format(dcu_index=dcu_id),
+                "name": f"DCU {dcu_id} Power (W)",
+                "value": math.nan,
+                "config": self.per_power_configs[f"DCU {dcu_id}"],
+            }
+            dcu_power = dcu_info["Average Graphics Package Power (W)"]
+            power_infos[dcu_id]["value"] = float(dcu_power)
+        return power_infos


### PR DESCRIPTION
> 海光 DCU 同样支持 `json` 格式输出指标 （不过会有一些奇怪的尖刺...），基本用法：`hy-smi --showxxx --json`


- 支持海光 DCU 硬件信息指标监控
- 设计文档：https://rjwalmzfj2.feishu.cn/docx/CvBcdTrMnokb9YxI2AocHKUEnRg?from=from_copylink

- 更正摩尔线程 `Moore Threads` 的命名
