### PR TITLE
fix(api): fix method `get_summary` in class `OpenApi`

### DIFF
--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -125,8 +125,8 @@ class ExperimentAPI(ApiBase):
             "projectId": pro_id,
         }
         if root_exp_id and root_pro_id:
-            data["rootExperimentId"] = root_exp_id
-            data["rootProjectId"] = root_pro_id
+            data["rootExpId"] = root_exp_id
+            data["rootProId"] = root_pro_id
 
         resp = self.http.post("/house/metrics/summaries", data=[data], params={})
         if resp.errmsg:

--- a/swanlab/api/main.py
+++ b/swanlab/api/main.py
@@ -210,8 +210,8 @@ class OpenApi:
         return self.experiment.get_summary(
             exp_id=exp_id,
             pro_id=project_cuid,
-            root_exp_id=exp.data.get("rootProId", ""), 
-            root_pro_id=exp.data.get("rootExpId", "")
+            root_exp_id=exp.data.get("rootExpId", ""), 
+            root_pro_id=exp.data.get("rootProId", "")
         )
 
     def get_metrics(


### PR DESCRIPTION
## Description

- When integrating SwanLab's OpenAPI into MCP Server tools, the `get_metrics` function frequently throws a `list index out of range` error, preventing proper functionality. This pull request fixed this bug.

### Root Cause Analysis
Through systematic investigation and collaborative debugging, we identified the following error chain:
1. Immediate Cause: Line 135 in `swanlab/api/experiment.py` attempts to access `[0]` from an empty list
   ```python
   resp.data = list(resp.data.values())[0]  # Line 135
   ```
2. Underlying Cause: Line 131 returns an empty response (`resp.data` is empty)
    ```python
    resp = self.http.post("/house/metrics/summaries", data=[data], params={})  # Line 131
    ```
3. Root Cause: The HTTP request returns empty results due to incorrect field naming in the data parameter format


Closes: #1244 

<!-- ## Tests -->
<!-- There are no hive tests yet -->
