### PR TITLE
feat: allow job_type and group params

### DIFF
--- a/swanlab/core_python/client/__init__.py
+++ b/swanlab/core_python/client/__init__.py
@@ -296,6 +296,8 @@ class Client:
         exp_name,
         colors: Tuple[str, str],
         description: str = None,
+        job_type: str = None,
+        group: str = None,
         tags: List[str] = None,
         created_at: str = None,
         cuid: str = None,
@@ -306,6 +308,8 @@ class Client:
         :param exp_name: 所属实验名称
         :param colors: 实验颜色，有两个颜色
         :param description: 实验描述
+        :param job_type: 任务类型
+        :param group: 实验组
         :param tags: 实验标签
         :param created_at: 实验创建时间，格式为 ISO 8601
         :param cuid: 实验的唯一标识符，如果不提供则由后端生成
@@ -333,6 +337,8 @@ class Client:
             "createdAt": created_at,
             "colors": list(colors),
             "labels": labels if len(labels) else None,
+            "job": job_type,
+            "cluster": group,
             "cuid": cuid,
         }
         post_data = {k: v for k, v in post_data.items() if v is not None}  # 移除值为None的键

--- a/swanlab/data/porter/mounter.py
+++ b/swanlab/data/porter/mounter.py
@@ -63,6 +63,8 @@ class Mounter:
                 exp_name=run_store.run_name,
                 colors=run_store.run_colors,
                 description=run_store.description,
+                job_type=run_store.job_type,
+                group=run_store.group,
                 tags=run_store.tags,
                 cuid=run_store.run_id,
                 must_exist=run_store.resume == 'must',

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -95,6 +95,8 @@ class SwanLabInitializer:
         workspace: str = None,
         experiment_name: str = None,
         description: str = None,
+        job_type: str = None,
+        group: str = None,
         tags: List[str] = None,
         config: Union[dict, str] = None,
         logdir: str = None,
@@ -129,6 +131,10 @@ class SwanLabInitializer:
             The experiment description you currently have open,
             used for a more detailed introduction or labeling of the current experiment.
             If you do not provide this parameter, you can modify it later in the web interface.
+        job_type: str, optional
+            The job type of the current experiment, used to distinguish different types of experiments.
+        group : str, optional
+            The experiment group of the current experiment, used for grouping experiments.
         tags : List[str], optional
             The tags of the experiment, used for labeling the current experiment.
             If you do not provide this parameter, you can modify it later in the web interface.
@@ -177,7 +183,7 @@ class SwanLabInitializer:
                 - allow: If the run exists, it will be resumed, otherwise a new run will be created.
                 - never: You cannot pass the `id` parameter, and a new run will be created.
             You can also pass a boolean value, where `True` is equivalent to 'allow' and `False` is equivalent to 'never'.
-            [Note that] This parameter is only valid when mode='cloud'
+            [Notice that] This parameter is only valid when mode='cloud'
         id : str, optional
             The run ID of the previous run, which is used to resume the previous run.
         reinit : bool, optional
@@ -216,6 +222,8 @@ class SwanLabInitializer:
             load_data = check_load_json_yaml(load, load)
             experiment_name = _load_from_dict(load_data, "experiment_name", experiment_name)
             description = _load_from_dict(load_data, "description", description)
+            job_type = _load_from_dict(load_data, "job_type", job_type)
+            group = _load_from_dict(load_data, "group", group)
             tags = _load_from_dict(load_data, "tags", tags)
             config = _load_from_dict(load_data, "config", config)
             logdir = _load_from_dict(load_data, "logdir", logdir)
@@ -239,6 +247,8 @@ class SwanLabInitializer:
         project = _load_from_env(SwanLabEnv.PROJ_NAME.value, project)
         experiment_name = _load_from_env(SwanLabEnv.EXP_NAME.value, experiment_name)
         description = _load_from_env(SwanLabEnv.DESCRIPTION.value, description)
+        job_type = _load_from_env(SwanLabEnv.JOB.value, job_type)
+        group = _load_from_env(SwanLabEnv.GROUP.value, group)
         tags = _load_list_from_env(SwanLabEnv.TAGS.value, tags)
         resume = _load_from_env(SwanLabEnv.RESUME.value, resume)
         id = _load_from_env(SwanLabEnv.RUN_ID.value, id)
@@ -262,7 +272,19 @@ class SwanLabInitializer:
             if description != d:
                 swanlog.warning("The description has been truncated automatically.")
                 description = d
-        # 2.4 校验标签
+        # 2.4 校验任务类型
+        if job_type:
+            j = job_type.strip()
+            if j != job_type:
+                swanlog.warning("The job type has been stripped automatically.")
+                job_type = j
+        # 2.5 校验实验组
+        if group:
+            g = group.strip()
+            if g != group:
+                swanlog.warning("The group has been stripped automatically.")
+                group = g
+        # 2.6 校验标签
         if tags:
             new_tags = check_tags_format(tags)
             for i in range(len(tags)):
@@ -312,6 +334,8 @@ class SwanLabInitializer:
         run_store.project = project
         run_store.workspace = workspace
         run_store.visibility = public
+        run_store.job_type = job_type
+        run_store.group = group
         run_store.tags = tags
         run_store.description = description
         run_store.run_name = experiment_name

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -35,6 +35,10 @@ class RunStore(BaseModel):
     run_colors: Optional[Tuple[str, str]] = None
     # 实验标签
     tags: Optional[List[str]] = None
+    # 任务类型
+    job_type: Optional[str] = None
+    # 实验组
+    group: Optional[str] = None
     # 实验描述
     description: Optional[str] = None
     # 实验运行 ID

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -113,6 +113,14 @@ class SwanLabEnv(enum.Enum):
     """
     实验描述，用于为实验提供更详细的介绍或标注
     """
+    JOB = "SWANLAB_JOB_TYPE"
+    """
+    实验任务类型，用于标注当前实验的任务类型，例如分类、回归等
+    """
+    GROUP = "SWANLAB_GROUP"
+    """
+    实验组，用于将实验划分到不同的组别，便于管理和区分
+    """
     TAGS = "SWANLAB_TAGS"
     """
     实验标签，用于标注当前实验，多个标签用逗号分隔

--- a/swanlab/formatter.py
+++ b/swanlab/formatter.py
@@ -163,6 +163,28 @@ def check_tags_format(tags: List[str], auto_cut: bool = True) -> List[str]:
     return new_tags
 
 
+def check_job_type_format(job_type: str, auto_cut: bool = True) -> str:
+    """
+    检查任务类型格式，最大长度为256个字符，一个中文字符算一个字符
+    :param job_type: 任务类型
+    :param auto_cut: 是否自动截断，默认为True
+    :return: str 检查后的字符串
+    """
+    max_len = 255
+    return _auto_cut("job_type", job_type, max_len, auto_cut)
+
+
+def check_group_format(group: str, auto_cut: bool = True) -> str:
+    """
+    检查实验组格式，最大长度为256个字符，一个中文字符算一个字符
+    :param group: 实验组
+    :param auto_cut: 是否自动截断，默认为True
+    :return: str 检查后的字符串
+    """
+    max_len = 256
+    return _auto_cut("group", group, max_len, auto_cut)
+
+
 def check_run_id_format(run_id: str = None) -> Optional[str]:
     """
     检查运行ID格式，要求：


### PR DESCRIPTION
添加`job_type`和`group`两个参数，用于辅助分组

相应的环境变量为 `SWANLAB_JOB_TYPE` 和 `SWANLAB_GROUP`

closes: #1323 

closes: #1322 