### PR TITLE
fix: localize issue templates to Chinese

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,58 +1,58 @@
-name: Bug report
-description: Create a bug report
+name: Bug 报告
+description: 创建 Bug 报告
 labels:
-  - 🐛 bug
-  - 🤔 unconfirmed
+  - 🐛🐛🐛 bug
+  - 🤔🤔 unconfirmed
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to file a bug report!
+        感谢您花时间提交 Bug 报告！
 
-        **Please note:**
-        1. General usage questions are not bug reports. If you're looking for support with your train, you can consider asking for help on the [community](https://docs.swanlab.cn/guide_cloud/community/online-support.html) instead.
-        2. `swanlab` can be integrated into other AI training frameworks, therefore bugs in other frameworks might cause errors in training that use `swanlab`. Please make sure that the bug you're experiencing is _caused by_ by `swanlab`.
-        3. If your issue appears to be network-related, you might want to [Report a network-related problem](https://github.com/SwanHubX/SwanLab/issues/new/choose) instead.
-        4. Bug reports without a reproduction may be closed immediately.
+        **请注意：**
+        1. 常规使用问题不属于 Bug 报告。如果您需要训练相关的帮助，可以考虑在[社区](https://docs.swanlab.cn/guide_cloud/community/online-support.html)寻求支持。
+        2. `swanlab` 可集成到其他 AI 训练框架中，因此其他框架的 Bug 可能导致使用 `swanlab` 的训练出错。请确保您遇到的 Bug 是由 `swanlab` *引起*的。
+        3. 如果您的问题似乎与网络相关，您可能需要[报告网络相关问题](https://github.com/SwanHubX/SwanLab/issues/new/choose)。
+        4. 没有复现步骤的 Bug 报告可能会被立即关闭。
   - type: checkboxes
     attributes:
-      label: Verifications
+      label: 确认项
       options:
-        - label: I've verified that the problem I'm experiencing isn't covered in [the docs](https://docs.swanlab.cn).
+        - label: 我已确认我遇到的问题在[文档](https://docs.swanlab.cn)中未有说明。
           required: true
-        - label: I've searched for similar, existing issues on [GitHub](https://github.com/SwanHubX/SwanLab/issues).
+        - label: 我已在 [GitHub](https://github.com/SwanHubX/SwanLab/issues) 上搜索过类似或已有的问题。
           required: true
-        - label: I have confirmed that this issue was not caused by a network error.
+        - label: 我已确认此问题并非由网络错误引起。
           required: true
   - type: textarea
     attributes:
-      label: Description
-      description: A clear and concise description of what the bug is.
+      label: 问题描述
+      description: 清晰、简洁地描述 Bug 是什么。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Mandatory reproduction Code
+      label: 必须的复现代码
       description: |
-        Please attach the code that can reproduce the bug, which can be a snippet, file, or repository. Our [template](https://github.com/SwanHubX/swanlab-bug-repro) might help you quickly create a new repository/snippet.
+        请附上能够复现 Bug 的代码，可以是一个片段、文件或仓库。我们的[模板](https://github.com/SwanHubX/swanlab-bug-repro)可能有助于您快速创建新仓库/代码片段。
       value: |
-        The core code is …
+        核心代码是 …
         
-        Steps to reproduce:
-        1. Open reproduction
-        2. Click on …
-        3. See error: …
+        复现步骤：
+        1. 打开复现
+        2. 点击 …
+        3. 看到错误： …
     validations:
       required: true
   - type: markdown
     attributes:
       value: |
-        **Creating a good reproduction takes time.**
+        **创建一个好的复现需要时间。**
 
-        To help us resolve the issue quickly, please simplify the reproduction as much as possible by removing any unnecessary code, files, and dependencies that are not directly related to the problem. The easier it is for us to see the issue, the faster we can help you.
+        为帮助我们快速解决问题，请尽可能简化复现，移除与问题不直接相关的任何不必要的代码、文件和依赖项。我们越容易看到问题，就能越快帮助您。
   - type: textarea
     attributes:
-      label: Error message
-      description: Please provide a complete error stack trace so we can quickly identify the issue.
+      label: 错误信息
+      description: 请提供完整的错误堆栈跟踪，以便我们快速定位问题。
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/02_network_report.yml
+++ b/.github/ISSUE_TEMPLATE/02_network_report.yml
@@ -1,67 +1,67 @@
-name: Network report
-description: Report a network-related problem
+name: 网络问题报告
+description: 报告网络相关问题
 labels:
-  - 👾 network
-  - 🤔 unconfirmed
+  - 👾👾 network
+  - 🤔🤔 unconfirmed
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a network issue!
+        感谢您报告网络问题！
 
-        **Critical Notes for Network Issues:**
-        1. Network problems often involve local environment (proxies, firewalls), server status, or client configs. Please provide detailed context.
-        2. Ensure the issue is SwanLab-specific: e.g., you can access [https://swanlab.cn](https://swanlab.cn) via a browser, but SwanLab SDK fails.
-        3. Include network test results (ping/traceroute/curl) and raw error logs.
-        4. Reports without sufficient network details may be closed temporarily.
+        **网络问题关键注意事项：**
+        1. 网络问题通常涉及本地环境（代理、防火墙）、服务器状态或客户端配置，请提供详细上下文。
+        2. 请确保问题是 SwanLab 特有的：例如，您可以通过浏览器访问 [https://swanlab.cn](https://swanlab.cn)，但 SwanLab SDK 却失败。
+        3. 请包含网络测试结果（ping/traceroute/curl）和原始错误日志。
+        4. 缺乏足够网络详情的报告可能会被暂时关闭。
   - type: checkboxes
     attributes:
-      label: Verifications
+      label: 确认项
       options:
-        - label: I've searched [GitHub Issues](https://github.com/SwanHubX/SwanLab/issues) for similar network problems.
+        - label: 我已在 [GitHub Issues](https://github.com/SwanHubX/SwanLab/issues) 中搜索过类似的网络问题。
           required: true
-        - label: I've tested basic connectivity to SwanLab services.
+        - label: 我已测试到 SwanLab 服务的基本连通性。
           required: true
-        - label: I have attempted basic troubleshooting steps, including restarting the device, switching networks (Wi-Fi/mobile data), and temporarily disabling VPN/proxy.
+        - label: 我已尝试基本故障排除步骤，包括重启设备、切换网络（Wi-Fi/移动数据）以及临时禁用 VPN/代理。
           required: true
   - type: textarea
     attributes:
-      label: Problem Description
-      description: A clear, concise summary of the network issue.
+      label: 问题描述
+      description: 清晰、简洁地总结网络问题。
     validations:
       required: true
   - type: input
     attributes:
-      label: SwanLab Version
-      description: E.g., 0.6.11 (run `swanlab --version` or `pip show swanlab`)
+      label: SwanLab 版本
+      description: 例如：0.6.11（运行 `swanlab --version` 或 `pip show swanlab` 查看）
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Network Environment
-      description: E.g., OS, network type, proxy/VPN, firewall, corporate network, etc.
+      label: 网络环境
+      description: 例如：操作系统、网络类型、代理/VPN、防火墙、公司网络等。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Ping Results
-      description: Run `ping swanlab.cn` and paste the complete results.
+      label: Ping 结果
+      description: 运行 `ping swanlab.cn` 并粘贴完整结果。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Traceroute Results
-      description: Run `traceroute swanlab.cn` (Windows `tracert swanlab.cn`) and paste the complete results.
+      label: Traceroute 结果
+      description: 运行 `traceroute swanlab.cn`（Windows 系统使用 `tracert swanlab.cn`）并粘贴完整结果。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Curl Results
-      description: Run `curl -v https://swanlab.cn` and paste the complete results.
+      label: Curl 结果
+      description: 运行 `curl -v https://swanlab.cn` 并粘贴完整结果。
     validations:
       required: false
   - type: markdown
     attributes:
       value: |
-        **Why This Matters:**
-        Network issues require context about your environment and connectivity. Logs like `curl -v` or `traceroute` help us distinguish between client misconfigurations, proxy blocks, or server-side problems. Thank you for your patience—we’ll prioritize resolving this once we have enough details!
+        **为何需要这些信息：**
+        网络问题需要了解您的环境和连接状况。诸如 `curl -v` 或 `traceroute` 等日志有助于我们区分是客户端配置错误、代理阻止还是服务器端问题。感谢您的耐心——一旦获得足够详细信息，我们将优先解决此问题！

--- a/.github/ISSUE_TEMPLATE/03_web_report.yml
+++ b/.github/ISSUE_TEMPLATE/03_web_report.yml
@@ -1,49 +1,49 @@
-name: Website report
-description: Report a website-related problem
+name: 网站问题报告
+description: 报告与网站相关的问题
 labels:
-  - 💥 website
-  - 🤔 unconfirmed
+  - 💥💥 website
+  - 🤔🤔 unconfirmed
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a website issue!
+        感谢您报告网站问题！
 
-        **Critical Notes for Website Issues:**
-        1. Website problems often involve browser settings, extensions, or network issues. Please provide detailed context.
-        2. Ensure the issue is SwanLab-specific.
-        3. Include browser console logs and network test results if applicable.
-        4. Reports without sufficient details may be closed temporarily.
+        **网站问题关键注意事项：**
+        1. 网站问题通常涉及浏览器设置、扩展程序或网络问题，请提供详细上下文。
+        2. 请确保问题是 SwanLab 特有的。
+        3. 请包含浏览器控制台日志和相关的网络测试结果。
+        4. 缺乏足够详情的报告可能会被暂时关闭。
   - type: checkboxes
     attributes:
-      label: Verifications
+      label: 确认项
       options:
-        - label: I've searched [GitHub Issues](https://github.com/SwanHubX/SwanLab/issues) for similar network problems.
+        - label: 我已在 [GitHub Issues](https://github.com/SwanHubX/SwanLab/issues) 中搜索过类似的网络问题。
           required: true
-        - label: I've tested basic connectivity to SwanLab services.
+        - label: 我已测试到 SwanLab 服务的基本连通性。
           required: true
-        - label: I have attempted basic troubleshooting steps, including restarting the browser, clearing cache, disabling extensions, switching networks (Wi-Fi/mobile data), and temporarily disabling VPN/proxy.
+        - label: 我已尝试基本故障排除步骤，包括重启浏览器、清除缓存、禁用扩展程序、切换网络（Wi-Fi/移动数据）以及临时禁用 VPN/代理。
           required: true
   - type: textarea
     attributes:
-      label: Problem Description
-      description: A clear, concise summary of the network issue.
+      label: 问题描述
+      description: 清晰、简洁地总结网络问题。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Browser Environment
-      description: E.g., browser type, version, OS. 
+      label: 浏览器环境
+      description: 例如：浏览器类型、版本、操作系统。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Browser Console Logs
-      description: Press F12 → Network Tab → Copy failed request details
+      label: 浏览器控制台日志
+      description: 按 F12 → 网络(Network)标签页 → 复制失败的请求详情
     validations:
       required: true
   - type: markdown
     attributes:
       value: |
-        **Why This Matters:**
-        Providing detailed information helps us quickly identify and resolve issues, improving the experience for everyone. Thank you!
+        **为何需要这些信息：**
+        提供详细信息有助于我们快速识别并解决问题，从而改善每个人的使用体验。感谢您的配合！

--- a/.github/ISSUE_TEMPLATE/04_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/04_feature_request.yml
@@ -1,39 +1,39 @@
-name: Feature request
-description: Suggest an idea for this project
+name: 功能请求
+description: 为项目提出功能建议
 labels:
-  - 🏠 advice
-  - 💪 enhancement
-  - 🤔 unconfirmed
+  - 🏠🏠🏠 advice
+  - 💪💪 enhancement
+  - 🤔🤔 unconfirmed
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to improve swanlab!
+      value: 感谢您花时间改进 SwanLab！
   - type: markdown
     attributes:
       value: |
-        Please keep in mind:
+        请注意：
 
-        - If you're looking for specific support with your project, you can consider [asking for community support](https://docs.swanlab.cn/guide_cloud/community/online-support.html) instead.
-        - If something doesn't work as expected, you might want to [create a bug report](https://github.com/SwanHubX/SwanLab/issues/new/choose) instead.
-        - Please double check the [docs](https://docs.swanlab.cn) to see if your feature request is already supported.
-        - Please also check the [existing issues](https://github.com/SwanHubX/SwanLab/issues) to see if your feature request was already discussed.
+        - 如果您需要项目相关的具体支持，可以考虑[寻求社区支持](https://docs.swanlab.cn/guide_cloud/community/online-support.html)。
+        - 如果功能未按预期工作，您可能需要[创建 Bug 报告](https://github.com/SwanHubX/SwanLab/issues/new/choose)。
+        - 请仔细查阅[文档](https://docs.swanlab.cn)，确认您请求的功能是否已支持。
+        - 请检查[现有议题](https://github.com/SwanHubX/SwanLab/issues)，确认您的功能请求是否已被讨论过。
 
-        If you have a feature request that has not been discussed yet, please fill out this form completely.
+        如果您有尚未讨论的功能请求，请完整填写此表单。
   - type: textarea
     attributes:
-      label: Is your feature request related to a problem? Please describe.
-      description: A clear and concise description of what the problem is. E.g. I'm always frustrated when …
+      label: 功能请求是否与某个问题相关？请描述。
+      description: 清晰、简洁地描述问题所在。例如：当……时，我总是感到困扰。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen.
+      label: 描述您希望的解决方案
+      description: 清晰、简洁地描述您期望实现的效果。
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered.
+      label: 描述您考虑过的替代方案
+      description: 清晰、简洁地描述您考虑过的任何替代解决方案或功能。
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Report self-hosting issue
+  - name: 报告自托管问题
     url: https://github.com/SwanHubX/self-hosted/issues
-    about: Report issues related to self-hosting SwanLab
-  - name: View documentation
+    about: 报告与自托管 SwanLab 相关的问题
+  - name: 查看文档
     url: https://docs.swanlab.cn
-    about: Check out the official docs for answers to common questions
-  - name: Get AI support
+    about: 查阅官方文档获取常见问题解答
+  - name: 获取 AI 支持
     url: https://chat.swanlab.cn
-    about: Chat with our AI assistant for quick answers to your questions
-  - name: Get community support
+    about: 与我们的 AI 助手交流，快速获取问题解答
+  - name: 获取社区支持
     url: https://docs.swanlab.cn/guide_cloud/community/online-support.html
-    about: Post your question where experienced developers can offer assistance
+    about: 在有经验的开发者可以提供帮助的社区发布您的问题


### PR DESCRIPTION
Translated all GitHub issue templates and config descriptions from English to Chinese, including bug, network, website, and feature request forms. Also updated label formatting for clarity and consistency.
