### PR TITLE
refactor: tidy swankit

### DIFF
--- a/docs/插件化设计.md
+++ b/docs/插件化设计.md
@@ -25,7 +25,7 @@ swanlab一切的起点都是`swanlab.init`，此函数允许传入`callbacks`参
 `SwanKitCallback`，类似下面这样：
 
 ```python
-from swankit.callback import SwanKitCallback
+from swanlab.toolkit import SwanKitCallback
 
 
 class CustomCallback(SwanKitCallback):
@@ -41,7 +41,7 @@ class CustomCallback(SwanKitCallback):
 
 ```python
 import swanlab
-from swankit.callback import SwanKitCallback
+from swanlab.toolkit import SwanKitCallback
 
 
 class CustomCallback(SwanKitCallback):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ protobuf>=3.12.0,!=4.21.0,!=5.28.0,<7; python_version < '3.9' and sys_platform =
 protobuf>=3.15.0,!=4.21.0,!=5.28.0,<7; python_version == '3.9' and sys_platform == 'linux'
 protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; python_version > '3.9' and sys_platform == 'linux'
 protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; sys_platform != 'linux'
+rich>=13.6.0, <14.0.0

--- a/swanlab/cli/commands/auth/login.py
+++ b/swanlab/cli/commands/auth/login.py
@@ -10,10 +10,11 @@ r"""
 import os
 
 import click
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.core_python import auth
 from swanlab.env import SwanLabEnv
+from swanlab.log import swanlog
 from swanlab.package import has_api_key, HostFormatter
 
 
@@ -51,9 +52,12 @@ def login(api_key: str, relogin: bool, host: str, web_host: str):
     """Login to the swanlab cloud."""
     if not relogin and has_api_key():
         # 此时代表token已经获取，需要打印一条信息：已经登录
-        command = FONT.bold("swanlab login --relogin")
-        tip = FONT.swanlab("You are already logged in. Use `" + command + "` to force relogin.")
-        return print(tip)
+        return swanlog.info(
+            "You are already logged in. Use `",
+            Text("swanlab login --relogin", "bold"),
+            "` to force relogin.",
+            sep='',
+        )
     # 清除环境变量
     if relogin:
         del os.environ[SwanLabEnv.API_HOST.value]
@@ -64,4 +68,4 @@ def login(api_key: str, relogin: bool, host: str, web_host: str):
         raise click.BadParameter(str(e))
     # 进行登录，此时将直接覆盖本地token文件
     login_info = auth.terminal_login(api_key)
-    print(FONT.swanlab("Login successfully. Hi, " + FONT.bold(FONT.default(login_info.username))) + "!")
+    swanlog.info("Login successfully. Hi, ", Text(login_info.username, "bold"), "!", sep='')

--- a/swanlab/cli/commands/auth/logout.py
+++ b/swanlab/cli/commands/auth/logout.py
@@ -11,28 +11,30 @@ import shutil
 import sys
 
 import click
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.env import get_save_dir
+from swanlab.log import swanlog
 from swanlab.package import has_api_key
 
 
 @click.command()
 def logout():
     """Logout to the swanlab cloud."""
-    command = FONT.bold("swanlab login")
+    command = Text("swanlab login", "bold")
     if has_api_key():
         # 如果已经是登录状态，那么则询问用户是否确认，如果确认则删除token文件夹
-        confirm = input(FONT.swanlab("Are you sure you want to logout? (y/N): "))
+
+        swanlog.info("Are you sure you want to logout? (y/N): ", end='')
+        confirm = input()
         if confirm.lower() == "y":
             try:
                 shutil.rmtree(get_save_dir())
-                return print(FONT.swanlab("Logout successfully. You can use `" + command + "` to login again."))
+                return swanlog.info(" Logout successfully. You can use `", command, "` to login again.", sep="")
             except Exception as e:
-                return print(FONT.swanlab("Logout failed. Reason:" + str(e)))
+                return swanlog.info("Logout failed. Reason:" + str(e))
         else:
-            return print(FONT.swanlab("Logout canceled."))
+            return swanlog.info("Logout canceled.")
     # 如果还未登录，则不做任何处理，并告知用户如何登录
-    tip = FONT.swanlab("You are not logged in. If you want to login in, please use `" + command + "` to login.")
-    print(tip)
+    swanlog.info("You are not logged in. If you want to login in, please use `", command, "` to login.", sep="")
     return sys.exit(1)

--- a/swanlab/core_python/uploader/model.py
+++ b/swanlab/core_python/uploader/model.py
@@ -10,9 +10,8 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional, TypedDict, Literal
 
-from swankit.callback.models import ColumnClass, ColumnConfig
-
 from swanlab.data.modules import MediaBuffer
+from swanlab.toolkit import ColumnClass, ColumnConfig
 
 
 class ColumnModel:

--- a/swanlab/data/callbacker/cloud.py
+++ b/swanlab/data/callbacker/cloud.py
@@ -9,9 +9,7 @@
 import sys
 from typing import Literal
 
-from swankit.callback.models import RuntimeInfo, MetricInfo, ColumnInfo
-from swankit.env import create_time
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.env import in_jupyter, is_interactive
 from swanlab.error import KeyFileError
@@ -20,6 +18,12 @@ from swanlab.package import (
     get_package_version,
     get_package_latest_version,
     get_key,
+)
+from swanlab.toolkit import (
+    RuntimeInfo,
+    MetricInfo,
+    ColumnInfo,
+    create_time,
 )
 from ..run import get_run, SwanLabRunState
 from ..run.callback import SwanLabRunCallback
@@ -71,8 +75,8 @@ class CloudRunCallback(SwanLabRunCallback):
     def _view_web_print():
         http = get_client()
         proj_url, exp_url = http.web_proj_url, http.web_exp_url
-        swanlog.info("🏠 View project at " + FONT.blue(FONT.underline(proj_url)))
-        swanlog.info("🚀 View run at " + FONT.blue(FONT.underline(exp_url)))
+        swanlog.info("🏠 View project at", Text(proj_url, "blue underline"))
+        swanlog.info("🚀 View run at", Text(exp_url, "blue underline"))
         return exp_url
 
     def _clean_handler(self):
@@ -129,8 +133,9 @@ class CloudRunCallback(SwanLabRunCallback):
         # 打印实验开始信息，在 cloud 模式下如果没有开启 backup 的话不打印“数据保存在 xxx”的信息
         swanlab_settings = get_settings()
         self._train_begin_print(save_dir=self.settings.run_dir if swanlab_settings.backup else None)
-        swanlog.info("👋 Hi " + FONT.bold(FONT.default(http.username)) + ", welcome to swanlab!")
-        swanlog.info("Syncing run " + FONT.yellow(self.settings.exp_name) + " to the cloud")
+
+        swanlog.info(" 👋 Hi ", Text(http.username, "bold default"), ",welcome to swanlab!", sep="")
+        swanlog.info("Syncing run", Text(self.settings.exp_name, "yellow"), "to the cloud")
         experiment_url = self._view_web_print()
         # 在Jupyter Notebook环境下，显示按钮
         if in_jupyter():

--- a/swanlab/data/callbacker/local.py
+++ b/swanlab/data/callbacker/local.py
@@ -6,12 +6,12 @@
 local模式（目前）将自动调用swanboard，如果不存在则报错
 """
 
