### PR TITLE
feature: sync pro

### DIFF
--- a/swanlab/error.py
+++ b/swanlab/error.py
@@ -34,7 +34,10 @@ class APIKeyFormatError(Exception):
 
 
 class ValidationError(Exception):
-    """验证错误，此时后端验证用户的token或者api key失败"""
+    """验证错误，通常因为：
+    1. 此时后端验证用户的token或者api key失败
+    2. 本地日志文件完整性异常
+    """
 
     pass
 


### PR DESCRIPTION
本 PR 完善了 sync 功能的逻辑。

## 描述

本PR允许sync功能结合断点续训一起使用，经典场景为：

1. 用户使用 offline 功能，通过 nas 等网盘同步日志，此时可通过不断地sync上传实验指标信息
2. 用户在训练时网络中断，通过sync功能上传未被上传的日志

以上场景在底层被认为是`resume`功能的复用，在代码实现上也是如此

## API

从产品设计角度出发，在执行 sync 时依旧创建新的实验，断点续训被认为是可选操作，我们新增以下参数：

1. `--resume`：添加此参数后，swanlab将按照日志文件记录的项目、实验信息创建云端项目/实验，添加此参数后，`--project`、`--workspace`、`--id` 等参数完全作废
2. `--id`：用户可选将日志同步到任何实验，此参数被设置后，等价于使用`resume=auto`创建实验，此时`--project`、`--workspace`为必选项

## 注意事项

* 新版本日志与旧版本日志不兼容，这意味着新（旧）版本日志无法 sync 旧（新）版本日志文件
* 由于目前resume的技术限制，当传递了 `--resume` 或 `--id` 参数，不会同步实验运行时间（这与目前resume逻辑一致）
