### PR TITLE
fix bug when getting exp profile using api.runs()

### DIFF
--- a/swanlab/api/experiment/__init__.py
+++ b/swanlab/api/experiment/__init__.py
@@ -116,7 +116,7 @@ class Experiment:
         """
         Experiment profile containing config, metadata, requirements, and conda.
         """
-        if not self._data.get('profile'):
+        if 'profile' not in self._data:
             self._data = get_single_experiment(self._client, path=self.path)
 
         return Profile(self._data.get('profile', {}))


### PR DESCRIPTION
## Description

If the experiment profile cannot be found in the response, use the interface requesting a single experiment to get the complete information for the experiment

