### PR TITLE
feat(plugin): add Telegram notification callback

### DIFF
--- a/swanlab/plugin/__init__.py
+++ b/swanlab/plugin/__init__.py
@@ -12,4 +12,5 @@ __all__ = [
     "SlackCallback",
     "LogdirFileWriter",
     "BarkCallback",
+    "TelegramCallback",
 ]

--- a/test/plugin/notification_telegram.py
+++ b/test/plugin/notification_telegram.py
@@ -1,0 +1,47 @@
+"""
+@author: yugangcao
+@file: notification_telegram.py
+@time: 2025/12/05
+@description: 使用Telegram通知实验运行情况
+"""
+
+import argparse
+import random
+import time
+
+import swanlab
+from swanlab.plugin import TelegramCallback
+
+parser = argparse.ArgumentParser(description="测试Telegram通知功能")
+parser.add_argument('--api-key', type=str, default=None, help="SwanLab的API Key")
+parser.add_argument('--host', type=str, default=None, help="SwanLab的服务器地址")
+parser.add_argument("--bot-token", type=str, required=True, help="Telegram Bot Token (从@BotFather获取)")
+parser.add_argument("--chat-id", type=str, required=True, help="Telegram Chat ID (从@userinfobot获取)")
+parser.add_argument("--language", type=str, default="zh", choices=["zh", "en"], help="通知语言")
+parser.add_argument("--notify-on-start", action="store_true", help="实验开始时也发送通知")
+args = parser.parse_args()
+
+if args.api_key:
+    swanlab.login(api_key=args.api_key, host=args.host)
+# 集成TelegramCallback
+swanlab.register_callbacks([TelegramCallback(
+    bot_token=args.bot_token,
+    chat_id=args.chat_id,
+    language=args.language,
+    notify_on_start=args.notify_on_start,
+)])
+
+epochs = 50
+lr = 0.01
+offset = random.random() / 5
+# 初始化
+swanlab.init(description="测试Telegram通知功能", mode="cloud")
+swanlab.config.epochs = epochs
+swanlab.config.learning_rate = lr
+# 模拟训练
+for epoch in range(2, swanlab.config.epochs):
+    acc = 1 - 2**-epoch - random.random() / epoch - offset
+    loss = 2**-epoch + random.random() / epoch + offset
+    print(f"epoch={epoch}, accuracy={acc}, loss={loss}")
+    swanlab.log({"t/accuracy": acc, "loss": loss})
+    time.sleep(0.5)

