### PR TITLE
fix: requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 swankit==0.2.4
 urllib3>=1.26.0
-requests>=2.25.0
+requests>=2.28.0
 setuptools
 click
 pyyaml


### PR DESCRIPTION
## Description

测试发现requests在`2.26.0`之前无法导出`JSONDecodeError`，因此更新requests的限制为 `>=2.28.0`

> 提高两个版本也没啥问题 : )
