### PR TITLE
Remove LocalRunCallback import and update callback imports

### DIFF
--- a/swanlab/data/callbacker/__init__.py
+++ b/swanlab/data/callbacker/__init__.py
@@ -3,7 +3,7 @@
 @file: __init__.py
 @time: 2025/6/21 17:10
 @description: 回调器模块，四大回调器对应 swanlab 的四种运行模式。
-1. local： 本地模式回调器
+1. local： 本地模式回调器，此回调不自动导出
 2. cloud： 云端模式回调器
 3. offline： 离线模式回调器
 4. disabled： 禁用回调器
@@ -11,5 +11,4 @@
 
 from .cloud import CloudPyCallback
 from .disabled import DisabledCallback
-from .local import LocalRunCallback
 from .offline import OfflineCallback

--- a/swanlab/data/utils.py
+++ b/swanlab/data/utils.py
@@ -11,7 +11,6 @@ from typing import Union, Optional, List
 from rich.text import Text
 
 from swanlab.core_python import auth
-from swanlab.data.callbacker import *
 from swanlab.data.formatter import check_load_json_yaml
 from swanlab.data.run import SwanLabRun
 from swanlab.data.run.helper import SwanLabRunOperator
@@ -165,6 +164,8 @@ def _create_operator(
     :param cbs: 用户传递的回调函数列表
     :return: SwanLabRunOperator, CloudRunCallback
     """
+    from swanlab.data.callbacker import DisabledCallback, CloudPyCallback, OfflineCallback
+
     c = []
     # 1.1. 禁用模式
     if mode == SwanLabMode.DISABLED.value:


### PR DESCRIPTION
Removed the import of LocalRunCallback from the callbacker module and updated dynamic imports in utils.py to only include necessary callbacks.

修复如果 dashboard 没安装时即使没有使用本地模式也报错的问题