### PR TITLE
fix: add log_dir property to SwanLabLogger

### DIFF
--- a/swanlab/integration/pytorch_lightning.py
+++ b/swanlab/integration/pytorch_lightning.py
@@ -63,7 +63,7 @@ class SwanLabLogger(Logger):
         **kwargs: Any,
     ):
         super().__init__()
-        
+
         tags = tags or []
         tags.append("⚡️pytorch lightning") if "⚡️pytorch lightning" not in tags else None
 
@@ -91,7 +91,7 @@ class SwanLabLogger(Logger):
         if save_dir is not None:
             save_dir = os.fspath(save_dir)
         self._save_dir = save_dir
-    
+
     def update_config(self, config: Dict[str, Any]):
         swanlab.config.update(config)
 
@@ -100,7 +100,7 @@ class SwanLabLogger(Logger):
     def experiment(self) -> SwanLabRun:
         """创建实验"""
         swanlab.config["FRAMEWORK"] = "⚡️pytorch_lightning"
-        
+
         if swanlab.get_run() is None:
             self._experiment = swanlab.init(**self._swanlab_init)
         else:
@@ -205,6 +205,10 @@ class SwanLabLogger(Logger):
 
     @property
     def save_dir(self) -> Optional[str]:
+        return self._save_dir
+
+    @property
+    def log_dir(self) -> Optional[str]:
         return self._save_dir
 
     @property


### PR DESCRIPTION
## Description

add `log_dir` property to SwanLabLogger.

Reference implementation from wandb:

https://github.com/wandb/wandb/blob/f57cf2839e0d364027aa56b9ae3ae1dff266508a/wandb/integration/lightning/fabric/logger.py#L611-L619

This is specified in the base class `Logger` but missing in SwanLabLogger:

https://github.com/Lightning-AI/pytorch-lightning/blob/f58a176513bd0cdafec0228b9828d9cc9c63f22d/src/lightning/fabric/loggers/logger.py#L46-L50
