### PR TITLE
fix: dedup log collector

### DIFF
--- a/swanlab/core_python/uploader/thread/log_collector.py
+++ b/swanlab/core_python/uploader/thread/log_collector.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 r"""
 @DATE: 2024/4/1 19:40
 @File: log_collector.py
@@ -11,12 +10,13 @@ import time
 from typing import List, Optional
 
 from swanlab.core_python.types.uploader import UploadCallback
+from swanlab.core_python.uploader.upload import dedupe_metrics_by_key_step
 from swanlab.error import NetworkError, SyncError
 from swanlab.log import swanlog
 from swanlab.swanlab_settings import get_settings
+
 from .task_types import UploadType
-from .utils import LogQueue
-from .utils import ThreadUtil, ThreadTaskABC
+from .utils import LogQueue, ThreadTaskABC, ThreadUtil
 
 NETWORK_ERROR_INTERVAL = 30
 
@@ -80,6 +80,10 @@ class LogCollectorTask(ThreadTaskABC):
                 msg_count = len(msg[1])
                 total_count += msg_count
                 upload_tasks_dict[msg[0]].extend(msg[1])
+
+        for metric_type in (UploadType.SCALAR_METRIC, UploadType.MEDIA_METRIC):
+            if metric_type in upload_tasks_dict and len(upload_tasks_dict[metric_type]) > 1:
+                upload_tasks_dict[metric_type] = dedupe_metrics_by_key_step(upload_tasks_dict[metric_type])
 
         tasks_key_list = [key for key in upload_tasks_dict if len(upload_tasks_dict[key]) > 0]
 

--- a/swanlab/core_python/uploader/upload.py
+++ b/swanlab/core_python/uploader/upload.py
@@ -51,14 +51,16 @@ def dedupe_metrics_by_key_step(
     metrics: List[Union[ScalarModel, MediaModel]]
 ) -> List[Union[ScalarModel, MediaModel]]:
     """
-    对同一 key/step 的重复指标保留最后一次写入。
+    对同一 key/step 的重复指标保留写入序号最大的那条。
 
     训练过程中允许乱序覆盖已有 step，但上传线程会按类型聚合同一批消息。
