### PR TITLE
Fix error key usage in SwanLabKey class

### DIFF
--- a/swanlab/data/run/key.py
+++ b/swanlab/data/run/key.py
@@ -277,7 +277,7 @@ class SwanLabKey:
                     f"Invalid error format: {error}, expected and got must be provided. "
                     f"Maybe you need to update swanlab: pip install -U swanlab"
                 )
-            error = ParseErrorInfo(expected=error.get("expected"), got=error.get("got"), chart=chart)
+            error = ParseErrorInfo(expected=expected, got=got, chart=chart)
 
         column_info = ColumnInfo(
             key,

--- a/swanlab/data/run/key.py
+++ b/swanlab/data/run/key.py
@@ -270,8 +270,8 @@ class SwanLabKey:
             )
 
         if error is not None:
-            expected = error.get("expected")
-            got = error.get("got")
+            expected = error.get("excepted")
+            got = error.get("data_class")
             if expected is None or got is None:
                 raise RuntimeError(
                     f"Invalid error format: {error}, expected and got must be provided. "

--- a/test/unit/data/run/test_key.py
+++ b/test/unit/data/run/test_key.py
@@ -76,7 +76,7 @@ class TestMockKey:
                 key="test",
                 column_type="FLOAT",
                 column_class="CUSTOM",
-                error={"expected": "float", "got": "string"},
+                error={"excepted": "float", "data_class": "string"},
                 media_dir=run_state.store.media_dir,
                 log_dir=run_state.store.log_dir,
                 kid=0,
@@ -87,7 +87,7 @@ class TestMockKey:
 
     def test_column_with_error_unknown(self):
         """
-        测试传递错误信息时，如果 expected 或 got 为 None，应该报错
+        测试传递错误信息时，如果 excepted 或 data_class 为 None，应该报错
         因为这不符合目前的错误格式要求
         """
         with UseMockRunState() as run_state:
@@ -96,7 +96,7 @@ class TestMockKey:
                     key="test",
                     column_type="FLOAT",
                     column_class="CUSTOM",
-                    error={"expected": None, "got": "string"},
+                    error={"excepted": None, "data_class": "string"},
                     media_dir=run_state.store.media_dir,
                     log_dir=run_state.store.log_dir,
                     kid=0,
@@ -104,7 +104,7 @@ class TestMockKey:
                 )
             assert (
                 str(exc_info.value)
-                == "Invalid error format: {'expected': None, 'got': 'string'}, expected and got must be provided. "
+                == "Invalid error format: {'excepted': None, 'data_class': 'string'}, expected and got must be provided. "
                 "Maybe you need to update swanlab: pip install -U swanlab"
             )
 


### PR DESCRIPTION
Corrected the keys used to extract 'expected' and 'got' values from the error dictionary to 'excepted' and 'data_class', ensuring proper error handling in the SwanLabKey class.

修复了面对错误类型图表时 resume 出错的问题
