### PR TITLE
feat: add support for custom webhook value in env

### DIFF
--- a/swanlab/data/run/metadata/cooperation/__init__.py
+++ b/swanlab/data/run/metadata/cooperation/__init__.py
@@ -5,7 +5,7 @@
 @description: 合作信息采集
 """
 
-from typing import TypedDict, Optional
+from typing import TypedDict, Optional, Union
 
 from swanlab.core_python import get_client
 from swanlab.env import get_mode, get_swanlog_dir
@@ -17,7 +17,7 @@ class SwanLabInfo(TypedDict):
     version: str
     mode: str
     swanlog_dir: str
-    exp_url: str
+    exp_url: Union[str, None]
 
 
 class CoopInfo(TypedDict):
@@ -41,6 +41,7 @@ def get_swanlab_info() -> SwanLabInfo:
         "version": get_package_version(),
         "mode": get_mode(),
         "swanlog_dir": get_swanlog_dir(),
+        "exp_url": None,
     }
     try:
         client = get_client()

--- a/swanlab/data/run/webhook.py
+++ b/swanlab/data/run/webhook.py
@@ -21,7 +21,10 @@ def try_send_webhook():
     webhook = os.getenv(SwanLabEnv.WEBHOOK.value)
     if not webhook:
         return
-    data = get_cooperation_info(swanlab=True)
+    value = os.getenv(SwanLabEnv.WEBHOOK_VALUE.value)
+    data = get_cooperation_info(swanlab=True) or {}
+    if value:
+        data["value"] = value
     try:
         requests.post(webhook, json=data)
     except Exception as e:  # noqa

--- a/swanlab/env.py
+++ b/swanlab/env.py
@@ -109,6 +109,10 @@ class SwanLabEnv(enum.Enum):
     """
     webhook地址。swanlab初始化完毕时，如果此环境变量存在，会调用此地址，发送消息。
     """
+    WEBHOOK_VALUE = "SWANLAB_WEBHOOK_VALUE"
+    """
+    webhook发送的自定义内容，以字符串读取此环境变量值后发送
+    """
     DESCRIPTION = "SWANLAB_DESCRIPTION"
     """
     实验描述，用于为实验提供更详细的介绍或标注


### PR DESCRIPTION
支持新的环境变量：SWANLAB_WEBHOOK_VALUE，在添加webhook的时候会自动发送该值（以字符串形式）