-    如果重复 step 在同一批请求内直接原样发送，后端/展示层可能不会稳定地以最后一条为准。
+    下游去重应该依赖 metric epoch，而不是调用方传入列表的顺序。
     """
     deduped = {}
     for metric in metrics:
-        deduped[(metric.key, metric.step)] = metric
+        key = (metric.key, metric.step)
+        if key not in deduped or metric.epoch >= deduped[key].epoch:
+            deduped[key] = metric
     return list(deduped.values())
 
 

--- a/swanlab/core_python/uploader/upload.py
+++ b/swanlab/core_python/uploader/upload.py
@@ -7,15 +7,16 @@
 
 import inspect
 from functools import wraps
-from typing import List
+from typing import List, Union
 
 from swanlab.core_python.types.uploader import UploadCallback
 from swanlab.log import swanlog
-from .batch import MetricDict, create_data, trace_metrics
-from .model import ColumnModel, MediaModel, ScalarModel, FileModel, LogModel
-from ..api.service import upload_to_cos
-from ..client import get_client, safe_request, decode_response
+
 from ...error import ApiError
+from ..api.service import upload_to_cos
+from ..client import decode_response, get_client, safe_request
+from .batch import MetricDict, create_data, trace_metrics
+from .model import ColumnModel, FileModel, LogModel, MediaModel, ScalarModel
 
 
 def skip_if_empty(log_message: str):
@@ -44,6 +45,21 @@ def skip_if_empty(log_message: str):
 
 
 HOUSE_URL = '/house/metrics'
+
+
+def dedupe_metrics_by_key_step(
+    metrics: List[Union[ScalarModel, MediaModel]]
+) -> List[Union[ScalarModel, MediaModel]]:
+    """
+    对同一 key/step 的重复指标保留最后一次写入。
+
+    训练过程中允许乱序覆盖已有 step，但上传线程会按类型聚合同一批消息。
+    如果重复 step 在同一批请求内直接原样发送，后端/展示层可能不会稳定地以最后一条为准。
+    """
+    deduped = {}
+    for metric in metrics:
+        deduped[(metric.key, metric.step)] = metric
+    return list(deduped.values())
 
 
 @safe_request
@@ -146,6 +162,7 @@ def upload_columns(columns: List[ColumnModel], upload_callback: UploadCallback =
 
 
 __all__ = [
+    "dedupe_metrics_by_key_step",
     "MetricDict",
     "upload_logs",
     "upload_media_metrics",

--- a/swanlab/data/porter/__init__.py
+++ b/swanlab/data/porter/__init__.py
@@ -13,25 +13,39 @@ SwanLab 不生产数据，我们只是 AI 训练的搬运工，祝愿所有训�
 
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Literal, List, Union, Tuple, Callable
+from typing import Callable, List, Literal, Optional, Tuple, Union
 
 import wrapt
 
 from swanlab.core_python import get_client
 from swanlab.core_python.types.uploader import UploadCallback
-from swanlab.core_python.uploader import ColumnModel, ScalarModel, MediaModel
+from swanlab.core_python.uploader import ColumnModel, MediaModel, ScalarModel
 from swanlab.core_python.uploader.thread import ThreadPool, UploadType
+from swanlab.core_python.uploader.upload import dedupe_metrics_by_key_step
 from swanlab.data.store import RunStore, get_run_store, reset_run_store
 from swanlab.env import create_time
 from swanlab.error import ValidationError
 from swanlab.log.type import LogData
-from swanlab.proto.v0 import Log, Header, Project, Experiment, Column, Metric, BaseModel, Runtime, Footer, Media, Scalar
-from swanlab.toolkit import MetricInfo, ColumnInfo, RuntimeInfo
-from .datastore import DataStore
-from .mounter import Mounter
-from .utils import filter_metric, filter_epoch, filter_column
+from swanlab.proto.v0 import (
+    BaseModel,
+    Column,
+    Experiment,
+    Footer,
+    Header,
+    Log,
+    Media,
+    Metric,
+    Project,
+    Runtime,
+    Scalar,
+)
+from swanlab.toolkit import ColumnInfo, MetricInfo, RuntimeInfo
+
 from ...core_python.api.experiment import update_experiment_state
 from ...toolkit.models.log import LogContent
+from .datastore import DataStore
+from .mounter import Mounter
+from .utils import filter_column, filter_epoch, filter_metric
 
 __all__ = ['DataPorter', 'Mounter']
 
@@ -527,11 +541,11 @@ class DataPorter:
 
         # 统计待上传数量
         columns = list(filter(self._filter_column_by_key, [column.to_column_model() for column in self._columns]))
-        scalars = list(filter(self._filter_scalar_by_step, [scalar.to_scalar_model() for scalar in self._scalars]))
-        medias = list(
-            filter(
-                self._filter_media_by_step, [media.to_media_model(self._run_store.media_dir) for media in self._medias]
-            )
+        scalars = dedupe_metrics_by_key_step(
+            list(filter(self._filter_scalar_by_step, [scalar.to_scalar_model() for scalar in self._scalars]))
+        )
+        medias = dedupe_metrics_by_key_step(
+            list(filter(self._filter_media_by_step, [media.to_media_model(self._run_store.media_dir) for media in self._medias]))
         )
         logs = [log.to_log_model() for log in self._logs]
         log_count = 0

--- a/swanlab/data/run/key.py
+++ b/swanlab/data/run/key.py
@@ -42,8 +42,10 @@ class SwanLabKey:
         self.key = key
         # 当前 key 包含的 step
         self.steps = set()
-        # 当前 key 的 step 与首次写入 epoch 的映射，重复 step 覆盖时需要保持 epoch 不变
+        # 当前 key 的 step 与首次写入顺序的映射，用于定位本地原始分片并在覆盖时重写原位置。
         self._step_epochs: Dict[int, int] = {}
+        # 当前 key 的实际写入序号。覆盖写入需要拿到更新的序号，便于下游稳定识别“最新一次写入”。
+        self._write_epoch: int = 0
         # 当前 key 的 step 与摘要值的映射，用于覆盖时重建 summary
         self._step_summary_values: Dict[int, Optional[object]] = {}
         self.column_info: Optional[ColumnInfo] = None
@@ -118,7 +120,9 @@ class SwanLabKey:
         if not overwrite:
             self.steps.add(result.step)
             self._step_epochs[result.step] = len(self.steps)
-        epoch = self._step_epochs[result.step]
+        storage_epoch = self._step_epochs[result.step]
+        self._write_epoch += 1
+        write_epoch = self._write_epoch
         new_data = self.__new_metric(result.step, r, more=result.more)
 
         # 覆盖写入时，只有当前 step 持有的 extremum 被削弱/移除时才需要全量重建。
@@ -132,12 +136,12 @@ class SwanLabKey:
         swanlog.debug(
             f"{'Overwrite' if overwrite else 'Add'} data, key: {self.key}, step: {result.step}, data: {r}"
         )
-        mu = math.ceil(epoch / self.__slice_size)
+        mu = math.ceil(storage_epoch / self.__slice_size)
         return MetricInfo(
             column_info=self.column_info,
             metric=new_data.copy() if result.more is None else json.loads(json.dumps(new_data)),
             metric_summary=self._summary.copy(),
-            metric_epoch=epoch,
+            metric_epoch=write_epoch,
             metric_step=result.step,
             metric_buffers=result.buffers,
             metric_file_name=str(mu * self.__slice_size) + ".log",
@@ -371,4 +375,5 @@ class SwanLabKey:
             for i in range(step + 1):
                 key_obj.steps.add(i)
                 key_obj._step_epochs[i] = i + 1
+            key_obj._write_epoch = len(key_obj.steps)
         return key_obj, column_info

--- a/swanlab/data/run/key.py
+++ b/swanlab/data/run/key.py
@@ -71,6 +71,27 @@ class SwanLabKey:
         """判断当前tag对应的自动创建图表是否成功"""
         return self.column_info.error is None
 
+    def _allocate_epochs(self, step: int) -> Tuple[int, int, bool]:
+        """
+        为当前写入分配两个不同语义的 epoch：
+
+        - storage_epoch: step 首次出现时对应的原始槽位，用于定位本地分片文件
+        - write_epoch: 每次实际写入都递增的序号，用于判定同 step 的新旧顺序
+        """
+        overwrite = step in self._step_epochs
+        if not overwrite:
+            self.steps.add(step)
+            self._step_epochs[step] = len(self.steps)
+        storage_epoch = self._step_epochs[step]
+        self._write_epoch += 1
+        write_epoch = self._write_epoch
+
+        assert write_epoch >= storage_epoch, "write_epoch must not fall behind storage_epoch"
+        if overwrite:
+            assert write_epoch > storage_epoch, "overwrite must advance write_epoch while preserving storage_epoch"
+
+        return storage_epoch, write_epoch, overwrite
+
     def add(self, data: DataWrapper) -> MetricInfo:
         """添加一个数据，在内部完成数据类型转换
         如果转换失败，打印警告并退出
