### PR TITLE
fix: rename __init__.py

### DIFF
--- a/swanlab/plugin/__init__.py
+++ b/swanlab/plugin/__init__.py
@@ -1,0 +1,14 @@
+from .notification import *
+from .writer import *
+
+__all__ = [
+    "EmailCallback",
+    "LarkCallback",
+    "PrintCallback",
+    "CSVWriter",
+    "DingTalkCallback",
+    "WXWorkCallback",
+    "DiscordCallback",
+    "SlackCallback",
+    "LogdirFileWriter",
+]

--- a/swanlab/plugin/__init___.py
+++ b/swanlab/plugin/__init___.py
@@ -1,4 +1,0 @@
-from .notification import EmailCallback, LarkCallback, PrintCallback, SlackCallback, DingTalkCallback, WXWorkCallback, DiscordCallback
-from .writer import CSVWriter, LogdirFileWriter
-
-__all__ = ["EmailCallback", "LarkCallback", "PrintCallback", "CSVWriter", "WebhookCallback", "DingTalkCallback", "WXWorkCallback", "DiscordCallback", "SlackCallback", "LogdirFileWriter"]


### PR DESCRIPTION
修复`__init__.py`文件的命名问题，并删除不希望用户使用的`WebhookCallback`基类