### PR TITLE
fix(core): add default timeout for request session

### DIFF
--- a/swanlab/core_python/session.py
+++ b/swanlab/core_python/session.py
@@ -24,7 +24,7 @@ class TimeoutHTTPAdapter(HTTPAdapter):
 
     def send(self, request, **kwargs):
         # 如果 kwargs 中没有显式设置 timeout，则使用 self.timeout
-        if self.timeout is not None and kwargs.get("timeout") is None:
+        if "timeout" not in kwargs and self.timeout is not None:
             kwargs["timeout"] = self.timeout
 
         return super().send(request, **kwargs)


### PR DESCRIPTION
目前项目存在的一个 Bug 是在 http 请求未响应的情况下，可能是由于网关的原因导致丢包，会导致阻塞上传请求，参考 [Requests - Timeout](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts)。

解决方案是为请求会话设置默认超时时间（60s），避免在请求后未接收到响应的情况下阻塞上传。
