### PR TITLE
fix(sdk): login choice 3

### DIFF
--- a/swanlab/data/utils.py
+++ b/swanlab/data/utils.py
@@ -105,7 +105,7 @@ def _init_mode(mode: str = None):
                 swanlog.warning("Invalid choice, please enter again:")
                 code = input("")
             if code == "3":
-                mode = "local"
+                mode = "offline"
             elif code == "2":
                 swanlog.info("You chose 'Use an existing swanlab account'")
                 swanlog.info("Logging into", Text(web_host, 'yellow'))


### PR DESCRIPTION
Updated the mode assignment from 'local' to 'offline' when the user selects option 3 in the _init_mode function. This likely aligns with updated terminology or functionality.

## Description

https://github.com/datawhalechina/happy-llm/issues/104

Solve the issue where the user needs to install `swanlab[board]` when running code option 3.
