### PR TITLE
修复SwanLab accelerate集成使其对1.7.0版本及以下accelerate支持

### DIFF
--- a/swanlab/integration/accelerate.py
+++ b/swanlab/integration/accelerate.py
@@ -53,16 +53,18 @@ class SwanLabTracker(GeneralTracker):
 
     name = "swanlab"
     requires_logging_directory = False
-    main_process_only = False
+    main_process_only = True  # it must be True in tracker module
 
     def __init__(self, run_name: str, **kwargs):
         super().__init__()
         self.run_name = run_name
         self.init_kwargs = kwargs
+        self.start()  # auto start swanlab when instantiation tracker
 
     @on_main_process
     def start(self):
-        import swanlab
+        if hasattr(self, "run") and self.run is not None:
+            return
 
         self.run = swanlab.init(project=self.run_name, **self.init_kwargs)
         swanlab.config["FRAMEWORK"] = "accelerate"  # add accelerate logo in config


### PR DESCRIPTION
感谢社区用户@Laniakea 报bug

![image](https://github.com/user-attachments/assets/37130ccb-bd4b-4841-b1bf-83ee5e25d14e)

在使用accelerate 1.7.0及以下版本会出现无法正确初始化swanlab的问题

具体表现是

```bash
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/chenshaohon/projects/accelerate/examples/complete_cv_example.py", line 331, in <module>
[rank0]:     main()
[rank0]:   File "/home/chenshaohon/projects/accelerate/examples/complete_cv_example.py", line 327, in main
[rank0]:     training_function(config, args)
[rank0]:   File "/home/chenshaohon/projects/accelerate/examples/complete_cv_example.py", line 260, in training_function
[rank0]:     accelerator.log(
[rank0]:   File "/home/chenshaohon/miniconda3/envs/acc_itg/lib/python3.12/site-packages/accelerate/accelerator.py", line 787, in _inner
[rank0]:     return PartialState().on_main_process(function)(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/chenshaohon/miniconda3/envs/acc_itg/lib/python3.12/site-packages/accelerate/accelerator.py", line 2999, in log
[rank0]:     tracker.log(values, step=step, **log_kwargs.get(tracker.name, {}))
[rank0]:   File "/home/chenshaohon/miniconda3/envs/acc_itg/lib/python3.12/site-packages/accelerate/tracking.py", line 81, in execute_on_main_process
[rank0]:     return PartialState().on_main_process(function)(self, *args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/chenshaohon/miniconda3/envs/acc_itg/lib/python3.12/site-packages/swanlab/integration/accelerate.py", line 114, in log
[rank0]:     self.run.log(values, step=step, **kwargs)
[rank0]:     ^^^^^^^^
[rank0]: AttributeError: 'SwanLabTracker' object has no attribute 'run'
```

原因是accelerate团队在1.8.0版本后调整了tracker的初始化位置，使得适配于新版本的tracker不能初始化了，目前该PR已经修复了这个问题。

![image](https://github.com/user-attachments/assets/b8481ab2-e1ef-465c-bdf8-867bdded0179)
