### PR TITLE
feat: support tensorboard types filter and refactor converter

### DIFF
--- a/swanlab/cli/commands/converter/__init__.py
+++ b/swanlab/cli/commands/converter/__init__.py
@@ -109,7 +109,7 @@ def convert(
         workspace: str,
         logdir: str,
         tb_logdir: str,
-        tb_types: list,
+        tb_types: str,
         wb_project: str,
         wb_entity: str,
         wb_runid: str,

--- a/swanlab/converter/tfb/tfb_converter.py
+++ b/swanlab/converter/tfb/tfb_converter.py
@@ -29,7 +29,7 @@ class TFBConverter:
             self.types = SUPPORTED_TYPES
         else:
             self.types = self.types.split(",")
-            self.types = [type.strip().lower() for type in self.types]
+            self.types = [t.strip().lower() for t in self.types]
             self.types = list(set(self.types))
             if not all(type in SUPPORTED_TYPES for type in self.types):
                 raise ValueError(f"Unsupported types: {self.types}")
@@ -94,9 +94,7 @@ class TFBConverter:
                             tag_type = type_by_tags[tag]
                             if tag_type not in self.types:
                                 continue
-                            handler = handlers.get(tag_type)
-                            if not handler:
-                                continue
+                            handler = handlers[tag_type]
                             index += 1
                             for step, value, t in data:
                                 times.append(t)


### PR DESCRIPTION
## Description

为TensorBoard日志转化器增加`tb-types`参数，用于筛选log的指标类型（比如`scalar`）

命令示例：

```bash
swanlab convert -t tensorboard --tb_logdir logs --tb-types scalar
```

筛选多个类型：

```bash
swanlab convert -t tensorboard --tb_logdir logs --tb-types scalar,image
```

