### PR TITLE
fix: change pydantic version constraint in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ psutil>=5.0.0
 pynvml
 boto3>=1.35.49
 botocore
-pydantic<3
+pydantic~=2.0
 pyecharts>=2.0.0
 wrapt>=1.17.0
 platformdirs>=4.2.0


### PR DESCRIPTION
在 #1257 中规定的pydantic版本有些宽松了，进行了一些调整


Closes: #1264 