### PR TITLE
Fix host string handling in save_key and add tests

### DIFF
--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -195,7 +195,9 @@ def save_key(username: str, password: str, host: str = None) -> bool:
     """
     if host is None:
         host = get_host_api()
-    host = host.rstrip("/api")
+    host = host.rstrip()
+    if host.endswith("/api"):
+        host = host[:-4]
     path = get_nrc_path()
     if not os.path.exists(path):
         with open(path, "w") as f:

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -167,6 +167,18 @@ class TestSaveKey:
         assert len(nrc.hosts) == 1
         assert nrc.authenticators(new_host) is not None
 
+    def test_host(self):
+        """
+        测试 host 的正确性
+        """
+        path = os.path.join(get_save_dir(), ".netrc")
+        password = nanoid.generate()
+        host = "https://swanlab.ai/api"
+        P.save_key("user", password, host=host)
+        nrc = netrc.netrc(path)
+        assert len(nrc.hosts) == 1
+        assert nrc.authenticators("https://swanlab.ai") is not None
+
     def test_duplicate(self):
         """
         测试重复保存，此时会略过保存，因此不会改变文件的修改时间


### PR DESCRIPTION
Improves host string processing in save_key by correctly removing trailing '/api' and whitespace. Adds unit tests to verify correct host handling and extends HostFormatter test coverage.

Thanks to https://github.com/kingdee for the feedback.
