### PR TITLE
fix: sync resume folder

### DIFF
--- a/swanlab/data/run/key.py
+++ b/swanlab/data/run/key.py
@@ -285,7 +285,7 @@ class SwanLabKey:
         if column_class == "SYSTEM":
             section_type: SectionType = "SYSTEM"
         else:
-            if chart.value == chart.ECHARTS.value:
+            if chart is ChartType.ECHARTS:
                 section_type = "CUSTOM"
             else:
                 section_type = "PUBLIC"

--- a/swanlab/data/run/key.py
+++ b/swanlab/data/run/key.py
@@ -281,7 +281,15 @@ class SwanLabKey:
                     f"Maybe you need to update swanlab: pip install -U swanlab"
                 )
             error = ParseErrorInfo(expected=expected, got=got, chart=chart)
-
+        # 3. 根据 column_class 和 chart 适配 section_type
+        if column_class == "SYSTEM":
+            section_type: SectionType = "SYSTEM"
+        else:
+            if chart.value == chart.ECHARTS.value:
+                section_type = "CUSTOM"
+            else:
+                section_type = "PUBLIC"
+        # 4. 创建 ColumnInfo 对象
         column_info = ColumnInfo(
             key,
             str(kid),
@@ -291,10 +299,10 @@ class SwanLabKey:
             chart_reference="STEP",
             error=error,
             section_name=None,
-            section_type="PUBLIC",
+            section_type=section_type,
         )
         key_obj.column_info = column_info
-        # 3. 设置当前步数，resume 后不允许设置历史步数，所以需要覆盖
+        # 5. 设置当前步数，resume 后不允许设置历史步数，所以需要覆盖
         if step is not None:
             for i in range(step + 1):
                 key_obj.steps.add(i)

--- a/test/resume/must.py
+++ b/test/resume/must.py
@@ -14,11 +14,6 @@ import swanlab
 run = swanlab.init()
 swanlab.log({"loss": 0.1, "accuracy": 0.9}, step=1)
 
-# 2. 继续一个不存在的实验
-try:
-    run = swanlab.init(id="".join(random.choices("abcdefghijklmnopqrstuvwxyz0123456789", k=21)), resume='must')
-except RuntimeError:
-    pass
 import time
 
 time.sleep(5)
@@ -33,3 +28,14 @@ assert not ll["loss"].is_error, "Expected loss metric to be logged successfully 
 assert not ll['accuracy'].is_error, "Expected accuracy metric to be logged successfully after reinit"
 assert ll['loss'].data == 0.5
 assert ll['accuracy'].data == 0.8
+
+# 2. 继续一个不存在的实验
+try:
+    run = swanlab.init(
+        id="".join(random.choices("abcdefghijklmnopqrstuvwxyz0123456789", k=21)),
+        resume='must',
+        reinit=True,
+    )
+    raise Exception("Should have raised exception")
+except RuntimeError:
+    pass

--- a/test/unit/data/run/test_key.py
+++ b/test/unit/data/run/test_key.py
@@ -18,6 +18,59 @@ class TestMockKey:
     """
 
     @pytest.mark.parametrize(
+        "column_class, expected_section_type",
+        [
+            ["CUSTOM", "PUBLIC"],
+            ["SYSTEM", "SYSTEM"],
+        ],
+    )
+    def test_column_class_ok(self, column_class, expected_section_type):
+        """
+        测试不同的 column_class 是否能正确映射到预期的 SectionType
+        """
+        with UseMockRunState() as run_state:
+            key_obj, column_info = SwanLabKey.mock_from_remote(
+                key="test",
+                column_type="FLOAT",
+                column_class=column_class,
+                error=None,
+                media_dir=run_state.store.media_dir,
+                log_dir=run_state.store.log_dir,
+                kid=0,
+                step=None,
+            )
+            assert column_info.section_type == expected_section_type
+
+    @pytest.mark.parametrize(
+        "column_type, expected_section_type",
+        [
+            ["FLOAT", "PUBLIC"],
+            ["IMAGE", "PUBLIC"],
+            ["AUDIO", "PUBLIC"],
+            ["TEXT", "PUBLIC"],
+            ["OBJECT3D", "PUBLIC"],
+            ["MOLECULE", "PUBLIC"],
+            ["ECHARTS", "CUSTOM"],
+        ],
+    )
+    def test_column_type_section_type(self, column_type, expected_section_type):
+        """
+        测试不同的 column_type 是否能正确映射到预期的 SectionType
+        """
+        with UseMockRunState() as run_state:
+            key_obj, column_info = SwanLabKey.mock_from_remote(
+                key="test",
+                column_type=column_type,
+                column_class="CUSTOM",
+                error=None,
+                media_dir=run_state.store.media_dir,
+                log_dir=run_state.store.log_dir,
+                kid=0,
+                step=None,
+            )
+            assert column_info.section_type == expected_section_type
+
+    @pytest.mark.parametrize(
         "column_type, expected_chart_type",
         [
             ["FLOAT", ChartType.LINE],


### PR DESCRIPTION
修复 sync  一个 resume 的 folder 会出现的列类型错误

现在的设计是 resume 时硬件监控不会开启，但是考虑到后续的更新，在backup file文件夹依旧保存了硬件监控相关的列信息
当 sync resume 的文件夹时就出现了列的类型错误，导致显示问题
