### PR TITLE
chore: bump swanboard to 0.1.9b2

### DIFF
--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,1 +1,1 @@
-swanboard==0.1.9b1
+swanboard==0.1.9b2


### PR DESCRIPTION
升级 swanboard ，解决watch时的问题


closes: #1427 