### PR TITLE
feat: LogdirFileWriter plugin

### DIFF
--- a/swanlab/plugin/__init___.py
+++ b/swanlab/plugin/__init___.py
@@ -1,3 +1,4 @@
-from .notification import EmailCallback, LarkCallback, PrintCallback
+from .notification import EmailCallback, LarkCallback, PrintCallback, SlackCallback, DingTalkCallback, WXWorkCallback, DiscordCallback
+from .writer import CSVWriter, LogdirFileWriter
 
-__all__ = ["EmailCallback", "LarkCallback", "PrintCallback"]
+__all__ = ["EmailCallback", "LarkCallback", "PrintCallback", "CSVWriter", "WebhookCallback", "DingTalkCallback", "WXWorkCallback", "DiscordCallback", "SlackCallback", "LogdirFileWriter"]


### PR DESCRIPTION
## Description

增加1个插件`LogdirFileWriter`，它的作用是：支持传入1个文件路径列表，会在执行`swanlab.init`时，将文件移动到对应的`run`文件夹下

参数：
- `sub_dir`：如果不为None，则在`run`目录下创建1个sub_dir文件夹来保存文件
- `file_path`：支持传入1个文件路径列表（也支持仅传入1个str）

Related Issue: #1106 

测试代码：

```python
from swanlab.plugin.writer import LogdirConfigWriter
import swanlab

logdir_config_writer = LogdirConfigWriter(
    sub_dir="code",
    file_path=["a.py", "b.py"],
)
swanlab.register_callbacks([logdir_config_writer])

swanlab.init()
```
