### PR TITLE
fix: name blank string convert to None

### DIFF
--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -264,9 +264,9 @@ class SwanLabInitializer:
             swanlog.warning(f"project name is too long, auto cut to {p}")
             project = p
         # 2.2 校验实验名称
-        # 处理空字符串情况
-        if experiment_name == "":
-            swanlog.warning("The experiment name is an empty string, automatically converted to None.")
+        # 处理空字符串或纯空格字符串情况
+        if experiment_name is not None and not experiment_name.strip():
+            swanlog.warning("The experiment name is an empty or whitespace-only string, automatically converted to None.")
             experiment_name = None
         if experiment_name:
             e = check_exp_name_format(experiment_name)


### PR DESCRIPTION
## Description

当`swanlab.init`传入的`experiment_name`为空字符串时，会报错:

```bash
ValueError: Experiment with CUID None is a cloned experiment (cloned experiments cannot be resumed).
```

现将其改为自动转成`None`，然后报一个warning