### PR TITLE
Ensure netrc file is properly flushed and synced

### DIFF
--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -200,8 +200,8 @@ def save_key(username: str, password: str, host: str = None) -> bool:
         host = host[:-4]
     path = get_nrc_path()
     if not os.path.exists(path):
-        with open(path, "w") as f:
-            f.write("")
+        with open(path, 'w'):
+            pass
     nrc = netrc.netrc(path)
     new_info = (username, "", password)
     # 避免重复的写
@@ -211,6 +211,8 @@ def save_key(username: str, password: str, host: str = None) -> bool:
         nrc.hosts = {host: new_info}
         with open(path, "w") as f:
             f.write(nrc.__repr__())
+            f.flush()
+            os.fsync(f.fileno())
         return True
     return False
 


### PR DESCRIPTION
Added explicit flush and fsync calls after writing to the netrc file to ensure data is written to disk. Also simplified file creation logic when the file does not exist.

这应该能解决单测偶尔报错的问题
