### PR TITLE
Add verify command to check login status

### DIFF
--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -11,6 +11,7 @@ from typing import List
 
 from swanlab.api.base import ApiBase, ApiHTTP
 from swanlab.api.types import ApiResponse, Experiment, Pagination
+from swanlab.package import get_host_api
 
 try:
     from pandas import DataFrame
@@ -179,7 +180,12 @@ class ExperimentAPI(ApiBase):
             if resp.errmsg:
                 continue
 
-            url = resp.data.get("url", "")
+            url:str = resp.data.get("url", "")
+            # 私有化环境可能不会携带 ip：https://github.com/SwanHubX/SwanLab/issues/1267
+            if not (url.startswith('https://') or url.startswith('http://')):
+                url = get_host_api() + url  # url 已添加前缀 /
+
+
             df = pd.read_csv(url, index_col=0)
 
             if idx == 0:

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -11,7 +11,6 @@ from typing import List
 
 from swanlab.api.base import ApiBase, ApiHTTP
 from swanlab.api.types import ApiResponse, Experiment, Pagination
-from swanlab.package import get_host_api
 
 try:
     from pandas import DataFrame
@@ -180,12 +179,7 @@ class ExperimentAPI(ApiBase):
             if resp.errmsg:
                 continue
 
-            url:str = resp.data.get("url", "")
-            # 私有化环境可能不会携带 ip：https://github.com/SwanHubX/SwanLab/issues/1267
-            if not (url.startswith('https://') or url.startswith('http://')):
-                url = get_host_api() + url  # url 已添加前缀 /
-
-
+            url = resp.data.get("url", "")
             df = pd.read_csv(url, index_col=0)
 
             if idx == 0:

--- a/swanlab/cli/commands/__init__.py
+++ b/swanlab/cli/commands/__init__.py
@@ -7,7 +7,7 @@ r"""
 @Description:
     暴露子命令
 """
-from .auth import login, logout
+from .auth import login, logout, verify
 from .converter import convert
 from .dashboard import watch
 from .sync import sync

--- a/swanlab/cli/commands/auth/__init__.py
+++ b/swanlab/cli/commands/auth/__init__.py
@@ -9,3 +9,4 @@ r"""
 """
 from .login import login
 from .logout import logout
+from .verify import verify

--- a/swanlab/cli/commands/auth/verify.py
+++ b/swanlab/cli/commands/auth/verify.py
@@ -1,0 +1,25 @@
+"""
+@author: cunyue
+@file: verify.py
+@time: 2025/9/23 11:06
+@description: 验证用户当前登录状态
+"""
+
+import click
+from rich.text import Text
+
+from swanlab.core_python import auth
+from swanlab.error import KeyFileError
+from swanlab.log import swanlog
+from swanlab.package import get_key
+
+
+@click.command()
+def verify():
+    """Verify the current login status."""
+    try:
+        key = get_key()
+    except KeyFileError:
+        raise click.ClickException("You are not verified. Please use `swanlab login` to login.")
+    login_info = auth.code_login(key, save_key=False)
+    swanlog.info('You are logged into', login_info.web_host, 'as', Text(login_info.username, "bold"))

--- a/swanlab/cli/main.py
+++ b/swanlab/cli/main.py
@@ -26,6 +26,8 @@ def cli():
 cli.add_command(C.login)  # 登录
 # noinspection PyTypeChecker
 cli.add_command(C.logout)  # 登出
+# noinspection PyTypeChecker
+cli.add_command(C.verify)  # 验证当前登录状态
 
 # noinspection PyTypeChecker
 cli.add_command(C.watch)  # 启动服务

--- a/test/unit/cli/test_cli_verify.py
+++ b/test/unit/cli/test_cli_verify.py
@@ -26,7 +26,8 @@ def test_verify_ok():
 # noinspection PyTypeChecker
 def test_verify_error():
     runner = CliRunner()
-    del os.environ[T.SwanLabEnv.API_KEY.value]
+    if T.SwanLabEnv.API_KEY.value in os.environ:
+        del os.environ[T.SwanLabEnv.API_KEY.value]
     result = runner.invoke(cli, ["verify"])
     assert result.exit_code == 1
     assert 'You are not verified. Please use `swanlab login` to login.' in result.output

--- a/test/unit/cli/test_cli_verify.py
+++ b/test/unit/cli/test_cli_verify.py
@@ -1,0 +1,32 @@
+"""
+@author: cunyue
+@file: test_cli_verify.py
+@time: 2025/9/23 11:22
+@description: 测试cli verify命令
+"""
+
+import os
+
+import pytest
+from click.testing import CliRunner
+
+import tutils as T
+from swanlab.cli.main import cli
+
+
+# noinspection PyTypeChecker
+@pytest.mark.skipif(T.is_skip_cloud_test, reason="skip cloud test")
+def test_verify_ok():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["verify"])
+    assert result.exit_code == 0
+    assert ("You are logged into " + T.WEB_HOST) in result.output
+
+
+# noinspection PyTypeChecker
+def test_verify_error():
+    runner = CliRunner()
+    del os.environ[T.SwanLabEnv.API_KEY.value]
+    result = runner.invoke(cli, ["verify"])
+    assert result.exit_code == 1
+    assert 'You are not verified. Please use `swanlab login` to login.' in result.output


### PR DESCRIPTION
Introduces a new 'verify' CLI command to validate the current user login status. Updates command registration and imports to include the new command.

Just use `swanlab verify` to check login status