--- a/test/plugin/test_notification_telegram.py
+++ b/test/plugin/test_notification_telegram.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+测试 TelegramCallback 插件
+参考 Discord/Slack 的测试风格，使用 responses 库 mock HTTP 请求
+"""
+import pytest
+import responses
+from unittest.mock import patch, MagicMock
+from swanlab.plugin import TelegramCallback
+from swanlab.plugin.notification import TelegramBot
+
+
+class TestTelegramBot:
+    """测试 TelegramBot 类"""
+
+    def test_init(self):
+        """测试初始化"""
+        bot = TelegramBot("test_token", "123456")
+        assert bot.bot_token == "test_token"
+        assert bot.chat_id == "123456"
+        assert bot.api_base == "https://api.telegram.org/bottest_token"
+
+    @responses.activate
+    def test_send_message_success(self):
+        """测试发送消息成功（使用 responses mock）"""
+        # Mock Telegram API 响应
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status=200,
+        )
+
+        bot = TelegramBot("test_token", "123456")
+        result = bot.send_message("Hello, World!")
+
+        assert result["ok"] is True
+        assert result["result"]["message_id"] == 123
+        assert len(responses.calls) == 1
+        
+        # 验证请求参数
+        import json
+        request_body = json.loads(responses.calls[0].request.body)
+        assert request_body["chat_id"] == "123456"
+        assert request_body["text"] == "Hello, World!"
+        assert request_body["parse_mode"] == "HTML"
+
+    @responses.activate
+    def test_send_message_with_markdown(self):
+        """测试使用 Markdown 格式发送消息"""
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": True, "result": {"message_id": 124}},
+            status=200,
+        )
+
+        bot = TelegramBot("test_token", "123456")
+        result = bot.send_message("**Bold** text", parse_mode="Markdown")
+
+        assert result["ok"] is True
+        import json
+        request_body = json.loads(responses.calls[0].request.body)
+        assert request_body["parse_mode"] == "Markdown"
+
+    @responses.activate
+    def test_send_message_api_error(self):
+        """测试 API 返回错误"""
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": False, "description": "Bad Request: chat not found"},
+            status=200,
+        )
+
+        bot = TelegramBot("test_token", "invalid_chat")
+        result = bot.send_message("Hello")
+
+        assert result["ok"] is False
+        assert "chat not found" in result["description"]
+
+    @responses.activate
+    def test_send_message_network_error(self):
+        """测试网络错误"""
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            body=Exception("Connection error"),
+        )
+
+        bot = TelegramBot("test_token", "123456")
+        with pytest.raises(Exception):
+            bot.send_message("Hello")
+
+
+class TestTelegramCallback:
+    """测试 TelegramCallback 类"""
+
+    def test_init(self):
+        """测试初始化"""
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        assert callback.bot.bot_token == "test_token"
+        assert callback.bot.chat_id == "123456"
+        assert callback.language == "zh"
+        assert callback.notify_on_start is False
+
+    def test_init_with_notify_on_start(self):
+        """测试带 notify_on_start 参数的初始化"""
+        callback = TelegramCallback("test_token", "123456", notify_on_start=True)
+        assert callback.notify_on_start is True
+
+    def test_init_english(self):
+        """测试英文语言初始化"""
+        callback = TelegramCallback("test_token", "123456", language="en")
+        assert callback.language == "en"
+
+    def test_str(self):
+        """测试 __str__ 方法"""
+        callback = TelegramCallback("test_token", "123456")
+        assert str(callback) == "TelegramCallback"
+
+    def test_on_init(self):
+        """测试 on_init 方法"""
+        callback = TelegramCallback("test_token", "123456")
+        callback.on_init("test_project", "test_workspace")
+        assert callback.project == "test_project"
+        assert callback.workspace == "test_workspace"
+
+    def test_on_init_with_optional_params(self):
+        """测试 on_init 方法带可选参数"""
+        callback = TelegramCallback("test_token", "123456")
+        callback.on_init("test_project", "test_workspace", public=True, logdir="/tmp/logs")
+        assert callback.project == "test_project"
+        assert callback.workspace == "test_workspace"
+
+    def test_before_init_experiment(self):
+        """测试 before_init_experiment 方法"""
+        callback = TelegramCallback("test_token", "123456")
+        callback.before_init_experiment(
+            run_id="test_run_id",
+            exp_name="test_exp",
+            description="test description",
+            colors=("#fff", "#000"),
+        )
+        assert callback.run_id == "test_run_id"
+        assert callback.exp_name == "test_exp"
+        assert callback.description == "test description"
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_success_zh(self, mock_get_url):
+        """测试创建成功通知内容（中文）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="stop", error=None)
+
+        assert "SwanLab 消息通知" in content
+        assert "实验已成功完成" in content
+        assert "test_project" in content
+        assert "test_workspace" in content
+        assert "test_exp" in content
+        assert "https://swanlab.cn/exp/123" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_success_en(self, mock_get_url):
+        """测试创建成功通知内容（英文）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="en")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="stop", error=None)
+
+        assert "SwanLab Notification" in content
+        assert "Experiment completed successfully" in content
+        assert "Project:" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_error_zh(self, mock_get_url):
+        """测试创建错误通知内容（中文）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="stop", error="内存不足")
+
+        assert "实验遇到错误" in content
+        assert "内存不足" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_error_en(self, mock_get_url):
+        """测试创建错误通知内容（英文）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="en")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="stop", error="Out of memory")
+
+        assert "Experiment failed" in content
+        assert "Out of memory" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_offline_zh(self, mock_get_url):
+        """测试离线模式通知内容（中文）"""
+        mock_get_url.return_value = None
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="stop", error=None)
+
+        assert "离线模式" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_offline_en(self, mock_get_url):
+        """测试离线模式通知内容（英文）"""
+        mock_get_url.return_value = None
+
+        callback = TelegramCallback("test_token", "123456", language="en")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="stop", error=None)
+
+        assert "offline mode" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_start_zh(self, mock_get_url):
+        """测试创建开始通知内容（中文）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="start")
+
+        assert "实验已开始" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_start_en(self, mock_get_url):
+        """测试创建开始通知内容（英文）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="en")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        content = callback._create_content(event="start")
+
+        assert "Experiment started" in content
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_create_content_none_description(self, mock_get_url):
+        """测试 description 为 None 时的处理"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = None
+
+        content = callback._create_content(event="stop", error=None)
+
+        assert "N/A" in content  # None 应该被替换为 N/A
+
+    @responses.activate
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_send_msg_success(self, mock_get_url):
+        """测试 send_msg 成功发送"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status=200,
+        )
+
+        callback = TelegramCallback("test_token", "123456")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        # 不应该抛出异常
+        callback.send_msg("Test message")
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_send_msg_failure(self, mock_get_url):
+        """测试 send_msg 发送失败"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": False, "description": "Bad Request"},
+            status=200,
+        )
+
+        callback = TelegramCallback("test_token", "123456")
+        # 不应该抛出异常，只打印错误信息
+        callback.send_msg("Test message")
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_on_stop_integration(self, mock_get_url):
+        """测试 on_stop 完整流程（集成测试）"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status=200,
+        )
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        callback.on_stop(error=None)
+
+        # 验证发送了请求
+        assert len(responses.calls) == 1
+        import json
+        request_body = json.loads(responses.calls[0].request.body)
+        assert "实验已成功完成" in request_body["text"]
+
+    @responses.activate
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_on_stop_with_error_integration(self, mock_get_url):
+        """测试 on_stop 带错误的完整流程"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status=200,
+        )
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        callback.on_stop(error="CUDA out of memory")
+
+        assert len(responses.calls) == 1
+        import json
+        request_body = json.loads(responses.calls[0].request.body)
+        assert "实验遇到错误" in request_body["text"]
+        assert "CUDA out of memory" in request_body["text"]
+
+    @responses.activate
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_on_run_with_notify_integration(self, mock_get_url):
+        """测试 on_run 带通知的完整流程"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_token/sendMessage",
+            json={"ok": True, "result": {"message_id": 123}},
+            status=200,
+        )
+
+        callback = TelegramCallback("test_token", "123456", notify_on_start=True, language="zh")
+        callback.project = "test_project"
+        callback.workspace = "test_workspace"
+        callback.exp_name = "test_exp"
+        callback.description = "test description"
+
+        callback.on_run()
+
+        assert len(responses.calls) == 1
+        import json
+        request_body = json.loads(responses.calls[0].request.body)
+        assert "实验已开始" in request_body["text"]
+
+    @responses.activate
+    def test_on_run_without_notify(self):
+        """测试 on_run 方法（禁用开始通知）"""
+        callback = TelegramCallback("test_token", "123456", notify_on_start=False)
+
+        callback.on_run()
+
+        # 不应该发送任何请求
+        assert len(responses.calls) == 0
+
+
+class TestTelegramCallbackEdgeCases:
+    """测试边界情况"""
+
+    def test_empty_bot_token(self):
+        """测试空 bot_token"""
+        callback = TelegramCallback("", "123456")
+        assert callback.bot.bot_token == ""
+        assert callback.bot.api_base == "https://api.telegram.org/bot"
+
+    def test_special_characters_in_chat_id(self):
+        """测试 chat_id 包含特殊字符（如频道 @username）"""
+        callback = TelegramCallback("test_token", "@my_channel")
+        assert callback.bot.chat_id == "@my_channel"
+
+    @patch("swanlab.plugin.notification.swanlab.get_url")
+    def test_html_escape_in_content(self, mock_get_url):
+        """测试内容中的 HTML 特殊字符"""
+        mock_get_url.return_value = "https://swanlab.cn/exp/123"
+
+        callback = TelegramCallback("test_token", "123456", language="zh")
+        callback.project = "test<project>"
+        callback.workspace = "test&workspace"
+        callback.exp_name = "test\"exp\""
+        callback.description = "test'description'"
+
+        # 不应该抛出异常
+        content = callback._create_content(event="stop", error=None)
+        assert "test<project>" in content
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+


### PR DESCRIPTION
- Add TelegramBot class for Telegram Bot API communication
- Add TelegramCallback class with bilingual support (en/zh)
- Support notification on experiment start (optional) and stop
- Support success/error/offline mode notifications
- Add comprehensive unit tests (30 test cases)
- Add integration test script following notification_bark.py style
- Export TelegramCallback in plugin __init__.py

## Description

Please include a concise summary, in clear English, of the changes in this pull request. If it closes an issue, please
mention it here.

Closes: #(issue)

## 🎯 PRs Should Target Issues

Before your create a PR, please check to see if there is [an existing issue](https://github.com/SwanHubX/SwanLab/issues)
for this change. If not, please create an issue before you create this PR, unless the fix is very small.

Not adhering to this guideline will result in the PR being closed.

<!-- ## Tests -->
<!-- There are no hive tests yet -->
