### PR TITLE
chore: restrict pydantic version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psutil>=5.0.0
 pynvml
 boto3>=1.35.49
 botocore
-pydantic>=2.9.0
+pydantic<3
 pyecharts>=2.0.0
 wrapt>=1.17.0
 platformdirs>=4.2.0


### PR DESCRIPTION
Updated the pydantic dependency to require a version less than 3, instead of just >=2.9.0. This may help avoid compatibility issues with breaking changes in pydantic 3.x.

Thanks to @GuoPingPan 