-from swankit.callback import ColumnInfo
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.log.backup import backup
 from swanlab.log.backup.writer import write_media_buffer, write_runtime_info
 from swanlab.log.type import LogData
+from swanlab.toolkit import ColumnInfo
 from ..run import get_run
 
 try:
@@ -34,9 +34,7 @@ import os
 from datetime import datetime
 from typing import Tuple, Optional, TextIO
 
-from swankit.callback.models import RuntimeInfo, MetricInfo
-from swankit.core import SwanLabSharedSettings
-
+from swanlab.toolkit import RuntimeInfo, MetricInfo, SwanLabSharedSettings
 from swanlab.data.run.callback import SwanLabRunCallback
 from swanlab.log import swanlog
 
@@ -57,9 +55,10 @@ class LocalRunCallback(SwanLabRunCallback):
         watch命令提示打印
         """
         swanlog.info(
-            "🌟 Run `"
-            + FONT.bold("swanlab watch {}".format(self.fmt_windows_path(self.settings.swanlog_dir)))
-            + "` to view SwanLab Experiment Dashboard locally"
+            " 🌟 Run `",
+            Text("swanlab watch {}".format(self.fmt_windows_path(self.settings.swanlog_dir)), "bold"),
+            "` to view SwanLab Experiment Dashboard locally",
+            sep="",
         )
 
     @backup("terminal")

--- a/swanlab/data/callbacker/offline.py
+++ b/swanlab/data/callbacker/offline.py
@@ -5,13 +5,13 @@
 @description: 日志备份回调
 """
 
-from swankit.callback import ColumnInfo, MetricInfo, RuntimeInfo
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.data.run.callback import SwanLabRunCallback
 from swanlab.log import swanlog
 from swanlab.log.backup import backup
 from swanlab.log.type import LogData
+from swanlab.toolkit import ColumnInfo, MetricInfo, RuntimeInfo
 from ..run import get_run
 
 
