### PR TITLE
feat: add interrupt handling for experiment termination

### DIFF
--- a/swanlab/core_python/client/__init__.py
+++ b/swanlab/core_python/client/__init__.py
@@ -374,14 +374,19 @@ class Client:
         self.pending = False
         return new
 
-    def update_state(self, success: bool, finished_at: str = None):
+    def update_state(self, success: bool, finished_at: str = None, interrupt: bool = False):
         """
         更新实验状态
         :param success: 实验是否成功
         :param finished_at: 实验结束时间，格式为 ISO 8601，如果不提供则使用当前时间
+        :param interrupt: 实验是否被中断
         """
+        if success:
+            state = "FINISHED"
+        else:
+            state = "ABORTED" if interrupt else "CRASHED"
         put_data = {
-            "state": "FINISHED" if success else "CRASHED",
+            "state": state,
             "finishedAt": finished_at,
             "from": "sdk",
         }

--- a/swanlab/data/callbacker/callback.py
+++ b/swanlab/data/callbacker/callback.py
@@ -66,9 +66,11 @@ class SwanLabRunCallback(SwanKitCallback):
         """
         异常退出清理函数
         """
+        interrupt = False
         # 1. 如果是KeyboardInterrupt异常，特殊显示
         if tp == KeyboardInterrupt:
             swanlog.info("KeyboardInterrupt by user")
+            interrupt = True
         else:
             swanlog.info("Error happened while training")
         # 2. 生成错误堆栈
@@ -78,7 +80,7 @@ class SwanLabRunCallback(SwanKitCallback):
             error += line
         error += str(val)
         # 3. 结束运行，注意此时终端错误还没打印
-        get_run().finish(SwanLabRunState.CRASHED, error=error)
+        get_run().finish(SwanLabRunState.CRASHED, error=error, interrupt=interrupt)
         assert swanlog.proxied is False, "except_handler should be called after swanlog.stop_proxy()"
         # 4. 打印终端错误，此时终端代理已经停止，不必担心此副作用
         print(error, file=sys.stderr)

--- a/swanlab/data/callbacker/cloud.py
+++ b/swanlab/data/callbacker/cloud.py
@@ -100,6 +100,8 @@ class CloudPyCallback(SwanLabRunCallback):
 
     def on_stop(self, error: str = None, *args, **kwargs):
         success = get_run().success
+        # FIXME 等合并 swankit 以后优化一下 interrupt 的传递问题
+        interrupt = kwargs.get("interrupt", False)
         http = get_client()
         if http.pending:
             swanlog.warning("This run was destroyed but it is pending!")
@@ -109,7 +111,7 @@ class CloudPyCallback(SwanLabRunCallback):
         self._unregister_sys_callback()
         self.porter.close_trace(success, error=error, epoch=error_epoch)
         # 更新实验状态，在此之后实验会话关闭
-        http.update_state(success)
+        http.update_state(success, interrupt=interrupt)
         reset_client()
         if not self.user_settings.backup:
             shutil.rmtree(self.run_store.run_dir, ignore_errors=True)

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -47,7 +47,6 @@ class RunStore(BaseModel):
     metrics: Optional[RemoteMetric] = None
     # 恢复实验时，云端实验的日志条数
     log_epoch: Optional[int] = None
-
     # ---------------------------------- 目录 ----------------------------------
     # 是否为临时目录，标识一些运行时环境
     tmp_dir: Optional[bool] = None


### PR DESCRIPTION
增加对 ctrl+c 的识别，提供一种新的实验状态

Related: #425 