### PR TITLE
Increase timeout for subprocess calls to 5 seconds and catch all exce

### DIFF
--- a/swanlab/data/run/metadata/requirements.py
+++ b/swanlab/data/run/metadata/requirements.py
@@ -12,15 +12,15 @@ def get_requirements():
     """获取当前环境依赖"""
     try:
         # 运行pixi命令获取当前环境下的环境目录
-        result = subprocess.run(["pixi", "list"], capture_output=True, text=True, timeout=0.5)
+        result = subprocess.run(["pixi", "list"], capture_output=True, text=True, timeout=5)
         if result.returncode == 0:
             return result.stdout
 
         # 运行uv命令获取当前环境下的环境目录
-        result = subprocess.run(["uv", "pip", "list", "--format=freeze"], capture_output=True, text=True, timeout=0.5)
+        result = subprocess.run(["uv", "pip", "list", "--format=freeze"], capture_output=True, text=True, timeout=5)
         if result.returncode == 0:
             return result.stdout
-    except (FileNotFoundError, PermissionError):
+    except Exception:  # noqa: 捕获所有异常，避免因环境问题导致程序崩溃
         pass
 
     try:


### PR DESCRIPTION
## Description

Closes: #1210

Timeout for subprocess calls to 5 seconds and catch all exceptions to prevent crashes due to environment issues