@@ -28,9 +28,10 @@ class OfflineCallback(SwanLabRunCallback):
         提示用户可以通过命令上传日志到远程服务器
         """
         swanlog.info(
-            "☁️ Run `"
-            + FONT.bold("swanlab sync {}".format(self.fmt_windows_path(self.settings.run_dir)))
-            + "` to sync logs to remote server"
+            " ☁️ Run `",
+            Text("swanlab sync {}".format(self.fmt_windows_path(self.settings.run_dir))),
+            "` to sync logs to remote server",
+            sep="",
         )
 
     @backup("terminal")
@@ -51,7 +52,7 @@ class OfflineCallback(SwanLabRunCallback):
     def on_run(self, *args, **kwargs):
         self.handle_run()
         self._train_begin_print(self.settings.run_dir)
-        swanlog.info("Backing up run " + FONT.yellow(self.settings.exp_name) + " locally")
+        swanlog.info("Backing up run", Text(self.settings.exp_name, "yellow"), "locally")
         self._sync_tip_print()
 
     @backup('runtime')

--- a/swanlab/data/formatter.py
+++ b/swanlab/data/formatter.py
@@ -13,7 +13,8 @@ import re
 from typing import Optional, Union, List
 
 import yaml
-from swankit.callback import SwanKitCallback
+
+from swanlab.toolkit import SwanKitCallback
 
 
 def check_string(target: str) -> bool:

--- a/swanlab/data/modules/__init__.py
+++ b/swanlab/data/modules/__init__.py
@@ -1,7 +1,6 @@
 from typing import List, Union
 
-from swankit.core.data import BaseType, MediaBuffer, MediaType
-
+from swanlab.toolkit import BaseType, MediaBuffer, MediaType
 from .audio import Audio
 from .custom_charts import echarts, Echarts, PyEchartsBase, PyEchartsTable
 from .image import Image

--- a/swanlab/data/modules/audio/__init__.py
+++ b/swanlab/data/modules/audio/__init__.py
@@ -7,8 +7,9 @@ r"""
 @Description:
     音频模块
 """
-from swankit.core import MediaBuffer, DataSuite as D, MediaType
 from typing import Union, Any
+
+from swanlab.toolkit import MediaBuffer, DataSuite as D, MediaType
 
 try:
     # noinspection PyPackageRequirements

--- a/swanlab/data/modules/custom_charts/__init__.py
+++ b/swanlab/data/modules/custom_charts/__init__.py
@@ -9,8 +9,8 @@ from typing import Union
 
 import pyecharts
 from pyecharts.charts.base import Base
-from swankit.core import MediaBuffer, DataSuite as D, MediaType
 
+from swanlab.toolkit import MediaBuffer, DataSuite as D, MediaType
 from . import echarts
 from .table import Table
 

--- a/swanlab/data/modules/image/__init__.py
+++ b/swanlab/data/modules/image/__init__.py
@@ -1,6 +1,7 @@
-from swankit.core import MediaBuffer, DataSuite as D, MediaType
-from typing import Union, Any, TYPE_CHECKING
 from io import BytesIO
+from typing import Union, Any, TYPE_CHECKING
+
+from swanlab.toolkit import MediaBuffer, DataSuite as D, MediaType
 
 if TYPE_CHECKING:
     # noinspection PyPackageRequirements

--- a/swanlab/data/modules/line/__init__.py
+++ b/swanlab/data/modules/line/__init__.py
@@ -12,9 +12,10 @@ r"""
     3. 如果传入NaN，返回NaN字符串，None
     4. 如果传入Infinity，返回INF字符串，None
 """
-from swanlab.error import DataTypeError
 from typing import Protocol, runtime_checkable
-from swankit.core import BaseType, DataSuite as D
+
+from swanlab.error import DataTypeError
+from swanlab.toolkit import BaseType, DataSuite as D
 
 
 @runtime_checkable

--- a/swanlab/data/modules/object3d/model3d.py
+++ b/swanlab/data/modules/object3d/model3d.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 
-from swankit.core.data import DataSuite as D
-from swankit.core.data import MediaBuffer, MediaType
+from swanlab.toolkit import DataSuite as D, MediaBuffer, MediaType
 
 
 @dataclass()

--- a/swanlab/data/modules/object3d/molecule.py
+++ b/swanlab/data/modules/object3d/molecule.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Optional, Tuple, Union
 
-from swankit.core.data import DataSuite as D
-from swankit.core.data import MediaBuffer, MediaType
+from swanlab.toolkit import DataSuite as D, MediaBuffer, MediaType
 
 # Attempt to import RDKit; if unavailable, set Chem and Mol to None
 try:

--- a/swanlab/data/modules/object3d/object3d.py
+++ b/swanlab/data/modules/object3d/object3d.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
-from swankit.core.data import MediaType
-
+from swanlab.toolkit import MediaType
 from .model3d import Model3D
 from .molecule import Molecule
 from .point_cloud import Box, PointCloud

--- a/swanlab/data/modules/object3d/point_cloud.py
+++ b/swanlab/data/modules/object3d/point_cloud.py
@@ -37,10 +37,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, TypedDict
 
-from swankit.core.data import DataSuite as D
-from swankit.core.data import MediaBuffer, MediaType
-
 from swanlab.data.namer import hex_to_rgb, light_colors
+from swanlab.toolkit import DataSuite as D, MediaBuffer, MediaType
 
 try:
     import numpy as np

--- a/swanlab/data/modules/text/__init__.py
+++ b/swanlab/data/modules/text/__init__.py
@@ -7,9 +7,9 @@ r"""
 @Description:
     文本模块
 """
-from swankit.core.data import MediaType
-from swankit.core import DataSuite as D
 from typing import Union
+
+from swanlab.toolkit import MediaType, DataSuite as D
 
 
 class Text(MediaType):

--- a/swanlab/data/modules/wrapper.py
+++ b/swanlab/data/modules/wrapper.py
@@ -9,9 +9,8 @@ r"""
 """
 from typing import Union, List, Optional
 
-from swankit.core import ParseResult, ParseErrorInfo, MediaType, ChartReference
-
 from swanlab.error import DataTypeError
+from swanlab.toolkit import ParseResult, ParseErrorInfo, MediaType, ChartReference
 from .custom_charts import Echarts
 from .line import Line
 

--- a/swanlab/data/run/callback.py
+++ b/swanlab/data/run/callback.py
@@ -13,9 +13,7 @@ import sys
 import traceback
 from typing import Optional
 
-from swankit.callback import SwanKitCallback
-from swankit.core import SwanLabSharedSettings
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.data.run import SwanLabRunState, get_run
 from swanlab.env import is_windows
@@ -24,6 +22,7 @@ from swanlab.log.backup import BackupHandler
 from swanlab.log.type import LogData
 from swanlab.package import get_package_version
 from swanlab.swanlab_settings import get_settings
+from swanlab.toolkit import SwanKitCallback, SwanLabSharedSettings
 
 
 def error_print(tp):
@@ -93,14 +92,14 @@ class U:
         swanlog.debug("SwanLab will take over all the print information of the terminal from now on")
         swanlog.info("Tracking run with swanlab version " + get_package_version())
         if save_dir is not None:
-            local_path = FONT.magenta(FONT.bold(self.fmt_windows_path(save_dir)))
-            swanlog.info("Run data will be saved locally in " + local_path)
+            local_path = Text(self.fmt_windows_path(save_dir), "magenta bold")
+            swanlog.info("Run data will be saved locally in", local_path)
 
     def _train_finish_print(self):
         """
         打印结束信息
         """
-        swanlog.info("Experiment {} has completed".format(FONT.yellow(self.settings.exp_name)))
+        swanlog.info("Experiment", Text(self.settings.exp_name, "yellow"), "has completed")
 
 
 class SwanLabRunCallback(SwanKitCallback, U):

--- a/swanlab/data/run/config.py
+++ b/swanlab/data/run/config.py
@@ -18,10 +18,10 @@ from typing import Any, Union
 from typing import Callable, Optional
 
 import yaml
-from swankit.callback import RuntimeInfo
 
 from swanlab.data.modules import Line
 from swanlab.log import swanlog
+from swanlab.toolkit import RuntimeInfo
 
 BASE_TYPE = (int, float, str)
 

--- a/swanlab/data/run/exp.py
+++ b/swanlab/data/run/exp.py
@@ -2,12 +2,18 @@ import json
 import math
 from typing import Dict, Optional
 
-from swankit.callback.models import MetricInfo, ColumnInfo, MetricErrorInfo, ColumnClass, SectionType, ColumnConfig
-from swankit.core import SwanLabSharedSettings
-from swankit.env import create_time
-
 from swanlab.data.modules import DataWrapper, Line
 from swanlab.log import swanlog
+from swanlab.toolkit import (
+    MetricInfo,
+    ColumnInfo,
+    MetricErrorInfo,
+    ColumnClass,
+    SectionType,
+    ColumnConfig,
+    SwanLabSharedSettings,
+    create_time,
+)
 from .helper import SwanLabRunOperator
 
 

--- a/swanlab/data/run/helper.py
+++ b/swanlab/data/run/helper.py
@@ -11,13 +11,10 @@ import threading
 from enum import Enum
 from typing import List, Union, Dict, Any, Tuple, Callable, Optional
 
-from swankit.callback import SwanKitCallback
-from swankit.callback.models import MetricInfo, ColumnInfo, RuntimeInfo
-from swankit.core import SwanLabSharedSettings
-
 from swanlab.data.run.webhook import try_send_webhook
 from swanlab.log import swanlog
 from swanlab.swanlab_settings import get_settings
+from swanlab.toolkit import SwanKitCallback, MetricInfo, ColumnInfo, RuntimeInfo, SwanLabSharedSettings
 
 OperatorReturnType = Dict[str, Any]
 

--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -11,15 +11,13 @@ import os
 import random
 from typing import Any, Callable, Dict, Optional, List
 
-from swankit.core import SwanLabSharedSettings
-from swankit.core.data import MediaType
-
 from swanlab.data import namer as N
 from swanlab.data.modules import DataWrapper, FloatConvertible, Line, Echarts, PyEchartsBase, PyEchartsTable
 from swanlab.env import get_mode, get_swanlog_dir
 from swanlab.log import swanlog
 from swanlab.package import get_package_version
 from swanlab.swanlab_settings import reset_settings, get_settings
+from swanlab.toolkit import SwanLabSharedSettings, MediaType
 from .config import SwanLabConfig
 from .exp import SwanLabExp
 from .helper import SwanLabRunOperator, RuntimeInfo, SwanLabRunState, MonitorCron, check_log_level

--- a/swanlab/data/run/metadata/cooperation/__init__.py
+++ b/swanlab/data/run/metadata/cooperation/__init__.py
@@ -7,11 +7,10 @@
 
 from typing import TypedDict, Optional
 
-from swankit.env import get_swanlog_dir
-
 from swanlab.core_python import get_client
 from swanlab.env import get_mode
 from swanlab.package import get_package_version
+from swanlab.toolkit import get_swanlog_dir
 from .qing_cloud import get_qing_cloud_info
 
 

--- a/swanlab/data/run/metadata/hardware/cpu.py
+++ b/swanlab/data/run/metadata/hardware/cpu.py
@@ -10,10 +10,9 @@ import platform
 import subprocess
 
 import psutil
-import os
-from swankit.env import is_macos
 
 from swanlab.data.run.metadata.hardware.type import HardwareFuncResult, HardwareCollector, HardwareInfoList
+from swanlab.toolkit import is_macos
 from .utils import CpuBaseCollector as C
 
 

--- a/swanlab/data/run/metadata/hardware/memory.py
+++ b/swanlab/data/run/metadata/hardware/memory.py
@@ -8,8 +8,8 @@
 from typing import List
 
 import psutil
-from swankit.env import is_macos
 
+from swanlab.toolkit import is_macos
 from .type import HardwareFuncResult, HardwareCollector, HardwareInfo
 from .utils import MemoryBaseCollector as M
 

--- a/swanlab/data/run/metadata/hardware/soc/apple.py
+++ b/swanlab/data/run/metadata/hardware/soc/apple.py
@@ -10,8 +10,8 @@ import multiprocessing
 import subprocess
 
 import psutil
-from swankit.env import is_macos
 
+from swanlab.toolkit import is_macos
 from ..type import HardwareFuncResult, HardwareInfoList, HardwareCollector as H
 from ..utils import CpuBaseCollector as C, MemoryBaseCollector as M
 

--- a/swanlab/data/run/metadata/hardware/type.py
+++ b/swanlab/data/run/metadata/hardware/type.py
@@ -8,10 +8,9 @@
 from abc import ABC, abstractmethod
 from typing import TypedDict, Tuple, Optional, Any, List, Union
 
-from swankit.callback.models import ColumnConfig, YRange
-
 from swanlab.data.namer import generate_colors
 from swanlab.log import swanlog
+from swanlab.toolkit import ColumnConfig, YRange
 
 
 # 定义硬件信息类型

--- a/swanlab/data/run/public.py
+++ b/swanlab/data/run/public.py
@@ -1,7 +1,6 @@
-from swankit.core import SwanLabSharedSettings
-
 from swanlab.core_python import get_client
 from swanlab.env import get_mode
+from swanlab.toolkit import SwanLabSharedSettings
 
 
 class SwanlabCloudConfig:

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -10,11 +10,10 @@ r"""
 import os
 from typing import Union, Dict, Literal, List
 
