### PR TITLE
Ensure netrc file is properly flushed and synced

### DIFF
--- a/swanlab/data/porter/__init__.py
+++ b/swanlab/data/porter/__init__.py
@@ -16,14 +16,13 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Literal, List, Union, Tuple
 
 import wrapt
-from swankit.callback import MetricInfo, ColumnInfo, RuntimeInfo
 
 from swanlab.core_python import get_client
 from swanlab.core_python.uploader.thread import ThreadPool, UploadType
 from swanlab.data.store import RunStore, get_run_store, reset_run_store
 from swanlab.log.type import LogData
 from swanlab.proto.v0 import Log, Header, Project, Experiment, Column, Metric, BaseModel, Runtime, Footer, Media, Scalar
-from swanlab.toolkit import create_time
+from swanlab.toolkit import MetricInfo, ColumnInfo, RuntimeInfo, create_time
 from .datastore import DataStore
 
 __all__ = ['DataPorter']

--- a/swanlab/data/porter/datastore.py
+++ b/swanlab/data/porter/datastore.py
@@ -228,8 +228,12 @@ class DataStore:
             # 4.3 写入最后一个数据块
             self._write_record(data[data_used:], LEVELDBLOG_LAST)
             # 刷写完整数据
-            self._fp.flush()
-            os.fsync(self._fp.fileno())
+            try:
+                self._fp.flush()
+                os.fsync(self._fp.fileno())
+            except OSError:
+                # 如果操作系统不支持 fsync，可能会抛出 OSError，忽略此错误即可
+                pass
             self._flush_offset = self._index
 
         return start_offset, self._index, self._flush_offset

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -200,8 +200,8 @@ def save_key(username: str, password: str, host: str = None) -> bool:
         host = host[:-4]
     path = get_nrc_path()
     if not os.path.exists(path):
-        with open(path, "w") as f:
-            f.write("")
+        with open(path, 'w'):
+            pass
     nrc = netrc.netrc(path)
     new_info = (username, "", password)
     # 避免重复的写
@@ -211,6 +211,8 @@ def save_key(username: str, password: str, host: str = None) -> bool:
         nrc.hosts = {host: new_info}
         with open(path, "w") as f:
             f.write(nrc.__repr__())
+            f.flush()
+            os.fsync(f.fileno())
         return True
     return False
 

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -12,6 +12,7 @@ import netrc
 import os
 import re
 from io import TextIOWrapper
+from pathlib import Path
 from typing import Optional
 
 import requests
@@ -214,8 +215,7 @@ def save_key(username: str, password: str, host: str = None) -> bool:
         host = host[:-4]
     path = get_nrc_path()
     if not os.path.exists(path):
-        with open(path, 'w'):
-            pass
+        Path(path).touch()
     nrc = netrc.netrc(path)
     new_info = (username, "", password)
     # 避免重复的写

--- a/swanlab/package.py
+++ b/swanlab/package.py
@@ -11,6 +11,7 @@ import json
 import netrc
 import os
 import re
+from io import TextIOWrapper
 from typing import Optional
 
 import requests
@@ -184,6 +185,19 @@ def get_key():
     return info[2]
 
 
+def flush_and_sync(file_obj: TextIOWrapper) -> None:
+    """
+    确保文件对象的内容被写入磁盘
+    :param file_obj: 文件对象
+    """
+    try:
+        file_obj.flush()
+        os.fsync(file_obj.fileno())
+    except OSError:
+        # 如果操作系统不支持fsync，可能会抛出OSError，忽略此错误即可
+        pass
+
+
 def save_key(username: str, password: str, host: str = None) -> bool:
     """
     保存key到对应的文件目录下，文件名称为.netrc（basename）
@@ -211,8 +225,7 @@ def save_key(username: str, password: str, host: str = None) -> bool:
         nrc.hosts = {host: new_info}
         with open(path, "w") as f:
             f.write(nrc.__repr__())
-            f.flush()
-            os.fsync(f.fileno())
+            flush_and_sync(f)
         return True
     return False
 

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -2,8 +2,6 @@ import json
 import netrc
 import os
 import time
-from io import TextIOWrapper
-from unittest.mock import MagicMock, patch
 
 import nanoid
 import pytest
@@ -254,25 +252,6 @@ class TestHasApiKey:
         self.save_api_key()
         os.environ[SwanLabEnv.API_HOST.value] = nanoid.generate()
         assert not P.has_api_key()
-
-
-class TestFlushAndSync:
-    def test_flush_and_fsync_called(self):
-        file_mock = MagicMock(spec=TextIOWrapper)
-        with patch("os.fsync") as fsync_mock:
-            P.flush_and_sync(file_mock)
-            file_mock.flush.assert_called_once()
-            file_mock.fileno.assert_called_once()
-            fsync_mock.assert_called_once_with(file_mock.fileno())
-
-    def test_ignore_oserror_on_fsync(self):
-        file_mock = MagicMock(spec=TextIOWrapper)
-        file_mock.fileno.side_effect = OSError
-        with patch("os.fsync") as fsync_mock:
-            P.flush_and_sync(file_mock)
-            file_mock.flush.assert_called_once()
-            file_mock.fileno.assert_called_once()
-            fsync_mock.assert_not_called()
 
 
 class TestHostFormatter:

--- a/test/unit/test_package.py
+++ b/test/unit/test_package.py
@@ -2,6 +2,8 @@ import json
 import netrc
 import os
 import time
+from io import TextIOWrapper
+from unittest.mock import MagicMock, patch
 
 import nanoid
 import pytest
@@ -252,6 +254,25 @@ class TestHasApiKey:
         self.save_api_key()
         os.environ[SwanLabEnv.API_HOST.value] = nanoid.generate()
         assert not P.has_api_key()
+
+
+class TestFlushAndSync:
+    def test_flush_and_fsync_called(self):
+        file_mock = MagicMock(spec=TextIOWrapper)
+        with patch("os.fsync") as fsync_mock:
+            P.flush_and_sync(file_mock)
+            file_mock.flush.assert_called_once()
+            file_mock.fileno.assert_called_once()
+            fsync_mock.assert_called_once_with(file_mock.fileno())
+
+    def test_ignore_oserror_on_fsync(self):
+        file_mock = MagicMock(spec=TextIOWrapper)
+        file_mock.fileno.side_effect = OSError
+        with patch("os.fsync") as fsync_mock:
+            P.flush_and_sync(file_mock)
+            file_mock.flush.assert_called_once()
+            file_mock.fileno.assert_called_once()
+            fsync_mock.assert_not_called()
 
 
 class TestHostFormatter:


### PR DESCRIPTION
Added explicit flush and fsync calls after writing to the netrc file to ensure data is written to disk. Also simplified file creation logic when the file does not exist.

这应该能解决单测偶尔报错的问题