### PR TITLE
fix: fix bugs when getting info when 'profile' param is None

### DIFF
--- a/swanlab/api/experiment/__init__.py
+++ b/swanlab/api/experiment/__init__.py
@@ -73,22 +73,14 @@ class Experiment:
         """
         Experiment configuration. Can be used as filter in the format of 'config.<key>'
         """
-        profile = getattr(self._data, 'profile', None)
-        if profile is not None:
-            return dict()
-        else:
-            return getattr(profile, 'config', dict())
+        return self._data.get('profile', dict()).get('config', dict())
 
     @property
     def summary(self) -> Dict[str, object]:
         """
         Experiment metrics data. Can be used as filter in the format of 'summary.<key>'
         """
-        profile = getattr(self._data, 'profile', None)
-        if profile is not None:
-            return dict()
-        else:
-            return getattr(profile, 'scalar', dict())
+        return self._data.get('profile', dict()).get('scalar', dict())
 
     @property
     def state(self) -> str:
@@ -123,10 +115,7 @@ class Experiment:
         """
         List of metric keys.
         """
-        if self.summary is not None:
-            return list(self.summary.keys())
-        else:
-            return list()
+        return list(self.summary.keys())
 
     @property
     def history_line_count(self) -> int:

--- a/swanlab/api/workspace/__init__.py
+++ b/swanlab/api/workspace/__init__.py
@@ -49,7 +49,7 @@ class Workspace:
         """
         Workspace profile.
         """
-        return getattr(self._data, 'profile', dict())
+        return self._data.get('profile', dict())
 
     @property
     def comment(self) -> str:


### PR DESCRIPTION
## Description

修复profile字段及相关信息在该字段为空时的value error

example code:
```python
import swanlab

if __name__ == '__main__':
    api = swanlab.Api()
    runs = api.runs(path='bainiantest/SwanLabkkkk')
    for run in runs:
        print(run.json())
```