-from swankit.callback import SwanKitCallback
-
 from swanlab.env import SwanLabEnv
 from swanlab.log import swanlog
 from swanlab.swanlab_settings import Settings, get_settings, set_settings
+from swanlab.toolkit import SwanKitCallback
 from .callbacker.cloud import CloudRunCallback
 from .formatter import check_load_json_yaml, check_callback_format
 from .modules import DataType

--- a/swanlab/data/utils.py
+++ b/swanlab/data/utils.py
@@ -8,9 +8,7 @@
 import os
 from typing import Union, Optional, List
 
-from swankit.callback import SwanKitCallback
-from swankit.env import SwanLabMode
-from swankit.log import FONT
+from rich.text import Text
 
 from swanlab.core_python import auth
 from swanlab.data.callbacker.cloud import CloudRunCallback
@@ -23,6 +21,7 @@ from swanlab.error import KeyFileError
 from swanlab.log import swanlog
 from swanlab.package import get_key, get_host_web
 from swanlab.swanlab_settings import get_settings
+from swanlab.toolkit import SwanKitCallback, SwanLabMode
 
 
 def _check_proj_name(name: str) -> str:
@@ -118,7 +117,9 @@ def _init_mode(mode: str = None):
         # 判断当前进程是否在交互模式下
         if is_interactive():
             swanlog.info(
-                f"Using SwanLab to track your experiments. Please refer to {FONT.yellow('https://docs.swanlab.cn')} for more information."
+                f"Using SwanLab to track your experiments. Please refer to",
+                Text('https://docs.swanlab.cn', 'yellow'),
+                "for more information.",
             )
             swanlog.info("(1) Create a SwanLab account.")
             swanlog.info("(2) Use an existing SwanLab account.")
@@ -126,7 +127,7 @@ def _init_mode(mode: str = None):
 
             web_host = get_host_web()
             # 交互选择
-            tip = FONT.swanlab("Enter your choice: ")
+            tip = swanlog.info("Enter your choice: ")
             code = input(tip)
             while code not in ["1", "2", "3"]:
                 swanlog.warning("Invalid choice, please enter again.")
@@ -135,11 +136,11 @@ def _init_mode(mode: str = None):
                 mode = "local"
             elif code == "2":
                 swanlog.info("You chose 'Use an existing swanlab account'")
-                swanlog.info("Logging into " + FONT.yellow(web_host))
+                swanlog.info("Logging into", Text(web_host, 'yellow'))
                 login_info = auth.terminal_login()
             elif code == "1":
                 swanlog.info("You chose 'Create a swanlab account'")
-                swanlog.info("Create a SwanLab account here: " + FONT.yellow(web_host + "/login"))
+                swanlog.info("Create a SwanLab account here:", Text(web_host + "/login", 'yellow'))
                 login_info = auth.terminal_login()
             else:
                 raise ValueError("Invalid choice")

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -16,8 +16,8 @@ import sys
 from typing import List
 from urllib.parse import urlparse
 
