### PR TITLE
fix: support finish call multiple times

### DIFF
--- a/swanlab/data/run/main.py
+++ b/swanlab/data/run/main.py
@@ -33,6 +33,8 @@ class SwanLabRun:
     There should be only one instance of the SwanLabRun class for each experiment.
     """
 
+    _initialized: bool = False
+
     def __init__(
         self,
         metadata: dict = None,
@@ -54,6 +56,7 @@ class SwanLabRun:
         if self.is_started():
             raise RuntimeError("SwanLabRun has been initialized")
         global run, config
+        SwanLabRun._initialized = True
         run_store = get_run_store()
         # ---------------------------------- 初始化类内参数 ----------------------------------
         operator = operator or SwanLabRunOperator()
@@ -232,7 +235,11 @@ class SwanLabRun:
         # 5. 返回old_run
         # 上述步骤中只有客户端对象 client 不清空，其余全局变量全部清理
         if run is None:
-            raise RuntimeError("The run object is None, please call `swanlab.init` first.")
+            if SwanLabRun._initialized:
+                # 已经 finish 过，静默返回（幂等）
+                swanlog.warning("The run object is already finished.")
+                return
+            return
         if state == SwanLabRunState.CRASHED and error is None:
             raise ValueError("When the state is 'CRASHED', the error message cannot be None.")
         error = error if state == SwanLabRunState.CRASHED else None

--- a/swanlab/data/sdk.py
+++ b/swanlab/data/sdk.py
@@ -470,7 +470,6 @@ def log(
     return ll
 
 
-@should_call_after_init("You must call swanlab.init() before using finish()")
 def finish(state: SwanLabRunState = SwanLabRunState.SUCCESS, error=None):
     """
     Finish the current run and close the current experiment
@@ -480,8 +479,12 @@ def finish(state: SwanLabRunState = SwanLabRunState.SUCCESS, error=None):
     If you mark the experiment as 'CRASHED' manually, `error` must be provided.
     """
     run = get_run()
+    if run is None:
+        if not SwanLabRun._initialized:
+            raise RuntimeError("You must call swanlab.init() before using finish()")
+        return swanlog.warning("The run object is already finished.")
     if not run.running:
-        return swanlog.error("After experiment is finished, you can't call finish() again.")
+        return swanlog.warning("The run object is already finished.")
     run.finish(state, error)
 
 

--- a/test/unit/data/test_sdk.py
+++ b/test/unit/data/test_sdk.py
@@ -9,6 +9,7 @@ r"""
 """
 import os
 import random
+from unittest.mock import Mock
 
 import platformdirs
 import pytest
@@ -43,6 +44,24 @@ def setup_function():
 
 
 MODE = SwanLabEnv.MODE.value
+
+
+def test_finish_before_init_raises_runtime_error(monkeypatch):
+    monkeypatch.setattr(S.SwanLabRun, "_initialized", False)
+
+    with pytest.raises(RuntimeError, match=r"You must call swanlab\.init\(\) before using finish\(\)"):
+        S.finish()
+
+
+def test_finish_after_init_warns_when_called_twice(monkeypatch):
+    warning_mock = Mock()
+    monkeypatch.setattr(swanlog, "warning", warning_mock)
+
+    S.init(mode="local")
+    S.finish()
+    S.finish()
+
+    warning_mock.assert_any_call("The run object is already finished.")
 
 
 class TestInitModeFunc:


### PR DESCRIPTION
# Description
- Support `swanlab.finish()` called multi times

# Issues
#1531 