### PR TITLE
fix: amd gpu abnormal display

### DIFF
--- a/swanlab/data/run/metadata/hardware/gpu/amd.py
+++ b/swanlab/data/run/metadata/hardware/gpu/amd.py
@@ -67,7 +67,7 @@ def get_amd_gpu_info() -> HardwareFuncResult:
 # Linux Logic (Initialization)
 # ==========================================
 
-def map_amd_gpu_linux() -> Tuple[Optional[str], dict]:
+def map_amd_gpu_linux() -> Tuple[Optional[str], Optional[dict]]:
     """
     初始化阶段：尝试获取显卡列表。
     虽然 rocm-smi 可能不稳定，但我们只在启动时跑一次。


### PR DESCRIPTION
修复这种在非AMD GPU上跑的程序，但显示AMD GPU的情况：

<img width="834" height="601" alt="image" src="https://github.com/user-attachments/assets/c1750a58-e6d9-4b88-b0f8-07e2879b098b" />