-import swankit.env as E
-from swankit.env import SwanLabSharedEnv
+import swanlab.toolkit as E
+from swanlab.toolkit import SwanLabSharedEnv
 
 
 # ---------------------------------- 环境变量枚举类 ----------------------------------

--- a/swanlab/log/backup/handler.py
+++ b/swanlab/log/backup/handler.py
@@ -10,13 +10,12 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 
 import wrapt
-from swankit.callback import ColumnInfo, MetricInfo, RuntimeInfo
-from swankit.env import create_time
 
 from swanlab.log.backup.datastore import DataStore
 from swanlab.log.backup.models import Experiment, Log, Project, Column, Runtime, Metric, Header, Footer
 from swanlab.log.backup.writer import write_media_buffer, write_runtime_info
 from swanlab.log.type import LogData
+from swanlab.toolkit import ColumnInfo, MetricInfo, RuntimeInfo, create_time
 
 
 def enable_check():

--- a/swanlab/log/backup/models.py
+++ b/swanlab/log/backup/models.py
@@ -11,12 +11,11 @@ from typing import Optional, List, Literal, Tuple, Union
 
 import yaml
 from pydantic import BaseModel as PydanticBaseModel
-from swankit.callback import ColumnInfo, ColumnConfig, RuntimeInfo, MetricInfo
-from swankit.callback.models import ColumnClass, SectionType, YRange
-from swankit.core import ChartReference, MediaBuffer
 
 from swanlab.core_python import FileModel, ScalarModel, ColumnModel, LogModel, MediaModel
 from swanlab.log.type import LogData
+from swanlab.toolkit import ChartReference, MediaBuffer
+from swanlab.toolkit import ColumnInfo, ColumnConfig, RuntimeInfo, MetricInfo, ColumnClass, SectionType, YRange
 
 
 class BaseModel(PydanticBaseModel):

--- a/swanlab/log/backup/writer.py
+++ b/swanlab/log/backup/writer.py
@@ -7,7 +7,7 @@
 
 import os
 
-from swankit.callback import RuntimeInfo, MetricInfo
+from swanlab.toolkit import RuntimeInfo, MetricInfo
 
 
 def write_runtime_info(files_dir: str, runtime_info: RuntimeInfo):

--- a/swanlab/log/log.py
+++ b/swanlab/log/log.py
@@ -9,17 +9,15 @@ import re
 import sys
 from typing import List, Tuple, Callable
 
-from swankit.env import create_time
-from swankit.log import SwanLabSharedLog
-
+from swanlab.toolkit import SwanKitLogger, create_time
 from .counter import AtomicCounter
 from .type import LogHandler, LogType, WriteHandler, LogData, LogContent, ProxyType
 
 
-class SwanLog(SwanLabSharedLog):
+class SwanLog(SwanKitLogger):
     """
     swanlab 日志类
-    继承自 SwanLabSharedLog 的同时增加标准输出、标准错误留拦截代理功能 ni
+    继承自 SwanKitLogger 的同时增加标准输出、标准错误留拦截代理功能
     """
 
     def __init__(self, name=__name__.lower(), level="info"):

--- a/swanlab/plugin/notification.py
+++ b/swanlab/plugin/notification.py
@@ -14,9 +14,9 @@ from email.mime.text import MIMEText
 from typing import Optional, Dict, Any, Tuple
 
 import requests
-from swankit.callback import SwanKitCallback
 
 import swanlab
+from swanlab.toolkit import SwanKitCallback
 
 
 class PrintCallback(SwanKitCallback):