@@ -116,13 +137,7 @@ class SwanLabKey:
         # 4. 更新 summary 并添加数据
         # 如果为Line且为NaN或者INF，不更新summary
         r = result.strings or result.float
-        overwrite = result.step in self._step_epochs
-        if not overwrite:
-            self.steps.add(result.step)
-            self._step_epochs[result.step] = len(self.steps)
-        storage_epoch = self._step_epochs[result.step]
-        self._write_epoch += 1
-        write_epoch = self._write_epoch
+        storage_epoch, write_epoch, overwrite = self._allocate_epochs(result.step)
         new_data = self.__new_metric(result.step, r, more=result.more)
 
         # 覆盖写入时，只有当前 step 持有的 extremum 被削弱/移除时才需要全量重建。

--- a/swanlab/toolkit/models/metric.py
+++ b/swanlab/toolkit/models/metric.py
@@ -181,7 +181,7 @@ class MetricInfo:
         :param metric_buffers: 此指标的媒体数据，如果为None，表示没有媒体数据
         :param metric_summary: 此指标的摘要信息
         :param metric_step: 此指标的步数
-        :param metric_epoch: 此指标对应本地的行数
+        :param metric_epoch: 此指标的写入序号，用于下游判定同 step 数据的先后顺序
         :param metric_file_name: 此指标的文件名
         :param swanlab_logdir: swanlab在本次实验的log文件夹路径
         :param swanlab_media_dir: swanlab在本次实验的media文件夹路径

