### PR TITLE
Improve dependency checks and imports in metrics module

### DIFF
--- a/.github/workflows/test-when-pr.yml
+++ b/.github/workflows/test-when-pr.yml
@@ -23,9 +23,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # 缓存 pip 依赖
 
-      - name: Install Dependencies
+      - name: Install base Dependency
         run: |
           pip install -r requirements.txt
+
+      - name: Run Import
+        run: python -c "import swanlab"
+
+      - name: Install Dependencies
+        run: |
           pip install -r requirements-media.txt
           pip install -r requirements-dev.txt
           pip install -r requirements-dashboard.txt

--- a/swanlab/data/modules/custom_charts/metrics.py
+++ b/swanlab/data/modules/custom_charts/metrics.py
@@ -7,7 +7,6 @@
 
 import importlib.util
 
-import numpy as np
 import pyecharts.options as opts
 from pyecharts.charts import HeatMap, Line
 
@@ -33,7 +32,12 @@ def roc_curve(ground_truth, predictions, title=None) -> Line:
         If string, will use that as title. If None or False, no title.
     """
     _check_sklearn()
-    from sklearn import metrics
+    try:
+        from sklearn import metrics
+    except ImportError:
+        raise ImportError(
+            "scikit-learn is required for this function. Please install it via `pip install scikit-learn`."
+        )
 
     fpr, tpr, _ = metrics.roc_curve(ground_truth, predictions)
     roc_auc = metrics.auc(fpr, tpr)
@@ -98,7 +102,12 @@ def pr_curve(ground_truth, predictions, title=None) -> Line:
         If string, will use that as title. If None or False, no title.
     """
     _check_sklearn()
-    from sklearn import metrics
+    try:
+        from sklearn import metrics
+    except ImportError:
+        raise ImportError(
+            "scikit-learn is required for this function. Please install it via `pip install scikit-learn`."
+        )
 
     precision, recall, _ = metrics.precision_recall_curve(ground_truth, predictions)
     pr_auc = metrics.auc(recall, precision)
@@ -151,7 +160,13 @@ def confusion_matrix(ground_truth, predictions, class_names, title=None) -> Heat
             If string, will use that as title. If None or False, no title.
     """
     _check_sklearn()
-    from sklearn import metrics
+    try:
+        from sklearn import metrics
+        import numpy as np
+    except ImportError:
+        raise ImportError(
+            "scikit-learn and numpy are required for this function. Please install them via `pip install scikit-learn numpy`."
+        )
 
     cm = metrics.confusion_matrix(ground_truth, predictions)
     # normalized

--- a/swanlab/data/modules/custom_charts/metrics.py
+++ b/swanlab/data/modules/custom_charts/metrics.py
@@ -5,16 +5,8 @@
 @description: 基于 echarts 实现部分 metrics 图表
 """
 
-import importlib.util
-
 import pyecharts.options as opts
 from pyecharts.charts import HeatMap, Line
-
-
-def _check_sklearn():
-    """Check if scikit-learn is installed."""
-    if importlib.util.find_spec("sklearn") is None:
-        raise TypeError("scikit-learn is required for this function. Please install it via `pip install scikit-learn`.")
 
 
 def roc_curve(ground_truth, predictions, title=None) -> Line:
@@ -31,7 +23,6 @@ def roc_curve(ground_truth, predictions, title=None) -> Line:
         Title for the chart. If True, will use default title with AUC.
         If string, will use that as title. If None or False, no title.
     """
-    _check_sklearn()
     try:
         from sklearn import metrics
     except ImportError:
@@ -101,7 +92,6 @@ def pr_curve(ground_truth, predictions, title=None) -> Line:
         Title for the chart. If True, will use default title with AUC.
         If string, will use that as title. If None or False, no title.
     """
-    _check_sklearn()
     try:
         from sklearn import metrics
     except ImportError:
@@ -159,7 +149,6 @@ def confusion_matrix(ground_truth, predictions, class_names, title=None) -> Heat
             Title for the chart. If True, will use default title.
             If string, will use that as title. If None or False, no title.
     """
-    _check_sklearn()
     try:
         from sklearn import metrics
         import numpy as np


### PR DESCRIPTION
Added try-except blocks to provide clearer ImportError messages for missing scikit-learn and numpy dependencies in custom_charts/metrics.py. Updated the GitHub Actions workflow to run a basic import of swanlab after installing base dependencies, improving early detection of import issues.