--- a/swanlab/plugin/writer.py
+++ b/swanlab/plugin/writer.py
@@ -2,30 +2,32 @@
 Writer plugin for SwanLab.
 Used for writing experiment metadata to CSV and online notes.
 """
+
 import os
+import shutil
 import time
 from typing import Tuple, List
-import shutil
-
-from swankit.callback import SwanKitCallback
 
 import swanlab
+from swanlab.toolkit import SwanKitCallback
 
 try:
     import pandas as pd
 except ImportError:
     raise ImportError("pandas is required for CSVWriter. Please install it using 'pip install pandas'.")
 
+
 class CSVWriter(SwanKitCallback):
     """CSV writer for SwanLab."""
+
     def __init__(self, dir: str = None, filename: str = "swanlab_run.csv"):
-        
+
         if dir is None:
             dir = os.getcwd()
-        
+
         # Create directory if it doesn't exist
         os.makedirs(dir, exist_ok=True)
-        
+
         self.save_path = os.path.join(dir, filename)
         self.file_exists = os.path.isfile(self.save_path)
         self.df = self._initialize_dataframe()
@@ -47,13 +49,15 @@ class CSVWriter(SwanKitCallback):
     def _create_empty_dataframe(self):
         """Create an empty DataFrame with default columns."""
         self.file_exists = False  # Treat as a new file
-        return pd.DataFrame(columns=["project", "exp_name", "description", "datetime", "run_id", "workspace", "logdir", "url"])
+        return pd.DataFrame(
+            columns=["project", "exp_name", "description", "datetime", "run_id", "workspace", "logdir", "url"]
+        )
 
     def on_init(self, proj_name: str, workspace: str, logdir: str = None, *args, **kwargs):
         """Initialize project and workspace information."""
         self.project = proj_name
         self.workspace = workspace
-    
+
     def before_init_experiment(
         self,
         run_id: str,
@@ -67,20 +71,29 @@ class CSVWriter(SwanKitCallback):
         self.run_id = run_id
         self.exp_name = exp_name
         self.description = description
-    
+
     def on_run(self, *args, **kwargs):
         """Handle actions to perform on run."""
         run = swanlab.get_run()
         config = run.config
         self.logdir = run.public.swanlog_dir
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-        
+
         # Set experiment URL if available
         self.experiment_url = run.public.cloud.experiment_url if run.public.cloud.project_url else None
-        
+
         headers = ["project", "exp_name", "description", "datetime", "run_id", "workspace", "logdir", "url"]
-        row_data = [self.project, self.exp_name, self.description, timestamp, self.run_id, self.workspace, self.logdir, self.experiment_url]
-        
+        row_data = [
+            self.project,
+            self.exp_name,
+            self.description,
+            timestamp,
+            self.run_id,
+            self.workspace,
+            self.logdir,
+            self.experiment_url,
+        ]
+
         if not self.file_exists:
             self._handle_new_file(config, headers, row_data)
         else:
@@ -92,11 +105,11 @@ class CSVWriter(SwanKitCallback):
             for key in config:
                 headers.append("config/" + key)
                 row_data.append(config[key])
-        
+
         self.df = pd.DataFrame([], columns=headers)
         updated_df = pd.DataFrame([row_data], columns=headers)
         updated_df.to_csv(self.save_path, index=False)
-        
+
         self.headers = headers
         self.last_row_data = row_data
 
@@ -106,22 +119,22 @@ class CSVWriter(SwanKitCallback):
         headers_metadata = headers[:8]
         headers_config = [header for header in headers[8:] if header.startswith("config/")]
         headers_config_dict = {key: {"value": " ", "index": headers_config.index(key)} for key in headers_config}
-        
+
         for key in config:
             if "config/" + key not in headers_config_dict:
                 headers_config_dict["config/" + key] = {"value": config[key], "index": len(headers_config)}
                 headers_config.append("config/" + key)
             else:
                 headers_config_dict["config/" + key]["value"] = config[key]
-                
+
         headers_config_list = [headers_config_dict[header]["value"] for header in headers_config]
         headers = headers_metadata + headers_config
         row_data = row_data + headers_config_list
-        
+
         new_row_df = pd.DataFrame([row_data], columns=headers)
         updated_df = pd.concat([self.df, new_row_df], ignore_index=True)
         updated_df.to_csv(self.save_path, index=False)
-        
+
         self.headers = headers
         self.last_row_data = row_data
 
@@ -129,15 +142,15 @@ class CSVWriter(SwanKitCallback):
         """Log data during the run."""
         if not data:
             return
-        
+
         new_headers = self.headers.copy()
         for key in data:
             if key not in new_headers:
                 new_headers.append(key)
         self.headers = new_headers
-        
+
         new_row = self.last_row_data.copy()
-        
+
         for key in data:
             if key in self.headers:
                 idx = self.headers.index(key)
@@ -150,28 +163,30 @@ class CSVWriter(SwanKitCallback):
             else:
                 self.headers.append(key)
                 new_row.append(data[key])
-        
+
         new_row_df = pd.DataFrame([new_row], columns=self.headers)
         updated_df = pd.concat([self.df, new_row_df], ignore_index=True)
         updated_df.to_csv(self.save_path, index=False)
-    
+
     def __str__(self):
         return "CSVWriter"
-    
+
+
 class LogdirFileWriter(SwanKitCallback):
     """
     Logdir writer for SwanLab.
     The logic of this writer is that users can write or move files they like into the run file corresponding to logdir.
     """
+
     def __init__(self, sub_dir: str = None, file_path: List[str] = None):
         self.sub_dir = sub_dir
         self.file_path = file_path
-        
+
     def on_init(self, proj_name: str, workspace: str, logdir: str = None, *args, **kwargs):
         """Initialize project and workspace information."""
         self.project = proj_name
         self.workspace = workspace
-        
+
     def on_run(self, *args, **kwargs):
         """Handle actions to perform on run."""
         run = swanlab.get_run()
@@ -181,13 +196,13 @@ class LogdirFileWriter(SwanKitCallback):
         else:
             total_path = os.path.join(self.logdir, self.sub_dir)
         os.makedirs(total_path, exist_ok=True)
-        
+
         if self.file_path is None:
             return
 
         if isinstance(self.file_path, str):
             self.file_path = [self.file_path]
-        
+
         for file_path in self.file_path:
             if os.path.isfile(file_path):
                 shutil.copy(file_path, total_path)
@@ -195,6 +210,6 @@ class LogdirFileWriter(SwanKitCallback):
                 shutil.copytree(file_path, total_path)
             else:
                 raise ValueError(f"[LogdirConfigWriter] File path {file_path} is not a file or directory.")
-    
+
     def __str__(self):
         return "LogdirConfigWriter"

--- a/swanlab/swanlab_settings.py
+++ b/swanlab/swanlab_settings.py
@@ -10,7 +10,7 @@ import json
 import os
 from pathlib import Path
 
-from swankit.env import is_windows
+from swanlab.toolkit import is_windows
 
 try:
     from typing import Annotated, Literal, Optional  # Python 3.9+

--- a/swanlab/sync/__init__.py
+++ b/swanlab/sync/__init__.py
@@ -1,7 +1,7 @@
 import os.path
 from sys import stdout
 
-from swankit.log import FONT
+from rich.status import Status
 
 from .mlflow import sync_mlflow
 from .tensorboard import sync_tensorboardX, sync_tensorboard_torch
@@ -34,49 +34,48 @@ def sync(
     """
     # 第一部分，处理备份文件，读取备份信息到内存中
     try:
-        assert os.path.exists(dir_path), f"Directory {dir_path} does not exist."
-        file_path = os.path.join(dir_path, BackupHandler.BACKUP_FILE)
-        assert os.path.exists(file_path), f"Can not find backup file {BackupHandler.BACKUP_FILE} in {dir_path}."
-        try:
-            client = get_client()
-        except ValueError:
-            client = None
-            assert not login_required, "Please log in first, use `swanlab login` to log in."
-        swanlog.info("🛠️Parsing...", end="")
-        stdout.flush()
-        ds = DataStore()
-        ds.open_for_scan(file_path)
-        # 根据类型分类日志文件
-        with ModelsParser() as models_parser:
-            for record in ds:
-                if record is None:
-                    continue
-                models_parser.parse_record(record)
-        header, project, experiment, logs, runtime, columns, scalars, medias, footer = models_parser.get_parsed()
-        # 0. 检查备份文件
-        assert (
-            header.backup_type == "DEFAULT"
-        ), f"Backup type mismatch: {header.backup_type}, please update your swanlab package."
-        # 1. 聚合信息
-        # 1.1 聚合日志
-        log_model_dict = {"INFO": [], "WARN": [], "ERROR": []}
-        for log in logs:
-            log_model = log.to_log_model()
-            log_model_dict[log_model['level']].append(log_model)
-        # 1.2 生成运行时
-        runtime_model = runtime.to_file_model(os.path.join(dir_path, "files"))
-        # 1.3 集合列
-        column_models = [c.to_column_model() for c in columns]
-        # 1.4 集合指标
-        scalar_models = [scalar.to_scalar_model() for scalar in scalars]
-        # 1.5 集合媒体
-        media_models = [media.to_media_model(os.path.join(dir_path, "media")) for media in medias]
-        assert client is not None, "Please log in first, use `swanlab login` to log in."
+        with Status("🛠️Parsing...", spinner="dots"):
+            assert os.path.exists(dir_path), f"Directory {dir_path} does not exist."
+            file_path = os.path.join(dir_path, BackupHandler.BACKUP_FILE)
+            assert os.path.exists(file_path), f"Can not find backup file {BackupHandler.BACKUP_FILE} in {dir_path}."
+            try:
+                client = get_client()
+            except ValueError:
+                client = None
+                assert not login_required, "Please log in first, use `swanlab login` to log in."
+            stdout.flush()
+            ds = DataStore()
+            ds.open_for_scan(file_path)
+            # 根据类型分类日志文件
+            with ModelsParser() as models_parser:
+                for record in ds:
+                    if record is None:
+                        continue
+                    models_parser.parse_record(record)
+            header, project, experiment, logs, runtime, columns, scalars, medias, footer = models_parser.get_parsed()
+            # 0. 检查备份文件
+            assert (
+                header.backup_type == "DEFAULT"
+            ), f"Backup type mismatch: {header.backup_type}, please update your swanlab package."
+            # 1. 聚合信息
+            # 1.1 聚合日志
+            log_model_dict = {"INFO": [], "WARN": [], "ERROR": []}
+            for log in logs:
+                log_model = log.to_log_model()
+                log_model_dict[log_model['level']].append(log_model)
+            # 1.2 生成运行时
+            runtime_model = runtime.to_file_model(os.path.join(dir_path, "files"))
+            # 1.3 集合列
+            column_models = [c.to_column_model() for c in columns]
+            # 1.4 集合指标
+            scalar_models = [scalar.to_scalar_model() for scalar in scalars]
+            # 1.5 集合媒体
+            media_models = [media.to_media_model(os.path.join(dir_path, "media")) for media in medias]
+            assert client is not None, "Please log in first, use `swanlab login` to log in."
     except Exception as e:
         if raise_error:
             raise e
         else:
