### PR TITLE
Update documentation links to official SwanLab docs

### DIFF
--- a/swanlab/cli/commands/sync/__init__.py
+++ b/swanlab/cli/commands/sync/__init__.py
@@ -60,7 +60,7 @@ from swanlab.sync import sync as sync_logs
     default=None,
     type=str,
     help="The experiment ID to sync the logs to. It can only be used when the path is a single directory."
-    "For more details, see https://github.com/SwanHubX/SwanLab/pull/1194",  # TODO 换成官网文档链接
+    "For more details, see https://docs.swanlab.cn/api/cli-swanlab-sync.html",
 )
 def sync(path, api_key, workspace, project, host, id):
     """

--- a/swanlab/data/porter/datastore.py
+++ b/swanlab/data/porter/datastore.py
@@ -84,9 +84,8 @@ class DataStore:
         if magic != LEVELDBLOG_HEADER_MAGIC:
             raise Exception("Invalid header")
         if version != LEVELDBLOG_HEADER_VERSION:
-            # TODO 更换为文档链接
             raise Exception(
-                f"Invalid backup version: {version}. For supported versions, see: https://github.com/SwanHubX/SwanLab/pull/1194"
+                f"Invalid backup version: {version}. For supported versions, see: https://docs.swanlab.cn/api/cli-swanlab-sync.html"
             )
         self._index += len(header)
 


### PR DESCRIPTION
Replaced GitHub PR links with official documentation URLs in sync CLI help and DataStore exception messages for better reference and maintainability.