--- a/test/unit/core_python/uploader/test_upload.py
+++ b/test/unit/core_python/uploader/test_upload.py
@@ -7,11 +7,15 @@
 
 import time
 from typing import List
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from swanlab.core_python.uploader.batch import trace_metrics, MetricDict
+from swanlab.core_python.uploader.batch import MetricDict, trace_metrics
+from swanlab.core_python.uploader.model import ScalarModel
+from swanlab.core_python.uploader.thread.log_collector import LogCollectorTask
+from swanlab.core_python.uploader.thread.task_types import UploadType
+from swanlab.core_python.uploader.upload import dedupe_metrics_by_key_step
 
 
 @pytest.fixture
@@ -48,3 +52,39 @@ def test_trace_metrics_uploads_all_metrics_in_batches(mock_client):
         assert mock_client.post.call_count == 3
         end = time.time()
         assert end - start > 3
+
+
+def test_dedupe_metrics_by_key_step_keeps_latest_duplicate():
+    metrics = [
+        ScalarModel({"data": 1.0}, "loss", 50, 51),
+        ScalarModel({"data": 3.0}, "loss", 51, 52),
+        ScalarModel({"data": 2.0}, "loss", 50, 51),
+    ]
+
+    deduped = dedupe_metrics_by_key_step(metrics)
+
+    assert len(deduped) == 2
+    assert [(metric.key, metric.step, metric.metric["data"]) for metric in deduped] == [
+        ("loss", 50, 2.0),
+        ("loss", 51, 3.0),
+    ]
+
+
+def test_log_collector_upload_dedupes_duplicate_scalar_steps():
+    first = ScalarModel({"data": 1.0}, "loss", 50, 51)
+    second = ScalarModel({"data": 2.0}, "loss", 50, 51)
+    captured = {}
+
+    def fake_upload(metrics, upload_callback=None):
+        captured["metrics"] = metrics
+        return None, None
+
+    collector = LogCollectorTask()
+    collector.container = [(UploadType.SCALAR_METRIC, [first]), (UploadType.SCALAR_METRIC, [second])]
+
+    with patch.dict(UploadType.SCALAR_METRIC.value, {"upload": fake_upload}, clear=False):
+        collector.upload()
+
+    assert len(captured["metrics"]) == 1
+    assert captured["metrics"][0] is second
+    assert all(task_type != UploadType.SCALAR_METRIC for task_type, _ in collector.container)

--- a/test/unit/core_python/uploader/test_upload.py
+++ b/test/unit/core_python/uploader/test_upload.py
@@ -54,20 +54,24 @@ def test_trace_metrics_uploads_all_metrics_in_batches(mock_client):
         assert end - start > 3
 
 