-            FONT.brush("", 20)
             return swanlog.error(f"❌  Error parsing backup file: {e}")
     # 第二部分，上传数据到云端
     try:
@@ -94,25 +93,23 @@ def sync(
             description=experiment.description,
             tags=experiment.tags,
         )
-        swanlog.info("🔁 Syncing...", end="")
-        stdout.flush()
-        # 3.2 上传日志
-        for key in log_model_dict:
-            if len(log_model_dict[key]) > 0:
-                uploader.upload_logs(log_model_dict[key])
-        # 3.3 上传运行时
-        uploader.upload_files([runtime_model])
-        # 3.4 上传列、标量、媒体
-        uploader.upload_columns(column_models)
-        uploader.upload_scalar_metrics(scalar_models)
-        uploader.upload_media_metrics(media_models)
-        # 3.5 更新实验状态
-        client.update_state(success=footer.success if footer else False)
-        swanlog.info("🚀 Sync completed, View run at ", client.web_exp_url)
+        with Status("🔁 Syncing...", spinner="dots"):
+            # 3.2 上传日志
+            for key in log_model_dict:
+                if len(log_model_dict[key]) > 0:
+                    uploader.upload_logs(log_model_dict[key])
+            # 3.3 上传运行时
+            uploader.upload_files([runtime_model])
+            # 3.4 上传列、标量、媒体
+            uploader.upload_columns(column_models)
+            uploader.upload_scalar_metrics(scalar_models)
+            uploader.upload_media_metrics(media_models)
+            # 3.5 更新实验状态
+            client.update_state(success=footer.success if footer else False)
     except Exception as e:
         if raise_error:
             raise e
         else:
-            FONT.brush("", 500)
             swanlog.error(f"❌  Error uploading data: {e}")
             return
+    swanlog.info("🚀 Sync completed, View run at ", client.web_exp_url)

