### PR TITLE
Fix resume parameter handling and add env var tests

### DIFF
--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -201,7 +201,6 @@ class SwanLabInitializer:
             resume = 'allow'
         elif resume is False:
             resume = 'never'
-        resume = resume or 'never'
         # for https://github.com/SwanHubX/SwanLab/issues/809
         if experiment_name is None and kwargs.get("name", None) is not None:
             experiment_name = kwargs.get("name")
@@ -273,6 +272,7 @@ class SwanLabInitializer:
         if mode in ["offline", "local"] and user_settings.backup is False:
             raise RuntimeError("You can't use offline or local mode with backup=False!")
         # 8. 校验 resume 与 id
+        resume = resume or 'never'
         if resume == 'never':
             # 不允许传递 id
             if id is not None:

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -684,3 +684,32 @@ class TestResume:
         with pytest.raises(ValueError) as e:
             S.init(resume='must')
         assert str(e.value) == "You must pass id when resume=must."
+
+
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+class TestResumeWithEnv:
+    @staticmethod
+    def teardown_method():
+        """
+        清理环境变量
+        """
+        if SwanLabEnv.RESUME.value in os.environ:
+            del os.environ[SwanLabEnv.RESUME.value]
+
+    def test_resume_env(self):
+        """
+        测试通过环境变量设置 resume 参数
+        """
+        os.environ[SwanLabEnv.RESUME.value] = "allow"
+        S.init()
+        run_store = get_run_store()
+        assert run_store.resume == "allow"
+
+    def test_resume_env_passed(self):
+        """
+        显式传递 resume 参数时，环境变量中的 resume 参数不生效
+        """
+        os.environ[SwanLabEnv.RESUME.value] = "allow"
+        S.init(resume="never")
+        run_store = get_run_store()
+        assert run_store.resume == "never"


### PR DESCRIPTION
Moved the defaulting of the 'resume' parameter to later in the initialization process to ensure correct precedence. Added unit tests to verify that the resume parameter can be set via environment variable and that explicit arguments override environment variables.