-def test_dedupe_metrics_by_key_step_keeps_latest_duplicate():
+def test_dedupe_metrics_by_key_step_keeps_highest_epoch_duplicate():
     metrics = [
-        ScalarModel({"data": 1.0}, "loss", 50, 51),
         ScalarModel({"data": 3.0}, "loss", 51, 52),
-        ScalarModel({"data": 2.0}, "loss", 50, 51),
+        ScalarModel({"data": 3.0}, "loss", 51, 52),
+        ScalarModel({"data": 2.0}, "loss", 50, 53),
+        ScalarModel({"data": 1.0}, "loss", 50, 51),
     ]
 
     deduped = dedupe_metrics_by_key_step(metrics)
 
     assert len(deduped) == 2
-    assert [(metric.key, metric.step, metric.metric["data"]) for metric in deduped] == [
-        ("loss", 50, 2.0),
-        ("loss", 51, 3.0),
-    ]
+    assert {
+        (metric.key, metric.step, metric.epoch, metric.metric["data"])
+        for metric in deduped
+    } == {
+        ("loss", 50, 53, 2.0),
+        ("loss", 51, 52, 3.0),
+    }
 
 
 def test_log_collector_upload_dedupes_duplicate_scalar_steps():

--- a/test/unit/data/run/test_key.py
+++ b/test/unit/data/run/test_key.py
@@ -352,6 +352,17 @@ class TestKeySummary:
                 "num": 3,
             }
 
+    def test_overwrite_uses_latest_write_epoch_but_same_storage_file(self):
+        with UseMockRunState() as run_state:
+            key_obj = self._new_key(run_state)
+
+            first = self._add_line(key_obj, 1, 0)
+            overwrite = self._add_line(key_obj, 2, 0)
+
+            assert overwrite.metric_overwrite is True
+            assert overwrite.metric_epoch == first.metric_epoch + 1
+            assert overwrite.metric_file_path == first.metric_file_path
+
     def test_overwrite_current_max_demote_triggers_rebuild(self, monkeypatch):
         with UseMockRunState() as run_state:
             key_obj = self._new_key(run_state)

--- a/test/unit/data/run/test_key.py
+++ b/test/unit/data/run/test_key.py
@@ -360,6 +360,8 @@ class TestKeySummary:
             overwrite = self._add_line(key_obj, 2, 0)
 
             assert overwrite.metric_overwrite is True
+            assert key_obj._step_epochs[0] == 1
+            assert key_obj._write_epoch == overwrite.metric_epoch
             assert overwrite.metric_epoch == first.metric_epoch + 1
             assert overwrite.metric_file_path == first.metric_file_path
 

--- a/test/unit/data/run/test_main.py
+++ b/test/unit/data/run/test_main.py
@@ -155,7 +155,7 @@ class TestSwanLabRunLog:
             ll2 = run.log(data, step=3)
             assert all(ll2[k].metric_step == 3 for k in ll2)
             overwrite_data = {"a": 10, "b": 0.2, "c": {"d": 4}, "math.nan": 3, "math.inf": 5}
-            # 重复的step会被覆盖，且保留原有epoch
+            # 重复的step会被覆盖，并保留原有文件位置，同时拿到更新的写入序号
             ll3 = run.log(overwrite_data, step=3)
             assert all(ll3[k].is_error is False for k in ll3)
             assert all(ll3[k].column_error is None for k in ll3)
@@ -166,7 +166,8 @@ class TestSwanLabRunLog:
             assert ll3["math.nan"].data == 3
             assert ll3["math.inf"].data == 5
             assert all(ll3[k].metric_step == 3 for k in ll3)
-            assert all(ll3[k].metric_epoch == ll2[k].metric_epoch for k in ll3)
+            assert all(ll3[k].metric_epoch > ll2[k].metric_epoch for k in ll3)
+            assert all(ll3[k].metric_file_path == ll2[k].metric_file_path for k in ll3)
             assert all(ll3[k].metric_overwrite is True for k in ll3)
             # 如果是新的key的重复step，会被添加
             ll4 = run.log({"tmp": 1}, step=3)


### PR DESCRIPTION
## Description

- Deduplicate metrics with identical indexes to support overwriting, and preserve the natural incremental growth of epochs in local logs

Closes: #(issue)

## 🎯 PRs Should Target Issues
None