--- a/swanlab/toolkit/__init__.py
+++ b/swanlab/toolkit/__init__.py
@@ -1,0 +1,47 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2025/6/19 16:05
+@description: 全局、用户可访问工具依赖
+"""
+
+from swankit.callback import SwanKitCallback
+from swankit.callback.models import *
+from swankit.core import *
+from swankit.env import *
+
+from .logger import SwanKitLogger
+
+__all__ = [
+    # logger
+    "SwanKitLogger",
+    # env
+    "SwanLabSharedEnv",
+    "SwanLabMode",
+    "create_time",
+    "is_macos",
+    "is_windows",
+    "get_save_dir",
+    "get_swanlog_dir",
+    "get_mode",
+    # callback
+    "SwanKitCallback",
+    "ColumnInfo",
+    "MetricInfo",
+    "MetricErrorInfo",
+    "RuntimeInfo",
+    "ColumnClass",
+    "SectionType",
+    "ColumnConfig",
+    "YRange",
+    # core
+    "BaseType",
+    "MediaType",
+    "ChartType",
+    "DataSuite",
+    "MediaBuffer",
+    "ParseResult",
+    "ParseErrorInfo",
+    "ChartReference",
+    "SwanLabSharedSettings",
+]

--- a/swanlab/toolkit/logger.py
+++ b/swanlab/toolkit/logger.py
@@ -1,0 +1,106 @@
+"""
+@author: cunyue
+@file: log.py
+@time: 2025/6/19 16:22
+@description: swanlab 终端日志输出器，添加了一些好看的样式
+"""
+
+from typing import Literal, Union
+
+from rich.console import Console
+from rich.text import Text
+
+Levels = Union[Literal["debug", "info", "warning", "error", "critical"], str]
+
+
+class SwanKitLogger:
+
+    def __init__(self, name=__name__.lower(), level: Levels = "info", file=None):
+        self.console = Console(file=file)
+        self.__level: int = 0
+        self.__config = {
+            "debug": (
+                10,
+                Text(name, style='grey54 bold', no_wrap=True) + Text(':', style="default"),
+            ),
+            "info": (
+                20,
+                Text(name, style='blue bold', no_wrap=True) + Text(':', style="default"),
+            ),
+            "warning": (
+                30,
+                Text(name, style='yellow bold', no_wrap=True) + Text(':', style="default"),
+            ),
+            "error": (
+                40,
+                Text(name, style='red bold', no_wrap=True) + Text(':', style="default"),
+            ),
+            "critical": (
+                50,
+                Text(name, style='red, bold', no_wrap=True) + Text(':', style="default"),
+            ),
+        }
+        self.__can_log = True
+
+        self.level = level
+
+    @property
+    def level(self):
+        return self.__level
+
+    @level.setter
+    def level(self, level: Levels):
+        """
+        设置日志等级
+        :param level: 日志等级，可选值为 debug, info, warning, error, critical，如果传入的值不在可选值中，则默认为 info
+        """
+        if level not in ("debug", "info", "warning", "error", "critical"):
+            _level = 20  # info
+        else:
+            _level = self.__config[level][0]
+        self.__level = _level
+
+    def disable_log(self):
+        """
+        关闭日志输出，实例化时默认开启
+        """
+        self.__can_log = False
+
+    def enable_log(self):
+        """
+        开启日志输出
+        """
+        self.__can_log = True
+
+    def __print(self, log_level: str, *args, **kwargs):
+        """
+        打印日志
+        """
+        if not self.__can_log:
+            return
+        level, prefix = self.__config[log_level]
+        if level < self.__level:
+            return
+        if kwargs.get("sep") == '':
+            prefix += " "
+        self.console.print(prefix, *args, **kwargs)
+
+    # 发送调试消息
+    def debug(self, *args, **kwargs):
+        return self.__print("debug", *args, **kwargs)
+
+    # 发送通知
+    def info(self, *args, **kwargs):
+        return self.__print("info", *args, **kwargs)
+
+    # 发生警告
+    def warning(self, *args, **kwargs):
+        return self.__print("warning", *args, **kwargs)
+
+    # 发生错误
+    def error(self, *args, **kwargs):
+        return self.__print("error", *args, **kwargs)
+
+    # 致命错误
+    def critical(self, *args, **kwargs):
+        return self.__print("critical", *args, **kwargs)

--- a/test/unit/cli/test_cli_logout.py
+++ b/test/unit/cli/test_cli_logout.py
@@ -7,10 +7,11 @@ r"""
 @Description:
     测试登出模块
 """
-from click.testing import CliRunner
-from swanlab.cli import cli
-import tutils as T
 import pytest
+from click.testing import CliRunner
+
+import tutils as T
+from swanlab.cli import cli
 
 
 # noinspection PyTypeChecker
@@ -19,7 +20,7 @@ def test_logout_ok(monkeypatch):
     runner = CliRunner()
     # 先登录
     runner.invoke(cli, ["login", "--api-key", T.API_KEY])
-    monkeypatch.setattr("builtins.input", lambda x: "y")
+    monkeypatch.setattr("builtins.input", lambda: "y")
     result = runner.invoke(cli, ["logout"])
     assert result.exit_code == 0
 
@@ -30,7 +31,7 @@ def test_logout_cancel(monkeypatch):
     runner = CliRunner()
     # 先登录
     runner.invoke(cli, ["login", "--api-key", T.API_KEY])
-    monkeypatch.setattr("builtins.input", lambda x: "n")
+    monkeypatch.setattr("builtins.input", lambda: "n")
     result = runner.invoke(cli, ["logout"])
     assert result.exit_code == 0
 

--- a/test/unit/core_python/test_client.py
+++ b/test/unit/core_python/test_client.py
@@ -12,11 +12,11 @@ import pytest
 import requests_mock
 import responses
 from responses import registries
-from swankit.core import MediaBuffer
 
 from swanlab.core_python import create_client, Client, CosClient
 from swanlab.core_python.auth import login_by_key
 from swanlab.package import get_host_api
+from swanlab.toolkit import MediaBuffer
 from tutils import is_skip_cloud_test, TEMP_PATH, API_KEY
 from tutils.setup import *
 

--- a/test/unit/data/callbacker/test_local.py
+++ b/test/unit/data/callbacker/test_local.py
@@ -9,11 +9,11 @@ import os.path
 
 from freezegun import freeze_time
 from nanoid import generate
-from swankit.core import SwanLabSharedSettings
 
 import tutils as T
 from swanlab.data.callbacker.local import LocalRunCallback
 from swanlab.log.type import LogData
+from swanlab.toolkit import SwanLabSharedSettings
 
 
 def test_local_write_handler(monkeypatch):

--- a/test/unit/data/run/metadata/hardware/soc/test_apple.py
+++ b/test/unit/data/run/metadata/hardware/soc/test_apple.py
@@ -6,9 +6,9 @@
 """
 
 import pytest
-from swankit.env import is_macos
 
 from swanlab.data.run.metadata.hardware.soc.apple import AppleChipCollector
+from swanlab.toolkit import is_macos
 
 
 @pytest.mark.skipif(not is_macos(), reason="Apple chip info only available on macOS")

--- a/test/unit/log/backup/test_models.py
+++ b/test/unit/log/backup/test_models.py
@@ -6,11 +6,11 @@
 """
 
 import pytest
-from swankit.env import create_time
 
 from swanlab.log.backup.models import BaseModel, Log, Runtime
 from swanlab.log.backup.writer import write_runtime_info
 from swanlab.log.type import LogData, LogContent
+from swanlab.toolkit import create_time
 from tutils import TEMP_PATH
 
 
@@ -50,7 +50,7 @@ def test_log(log_type):
 @pytest.mark.parametrize("metadata", [None, {"key": "value"}])
 @pytest.mark.parametrize("config", [None, {"setting": "value"}])
 def test_runtime(conda, requirements, metadata, config):
-    from swankit.callback import RuntimeInfo
+    from swanlab.toolkit import RuntimeInfo
 
     # 1. runtime info -> runtime
     runtime_info = RuntimeInfo(requirements, metadata, config, conda)

--- a/test/unit/sync/test_sync.py
+++ b/test/unit/sync/test_sync.py
@@ -12,13 +12,13 @@ from typing import List
 import numpy as np
 import pytest
 from nanoid import generate
-from swankit.callback import MetricInfo
 
 import swanlab
 from swanlab import sync
 from swanlab.log.backup import BackupHandler
 from swanlab.log.backup.datastore import DataStore
 from swanlab.log.backup.models import ModelsParser
+from swanlab.toolkit import MetricInfo
 
 
 def test_sync():


### PR DESCRIPTION
本 PR 清理了 swankit 的导入代码，接下来我们考虑将 swankit 部分的代码合并进入 swanlab 源码中，不再分包，导入方式为：
```python
from swanlab.toolkit import ...
```
就目前而言 swankit 依旧存在，在此过渡期本质上`swanlab/toolkit`只是导入了 swankit 中的工具函数并暴露——但是未来 swankit 会被抛弃。

---

此外，使用 [rich](https://rich.readthedocs.io/en/latest/index.html) 代替了原本自己写的高亮格式化工具，现在不会再出现 windows 字符乱码的情况。


