### PR TITLE
feat: detect and handle forked child processes in Run

### DIFF
--- a/swanlab/sdk/cmd/helper/__init__.py
+++ b/swanlab/sdk/cmd/helper/__init__.py
@@ -5,6 +5,7 @@
 @description: SwanLab SDK CMD 辅助函数
 """
 
+import os
 import threading
 from functools import wraps
 from typing import Callable
@@ -12,16 +13,22 @@ from typing import Callable
 from swanlab.sdk.internal.run import has_run
 
 _CMD_LOCK = threading.Lock()
+_CMD_PID = os.getpid()
 
 
 def with_cmd_lock(func):
     """
     全局锁装饰器。
     注意：此锁为不可重入锁 (Lock)，如果两个被此装饰器装饰的 API 相互调用，必定发生死锁
+    fork 后子进程中此锁可能处于已持有状态，检测到 fork 时替换为新锁
     """
 
     @wraps(func)
     def wrapper(*args, **kwargs):
+        global _CMD_LOCK, _CMD_PID
+        if os.getpid() != _CMD_PID:
+            _CMD_LOCK = threading.Lock()
+            _CMD_PID = os.getpid()
         with _CMD_LOCK:
             return func(*args, **kwargs)
 

--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -102,15 +102,6 @@ class RunMetrics:
             self._global_step += 1
             return self._global_step
 
-    def has_metric(self, key: str) -> bool:
-        """
-        检查是否存在指定的指标
-        :param key: 指标键
-        :return: 是否存在该指标
-        """
-        with self._lock:
-            return key in self._metrics
-
     def update_scalar(self, key: str, value: Union[float, int]):
         """
         更新标量指标状态

--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -7,7 +7,6 @@
 
 import math
 import sys
-import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Literal, Optional, Union
@@ -74,20 +73,24 @@ class MediaMetric:
 
 
 # 指标状态，实验运行过程中不断更新
+# 注意：此类不加锁保护。设计上对 RunMetrics 的写操作发生在以下线程：
+#   - next_step: 用户主线程（通过 Run.log，已在 with_api 锁内串行化）
+#   - next_system_step: Monitor Timer 线程（独立递增 system_step，与 next_step 互不干扰）
+#   - update_scalar: Consumer 线程（单线程消费队列，与 define_scalar/define_media 串行）
+#   - define_scalar/define_media: Consumer 线程（同上）
+# 如果未来引入多线程并发写入此对象，需要重新评估线程安全。
 @dataclass
 class RunMetrics:
     _global_step: int = 0
     _global_system_step: int = 0
-    _lock: threading.Lock = field(default_factory=threading.Lock)
     _metrics: Dict[str, Union[ScalarMetric, MediaMetric]] = field(default_factory=dict)
 
     def next_system_step(self) -> int:
         """
         获取下一个全局系统步数，用于系统内部监控指标
         """
-        with self._lock:
-            self._global_system_step += 1
-            return self._global_system_step
+        self._global_system_step += 1
+        return self._global_system_step
 
     def next_step(self, user_step: Optional[int] = None) -> int:
         """
@@ -95,12 +98,11 @@ class RunMetrics:
         在设计上我们允许用户在log时乱序设置step，但是global_step永远是最大的或者自增的那个，
         因此我们需要一个方法来获取当前的global_step，并且保证global_step是自增的
         """
-        with self._lock:
-            if user_step is not None:
-                self._global_step = max(self._global_step, user_step)
-                return user_step
-            self._global_step += 1
-            return self._global_step
+        if user_step is not None:
+            self._global_step = max(self._global_step, user_step)
+            return user_step
+        self._global_step += 1
+        return self._global_step
 
     def update_scalar(self, key: str, value: Union[float, int]):
         """
@@ -108,18 +110,17 @@ class RunMetrics:
         :param key: 指标键
         :param value: 标量值
         """
-        with self._lock:
-            scalar = self._metrics.get(key)
-            assert scalar is not None, f"Metric '{key}' does not exist."
-            assert isinstance(scalar, ScalarMetric), f"Metric '{key}' is not a scalar metric."
-            if math.isnan(value) or math.isinf(value):
-                console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
-                return
-            scalar.latest = value
-            if scalar.max is None or value > scalar.max:
-                scalar.max = value
-            if scalar.min is None or value < scalar.min:
-                scalar.min = value
+        scalar = self._metrics.get(key)
+        assert scalar is not None, f"Metric '{key}' does not exist."
+        assert isinstance(scalar, ScalarMetric), f"Metric '{key}' is not a scalar metric."
+        if math.isnan(value) or math.isinf(value):
+            console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
+            return
+        scalar.latest = value
+        if scalar.max is None or value > scalar.max:
+            scalar.max = value
+        if scalar.min is None or value < scalar.min:
+            scalar.min = value
 
     def define_scalar(
         self,
@@ -142,18 +143,17 @@ class RunMetrics:
         :param x_axis: x轴，可以是其他的标量，也可以是系统值"_step"或"_relative_time"
         :return:
         """
-        with self._lock:
-            assert key not in self._metrics, f"Metric '{key}' already exists."
-            x_axis = x_axis or "_step"
-            self._metrics[key] = ScalarMetric(
-                _chart=chart,
-                _chart_name=chart_name,
-                _name=name,
-                _system=system,
-                _color=color,
-                _x_axis=x_axis,
-                _type=ColumnType.COLUMN_TYPE_FLOAT,
-            )
+        assert key not in self._metrics, f"Metric '{key}' already exists."
+        x_axis = x_axis or "_step"
+        self._metrics[key] = ScalarMetric(
+            _chart=chart,
+            _chart_name=chart_name,
+            _name=name,
+            _system=system,
+            _color=color,
+            _x_axis=x_axis,
+            _type=ColumnType.COLUMN_TYPE_FLOAT,
+        )
 
     def define_media(self, key: str, media_type: ColumnType, path: Path):
         """
@@ -162,6 +162,5 @@ class RunMetrics:
         :param media_type: 媒体类型
         :param path: 媒体存储路径，绝对路径
         """
-        with self._lock:
-            assert key not in self._metrics, f"Metric '{key}' already exists."
-            self._metrics[key] = MediaMetric(_type=media_type, path=path)
+        assert key not in self._metrics, f"Metric '{key}' already exists."
+        self._metrics[key] = MediaMetric(_type=media_type, path=path)

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -61,35 +61,27 @@ __all__ = ["Run", "has_run", "get_run", "set_run", "clear_run"]
 from ..pkg.fs import safe_write
 
 
-def with_lock(func):
-    """线程安全装饰器，自动获取和释放外部API锁
-    Python 3.9 中无法定义在类内部
-    """
+def with_api(cmd: str, must_alive: bool = True):
+    """Run API 装饰器，统一处理：fork 检测、存活校验、线程安全
 
-    @wraps(func)
-    def wrapper(self, *args, **kwargs):
-        with self._api_lock:
-            return func(self, *args, **kwargs)
-
-    return wrapper
-
-
-def with_run(cmd: str):
-    """
-    run api装饰器，确保当前 run 实例激活
+    :param cmd: API 命令名，用于错误信息
+    :param must_alive: True 时要求 Run 存活，False 时仅做线程安全（如 finish 允许在非存活状态调用）
     """
 
     def decorator(f):
         @wraps(f)
         def wrapper(self: "Run", *args, **kwargs):
             if self._forked:
+                # fork 后子进程继承的锁可能已持有，替换为新锁避免死锁
+                self._api_lock = threading.RLock()
                 raise RuntimeError(
                     "SwanLab Run does not support fork yet. Use `multiprocessing.set_start_method('spawn')` "
                     "or call `swanlab.init()` in the child process."
                 )
-            if not self.alive:
+            if must_alive and not self.alive:
                 raise RuntimeError(f"`{cmd}` requires an active Run, call `swanlab.init()` first.")
-            return f(self, *args, **kwargs)
+            with self._api_lock:
+                return f(self, *args, **kwargs)
 
         return wrapper
 
@@ -152,7 +144,6 @@ class Run:
         self._ctx = ctx
         self._state: Union[FinishType, Literal["running"]] = "running"
         self._pid = os.getpid()
-        self._forked = False
         # 外部API锁，防止并发调用
         self._api_lock = threading.RLock()
         # 事件发射器：唯一的队列写入入口，可注入给内部系统组件
@@ -199,9 +190,6 @@ class Run:
         self._consumer.start()
 
         # ---------------------------------- 3. 注册副作用 ----------------------------------
-        # 注册 fork 回调：子进程中清除全局单例，让 swanlab.log() 等全局 API 自然失效
-        # 当前 CorePython 模式下仅做标记和清单例；未来 swanlab-core 模式下可在此重建连接
-        os.register_at_fork(after_in_child=self._handle_fork)
         # 设置全局运行实例
         set_run(self)
         # 注册退出钩子
@@ -219,17 +207,6 @@ class Run:
     # ----------------------------------
     # 私有钩子
     # ----------------------------------
-
-    def _handle_fork(self) -> None:
-        """fork 回调，在子进程中执行。
-
-        当前 CorePython 模式：仅做标记 + 清除全局单例，子进程无法继续使用父进程的 Run。
-        未来 swanlab-core 模式：可在此重建 emitter/consumer/monitor 等，使子进程无需重新 init。
-        """
-        if not self.alive:
-            return
-        self._forked = True
-        clear_run()
 
     def _handle_sigint(self, signum: int, frame: Any) -> None:
         """SIGINT handler：确保 Ctrl+C 能可靠地将实验标记为 aborted。
@@ -329,6 +306,11 @@ class Run:
         return f"{settings.web_host}/@{settings.project.workspace}/{settings.project.name}/runs/{settings.run.id}"
 
     @property
+    def _forked(self) -> bool:
+        """当前进程是否为创建 Run 时的进程的 fork 子进程"""
+        return os.getpid() != self._pid
+
+    @property
     def alive(self) -> bool:
         """
         If the run is alive. You can log metrics if the run is alive.
@@ -352,8 +334,7 @@ class Run:
     # ----------------------------------
     # 公开 API：只负责验证输入并发事件
     # ----------------------------------
-    @with_lock
-    @with_run("run.log()")
+    @with_api("run.log()")
     def log(self, data: Mapping[str, Any], step: Optional[int] = None):
         """Log a dictionary of metrics for the current step.
 
@@ -385,8 +366,7 @@ class Run:
         # 推送日志事件
         self._emitter.emit(MetricLogEvent(data=flatten_data, step=next_step, timestamp=ts))
 
-    @with_lock
-    @with_run("run.log_scalar()")
+    @with_api("run.log_scalar()")
     def log_scalar(self, *, key: str, value: Union[float, int], step: Optional[int] = None):
         """
         Log a scalar value.
@@ -397,8 +377,7 @@ class Run:
         """
         self.log({key: value}, step=step)
 
-    @with_lock
-    @with_run("run.log_text()")
+    @with_api("run.log_text()")
     def log_text(self, *, key: str, data: TextDatasType, caption: CaptionsType = None, step: Optional[int] = None):
         """
         A syntactic sugar for logging text data.
@@ -411,8 +390,7 @@ class Run:
         normalized_data = normalize_media_input(Text, data, caption=caption)
         self.log({key: normalized_data}, step=step)
 
-    @with_lock
-    @with_run("run.log_image()")
+    @with_api("run.log_image()")
     def log_image(
         self,
         *,
@@ -438,8 +416,7 @@ class Run:
         normalized_data = normalize_media_input(Image, data, mode=mode, caption=caption, size=size, file_type=file_type)
         self.log({key: normalized_data}, step=step)
 
-    @with_lock
-    @with_run("run.log_audio()")
+    @with_api("run.log_audio()")
     def log_audio(
         self,
         *,
@@ -461,8 +438,7 @@ class Run:
         normalized_data = normalize_media_input(Audio, data, caption=caption, sample_rate=sample_rate)
         self.log({key: normalized_data}, step=step)
 
-    @with_lock
-    @with_run("run.log_video()")
+    @with_api("run.log_video()")
     def log_video(
         self,
         *,
@@ -482,8 +458,7 @@ class Run:
         normalized_data = normalize_media_input(Video, data, caption=caption)
         self.log({key: normalized_data}, step=step)
 
-    @with_lock
-    @with_run("run.define_scalar()")
+    @with_api("run.define_scalar()")
     def define_scalar(
         self,
         *,
@@ -535,7 +510,7 @@ class Run:
             )
         )
 
-    @with_lock
+    @with_api("run.finish()", must_alive=False)
     def finish(self, state: FinishType = "success", error: Optional[str] = None):
         """Finish the current run and wait for all logs to be flushed.
 

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -9,6 +9,7 @@
 """
 
 import atexit
+import os
 import signal
 import sys
 import threading
@@ -81,6 +82,11 @@ def with_run(cmd: str):
     def decorator(f):
         @wraps(f)
         def wrapper(self: "Run", *args, **kwargs):
+            if self._forked:
+                raise RuntimeError(
+                    "SwanLab Run does not support fork yet. Use `multiprocessing.set_start_method('spawn')` "
+                    "or call `swanlab.init()` in the child process."
+                )
             if not self.alive:
                 raise RuntimeError(f"`{cmd}` requires an active Run, call `swanlab.init()` first.")
             return f(self, *args, **kwargs)
@@ -145,6 +151,8 @@ class Run:
         # ---------------------------------- 1. 基础状态准备 ----------------------------------
         self._ctx = ctx
         self._state: Union[FinishType, Literal["running"]] = "running"
+        self._pid = os.getpid()
+        self._forked = False
         # 外部API锁，防止并发调用
         self._api_lock = threading.RLock()
         # 事件发射器：唯一的队列写入入口，可注入给内部系统组件
@@ -191,16 +199,19 @@ class Run:
         self._consumer.start()
 
         # ---------------------------------- 3. 注册副作用 ----------------------------------
+        # 注册 fork 回调：子进程中清除全局单例，让 swanlab.log() 等全局 API 自然失效
+        # 当前 CorePython 模式下仅做标记和清单例；未来 swanlab-core 模式下可在此重建连接
+        os.register_at_fork(after_in_child=self._handle_fork)
         # 设置全局运行实例
         set_run(self)
         # 注册退出钩子
         self._sys_origin_excepthook = sys.excepthook
-        atexit.register(self._atexit_cleanup)
-        sys.excepthook = self._excepthook
+        atexit.register(self._handle_atexit)
+        sys.excepthook = self._handle_except
         # 注册 SIGINT handler，确保 Ctrl+C 能可靠地将实验标记为 aborted
         # sys.excepthook 在主线程阻塞于 C 扩展时可能无法触发
         self._original_sigint_handler = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGINT, self._sigint_handler)
+        signal.signal(signal.SIGINT, self._handle_sigint)
         # 绑定日志文件，运行正式开始
         if self._ctx.config.settings.mode != "disabled":
             log.bindfile(self._ctx.debug_dir)
@@ -209,14 +220,25 @@ class Run:
     # 私有钩子
     # ----------------------------------
 
-    def _sigint_handler(self, signum: int, frame: Any) -> None:
+    def _handle_fork(self) -> None:
+        """fork 回调，在子进程中执行。
+
+        当前 CorePython 模式：仅做标记 + 清除全局单例，子进程无法继续使用父进程的 Run。
+        未来 swanlab-core 模式：可在此重建 emitter/consumer/monitor 等，使子进程无需重新 init。
+        """
+        if not self.alive:
+            return
+        self._forked = True
+        clear_run()
+
+    def _handle_sigint(self, signum: int, frame: Any) -> None:
         """SIGINT handler：确保 Ctrl+C 能可靠地将实验标记为 aborted。
 
         sys.excepthook 依赖 Python 层面抛出 KeyboardInterrupt，但当主线程阻塞在 C 扩展（NumPy/PyTorch 等）时，
         KeyboardInterrupt 可能无法正常传播到 excepthook。
         此 handler 作为额外防线，在信号层直接处理。
         """
-        if self._state == "running":
+        if self.alive:
             console.info("KeyboardInterrupt by user")
             import traceback
 
@@ -233,14 +255,14 @@ class Run:
             # The default handler (SIG_DFL) raises KeyboardInterrupt.
             raise KeyboardInterrupt
 
-    def _atexit_cleanup(self) -> None:
+    def _handle_atexit(self) -> None:
         """程序正常退出时自动结束当前运行"""
-        if self._state != "running":
+        if not self.alive:
             return
         console.debug("SwanLab Run is finishing at exit...")
         self.finish()
 
-    def _excepthook(
+    def _handle_except(
         self,
         tp: Type[BaseException],
         val: BaseException,
@@ -248,7 +270,7 @@ class Run:
     ) -> None:
         """全局异常捕获，将实验标记为 crashed 或 aborted"""
         try:
-            if self._state != "running":
+            if not self.alive:
                 return
             state: FinishType = "crashed"
             if tp is KeyboardInterrupt:
@@ -312,7 +334,7 @@ class Run:
         If the run is alive. You can log metrics if the run is alive.
         :return: True if the run is alive, False otherwise
         """
-        return self._state == "running"
+        return not self._forked and self._state == "running"
 
     # ----------------------------------
     # 上下文管理器，允许用户以 with 语句启动和结束运行
@@ -522,7 +544,7 @@ class Run:
         """
         # 1. 状态校验
         # 有时执行finish也有可能是系统hook主动调用，此时无需再次打印警告，如果在finishing状态，也忽略
-        if self._state != "running":
+        if not self.alive:
             return
         state = state.lower()  # type: ignore
         if not (this_state := fmt.safe_validate_state(cast(FinishType, state))):
@@ -549,7 +571,7 @@ class Run:
         console.debug(f"SwanLab Run has finished with state: {self._state}, cleanup...")
         # 3.2 清理副作用
         console.debug("Cleanup system hook...")
-        atexit.unregister(self._atexit_cleanup)
+        atexit.unregister(self._handle_atexit)
         sys.excepthook = self._sys_origin_excepthook
         signal.signal(signal.SIGINT, self._original_sigint_handler)
         # 清理全局运行实例
@@ -579,7 +601,7 @@ def has_run() -> bool:
         ... else:
         ...     print("No active run")
     """
-    return _current_run is not None
+    return _current_run is not None and _current_run.alive
 
 
 def get_run() -> Run:

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -487,6 +487,7 @@ class TestInitConfigIntegration:
 # ============================================================
 
 
+@pytest.mark.skipif(not hasattr(__import__("os"), "register_at_fork"), reason="fork not available on this platform")
 class TestForkDetection:
     """测试 fork 检测机制：register_at_fork 回调 + with_run 拦截 + has_run 失效"""
 
@@ -542,8 +543,8 @@ class TestForkDetection:
         msg = result.get()
         assert "does not support fork" in msg
 
-    def test_fork_finish_noop_in_child(self):
-        """真实 fork 后，子进程中 finish() 不应抛异常"""
+    def test_fork_finish_raises_in_child(self):
+        """真实 fork 后，子进程中 finish() 也应抛出 RuntimeError"""
         run = init(mode="disabled")
 
         ctx = multiprocessing.get_context("fork")
@@ -552,14 +553,15 @@ class TestForkDetection:
         def child():
             try:
                 run.finish()
-                result.put("ok")
-            except Exception as e:
-                result.put(f"error: {e}")
+                result.put("no_error")
+            except RuntimeError as e:
+                result.put(str(e))
 
         p = ctx.Process(target=child)
         p.start()
         p.join(timeout=5)
-        assert result.get() == "ok"
+        msg = result.get()
+        assert "does not support fork" in msg
 
     def test_fork_does_not_affect_parent(self):
         """真实 fork 后，父进程中的 Run 应不受影响"""

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -14,6 +14,8 @@
   - TestInitCloudMode        : cloud 模式，依赖本文件内的 HTTP mock fixtures
 """
 
+import multiprocessing
+
 import pytest
 import responses as responses_lib
 import yaml
@@ -478,3 +480,121 @@ class TestInitConfigIntegration:
         assert data2["key2"]["value"] == "v2"
         # 两次 run 的 config_file 路径不同（时间戳不同）
         assert config_file1 != config_file2
+
+
+# ============================================================
+# TestForkDetection
+# ============================================================
+
+
+class TestForkDetection:
+    """测试 fork 检测机制：register_at_fork 回调 + with_run 拦截 + has_run 失效"""
+
+    def test_fork_sets_forked_flag(self):
+        """真实 fork 后，子进程中 Run._forked 应为 True"""
+        run = init(mode="disabled")
+        assert not run._forked
+
+        ctx = multiprocessing.get_context("fork")
+        result = ctx.Queue()
+
+        def child():
+            result.put(run._forked)
+
+        p = ctx.Process(target=child)
+        p.start()
+        p.join(timeout=5)
+        assert result.get() is True
+
+    def test_fork_clears_global_singleton(self):
+        """真实 fork 后，子进程中 has_run() 应返回 False"""
+        init(mode="disabled")
+        assert has_run()
+
+        ctx = multiprocessing.get_context("fork")
+        result = ctx.Queue()
+
+        def child():
+            result.put(has_run())
+
+        p = ctx.Process(target=child)
+        p.start()
+        p.join(timeout=5)
+        assert result.get() is False
+
+    def test_fork_log_raises_in_child(self):
+        """真实 fork 后，子进程中 run.log() 应抛出 RuntimeError"""
+        run = init(mode="disabled")
+
+        ctx = multiprocessing.get_context("fork")
+        result = ctx.Queue()
+
+        def child():
+            try:
+                run.log({"loss": 0.5})
+                result.put("no_error")
+            except RuntimeError as e:
+                result.put(str(e))
+
+        p = ctx.Process(target=child)
+        p.start()
+        p.join(timeout=5)
+        msg = result.get()
+        assert "does not support fork" in msg
+
+    def test_fork_finish_noop_in_child(self):
+        """真实 fork 后，子进程中 finish() 不应抛异常"""
+        run = init(mode="disabled")
+
+        ctx = multiprocessing.get_context("fork")
+        result = ctx.Queue()
+
+        def child():
+            try:
+                run.finish()
+                result.put("ok")
+            except Exception as e:
+                result.put(f"error: {e}")
+
+        p = ctx.Process(target=child)
+        p.start()
+        p.join(timeout=5)
+        assert result.get() == "ok"
+
+    def test_fork_does_not_affect_parent(self):
+        """真实 fork 后，父进程中的 Run 应不受影响"""
+        run = init(mode="disabled")
+        assert run.alive
+
+        ctx = multiprocessing.get_context("fork")
+        p = ctx.Process(target=lambda: None)
+        p.start()
+        p.join(timeout=5)
+
+        # 父进程中 Run 仍然 alive
+        assert run.alive
+        assert not run._forked
+        assert has_run()
+
+    def test_can_init_new_run_in_child_after_fork(self):
+        """真实 fork 后，子进程中可以重新 init 创建新 Run"""
+        init(mode="disabled")
+
+        ctx = multiprocessing.get_context("fork")
+        result = ctx.Queue()
+
+        def child():
+            # fork 后 has_run() 为 False，可以重新 init
+            try:
+                run2 = init(mode="disabled")
+                result.put(("ok", run2.alive, has_run()))
+            except Exception as e:
+                result.put(("error", str(e)))
+
+        p = ctx.Process(target=child)
+        p.start()
+        p.join(timeout=5)
+        r = result.get()
+        assert r[0] == "ok"
+        assert r[1] is True
+        assert r[2] is True

--- a/tests/unit/sdk/internal/run/test_finish_hook.py
+++ b/tests/unit/sdk/internal/run/test_finish_hook.py
@@ -30,6 +30,9 @@ def _make_mock_run(state: str = "running") -> MagicMock:
     """构造一个最小化的 Run 替身"""
     mock = MagicMock(spec=Run)
     mock._state = state
+    mock._forked = False
+    # alive property 依赖 _forked 和 _state，手动计算
+    type(mock).alive = property(lambda self: not self._forked and self._state == "running")
     mock._api_lock = threading.RLock()
     return mock
 
@@ -38,13 +41,13 @@ class TestAtexitCleanup:
     def test_no_op_when_not_running(self):
         """_state != 'running' 时直接返回，不调用 finish"""
         run = _make_mock_run(state="success")
-        Run._atexit_cleanup(run)
+        Run._handle_atexit(run)
         run.finish.assert_not_called()
 
     def test_calls_finish_when_running(self):
         """_state == 'running' 时应调用 finish()"""
         run = _make_mock_run(state="running")
-        Run._atexit_cleanup(run)
+        Run._handle_atexit(run)
         run.finish.assert_called_once()
 
 
@@ -54,7 +57,7 @@ class TestExcepthook:
         run = _make_mock_run()
         run._sys_origin_excepthook = MagicMock()
         tp, val, tb = _make_exc_info(KeyboardInterrupt())
-        Run._excepthook(run, tp, val, tb)
+        Run._handle_except(run, tp, val, tb)
         run.finish.assert_called_once_with(state="aborted", error=ANY)
 
     def test_generic_exception_calls_crashed(self):
@@ -62,7 +65,7 @@ class TestExcepthook:
         run = _make_mock_run()
         run._sys_origin_excepthook = MagicMock()
         tp, val, tb = _make_exc_info(RuntimeError("boom"))
-        Run._excepthook(run, tp, val, tb)
+        Run._handle_except(run, tp, val, tb)
         call_kwargs = run.finish.call_args.kwargs
         assert call_kwargs["state"] == "crashed"
         assert "boom" in call_kwargs["error"]
@@ -72,7 +75,7 @@ class TestExcepthook:
         run = _make_mock_run(state="success")
         run._sys_origin_excepthook = MagicMock()
         tp, val, tb = _make_exc_info(RuntimeError("no run"))
-        Run._excepthook(run, tp, val, tb)
+        Run._handle_except(run, tp, val, tb)
         run.finish.assert_not_called()
 
     def test_always_calls_saved_origin_excepthook(self):
@@ -81,7 +84,7 @@ class TestExcepthook:
         saved_hook = MagicMock()
         run._sys_origin_excepthook = saved_hook
         tp, val, tb = _make_exc_info(RuntimeError("test"))
-        Run._excepthook(run, tp, val, tb)
+        Run._handle_except(run, tp, val, tb)
         saved_hook.assert_called_once_with(tp, val, tb)
 
     def test_calls_saved_hook_not_builtin(self):
@@ -91,7 +94,7 @@ class TestExcepthook:
         run._sys_origin_excepthook = outer_framework_hook
         tp, val, tb = _make_exc_info(RuntimeError("outer"))
         with patch("sys.__excepthook__") as mock_builtin:
-            Run._excepthook(run, tp, val, tb)
+            Run._handle_except(run, tp, val, tb)
         outer_framework_hook.assert_called_once_with(tp, val, tb)
         mock_builtin.assert_not_called()
 
@@ -102,7 +105,7 @@ class TestExcepthook:
         saved_hook = MagicMock()
         run._sys_origin_excepthook = saved_hook
         tp, val, tb = _make_exc_info(RuntimeError("outer"))
-        Run._excepthook(run, tp, val, tb)
+        Run._handle_except(run, tp, val, tb)
         saved_hook.assert_called_once_with(tp, val, tb)
 
 
@@ -112,7 +115,7 @@ class TestSigintHandler:
         run = _make_mock_run()
         run._original_sigint_handler = signal.SIG_DFL
         with pytest.raises(KeyboardInterrupt):
-            Run._sigint_handler(run, signal.SIGINT, None)
+            Run._handle_sigint(run, signal.SIGINT, None)
         run.finish.assert_called_once_with(state="aborted", error="KeyboardInterrupt by user")
 
     def test_error_contains_stack_when_frame_provided(self):
@@ -123,7 +126,7 @@ class TestSigintHandler:
         run._original_sigint_handler = signal.SIG_IGN
         # 用当前真实 frame 模拟信号打断场景
         frame = sys._getframe()
-        Run._sigint_handler(run, signal.SIGINT, frame)
+        Run._handle_sigint(run, signal.SIGINT, frame)
         call_kwargs = run.finish.call_args.kwargs
         assert call_kwargs["state"] == "aborted"
         assert "KeyboardInterrupt by user" in call_kwargs["error"]
@@ -135,7 +138,7 @@ class TestSigintHandler:
         run = _make_mock_run(state="success")
         run._original_sigint_handler = signal.SIG_DFL
         with pytest.raises(KeyboardInterrupt):
-            Run._sigint_handler(run, signal.SIGINT, None)
+            Run._handle_sigint(run, signal.SIGINT, None)
         run.finish.assert_not_called()
 
     def test_calls_original_callable_handler(self):
@@ -143,7 +146,7 @@ class TestSigintHandler:
         run = _make_mock_run()
         original = MagicMock()
         run._original_sigint_handler = original
-        Run._sigint_handler(run, signal.SIGINT, None)
+        Run._handle_sigint(run, signal.SIGINT, None)
         run.finish.assert_called_once_with(state="aborted", error="KeyboardInterrupt by user")
         original.assert_called_once_with(signal.SIGINT, None)
 
@@ -152,5 +155,5 @@ class TestSigintHandler:
         run = _make_mock_run()
         run._original_sigint_handler = signal.SIG_IGN
         # Should not raise
-        Run._sigint_handler(run, signal.SIGINT, None)
+        Run._handle_sigint(run, signal.SIGINT, None)
         run.finish.assert_called_once_with(state="aborted", error="KeyboardInterrupt by user")

--- a/tests/unit/sdk/internal/run/test_log_media.py
+++ b/tests/unit/sdk/internal/run/test_log_media.py
@@ -51,6 +51,7 @@ class _MockRun:
 
     def __init__(self):
         self._api_lock = threading.RLock()
+        self._forked = False
         self.log = MagicMock()
         self.alive = True
 

--- a/tests/unit/sdk/internal/run/test_run_decorators.py
+++ b/tests/unit/sdk/internal/run/test_run_decorators.py
@@ -16,6 +16,7 @@ class TestWithRun:
 
         class MockRun:
             def __init__(self):
+                self._forked = False
                 self.alive = True
 
             @with_run(cmd="swanlab.my_method()")
@@ -31,6 +32,7 @@ class TestWithRun:
 
         class MockRun:
             def __init__(self):
+                self._forked = False
                 self.alive = False
 
             @with_run(cmd="swanlab.my_method()")
@@ -46,6 +48,7 @@ class TestWithRun:
 
         class MockRun:
             def __init__(self):
+                self._forked = False
                 self.alive = False
 
             @with_run(cmd="run.log()")
@@ -54,6 +57,38 @@ class TestWithRun:
 
         run = MockRun()
         with pytest.raises(RuntimeError, match="`run.log\\(\\)`"):
+            run.log()
+
+    def test_raises_when_forked(self):
+        """fork 后应抛出 RuntimeError，提示用户使用 spawn"""
+
+        class MockRun:
+            def __init__(self):
+                self._forked = True
+                self.alive = False
+
+            @with_run(cmd="swanlab.log()")
+            def log(self):
+                pass
+
+        run = MockRun()
+        with pytest.raises(RuntimeError, match="does not support fork"):
+            run.log()
+
+    def test_fork_error_takes_priority_over_not_running(self):
+        """fork 错误应优先于 not running 错误"""
+
+        class MockRun:
+            def __init__(self):
+                self._forked = True
+                self.alive = False
+
+            @with_run(cmd="swanlab.log()")
+            def log(self):
+                pass
+
+        run = MockRun()
+        with pytest.raises(RuntimeError, match="does not support fork"):
             run.log()
 
     def test_preserves_metadata(self):

--- a/tests/unit/sdk/internal/run/test_run_decorators.py
+++ b/tests/unit/sdk/internal/run/test_run_decorators.py
@@ -1,25 +1,28 @@
 """
 @author: cunyue
-@file: test_decorators.py
+@file: test_run_decorators.py
 @time: 2026/3/14
 @description: 测试 swanlab.sdk.internal.run 中的装饰器
 """
 
+import threading
+
 import pytest
 
-from swanlab.sdk.internal.run import with_run
+from swanlab.sdk.internal.run import with_api
 
 
-class TestWithRun:
-    def test_executes_when_state_is_running(self):
-        """当 _state 为 'running' 时，方法应正常执行"""
+class TestWithApi:
+    def test_executes_when_alive(self):
+        """当 alive 为 True 时，方法应正常执行"""
 
         class MockRun:
             def __init__(self):
                 self._forked = False
                 self.alive = True
+                self._api_lock = threading.RLock()
 
-            @with_run(cmd="swanlab.my_method()")
+            @with_api(cmd="swanlab.my_method()")
             def my_method(self, x, y):
                 return x + y
 
@@ -27,15 +30,16 @@ class TestWithRun:
         result = run.my_method(1, 2)
         assert result == 3
 
-    def test_raises_when_state_is_not_running(self):
-        """当 _state 不为 'running' 时，应抛出 RuntimeError，且错误信息包含 cmd"""
+    def test_raises_when_not_alive(self):
+        """当 alive 为 False 时，应抛出 RuntimeError，且错误信息包含 cmd"""
 
         class MockRun:
             def __init__(self):
                 self._forked = False
                 self.alive = False
+                self._api_lock = threading.RLock()
 
-            @with_run(cmd="swanlab.my_method()")
+            @with_api(cmd="swanlab.my_method()")
             def my_method(self):
                 return "ok"
 
@@ -50,8 +54,9 @@ class TestWithRun:
             def __init__(self):
                 self._forked = False
                 self.alive = False
+                self._api_lock = threading.RLock()
 
-            @with_run(cmd="run.log()")
+            @with_api(cmd="run.log()")
             def log(self):
                 pass
 
@@ -65,9 +70,9 @@ class TestWithRun:
         class MockRun:
             def __init__(self):
                 self._forked = True
-                self.alive = False
+                self._api_lock = threading.RLock()
 
-            @with_run(cmd="swanlab.log()")
+            @with_api(cmd="swanlab.log()")
             def log(self):
                 pass
 
@@ -75,27 +80,79 @@ class TestWithRun:
         with pytest.raises(RuntimeError, match="does not support fork"):
             run.log()
 
-    def test_fork_error_takes_priority_over_not_running(self):
-        """fork 错误应优先于 not running 错误"""
+    def test_fork_error_takes_priority_over_not_alive(self):
+        """fork 错误应优先于 not alive 错误"""
 
         class MockRun:
             def __init__(self):
                 self._forked = True
-                self.alive = False
+                self._api_lock = threading.RLock()
 
-            @with_run(cmd="swanlab.log()")
+            @with_api(cmd="swanlab.log()")
             def log(self):
                 pass
 
         run = MockRun()
         with pytest.raises(RuntimeError, match="does not support fork"):
             run.log()
+
+    def test_forked_replaces_lock(self):
+        """fork 后应替换锁，避免继承父进程已持有的锁导致死锁"""
+        old_lock = threading.RLock()
+
+        class MockRun:
+            def __init__(self):
+                self._forked = True
+                self._api_lock = old_lock
+
+            @with_api(cmd="swanlab.log()")
+            def log(self):
+                pass
+
+        run = MockRun()
+        try:
+            run.log()
+        except RuntimeError:
+            pass
+        assert run._api_lock is not old_lock
+
+    def test_must_alive_false_allows_not_alive(self):
+        """must_alive=False 时，not alive 状态不抛异常"""
+
+        class MockRun:
+            def __init__(self):
+                self._forked = False
+                self.alive = False
+                self._api_lock = threading.RLock()
+
+            @with_api(cmd="run.finish()", must_alive=False)
+            def finish(self):
+                return "ok"
+
+        run = MockRun()
+        assert run.finish() == "ok"
+
+    def test_must_alive_false_still_raises_on_fork(self):
+        """must_alive=False 时，fork 仍然抛异常"""
+
+        class MockRun:
+            def __init__(self):
+                self._forked = True
+                self._api_lock = threading.RLock()
+
+            @with_api(cmd="run.finish()", must_alive=False)
+            def finish(self):
+                pass
+
+        run = MockRun()
+        with pytest.raises(RuntimeError, match="does not support fork"):
+            run.finish()
 
     def test_preserves_metadata(self):
         """装饰器应保留被装饰方法的 __name__ 和 __doc__"""
 
         class MockRun:
-            @with_run(cmd="swanlab.my_method()")
+            @with_api(cmd="swanlab.my_method()")
             def my_method(self):
                 """My docstring"""
 


### PR DESCRIPTION
添加SwanLab对多进程fork的支持，由于现在swanlab为纯python实现，所以对fork进程的处理为拦截处理，要求重新执行`swanlab.init`，值得注意的是，不需要增加`reinit`参数。

通过合并`with_run`和`with_lock`，然后统一处理fork 检测（替换锁 + 抛异常）、存活检查、线程安全锁，来解决fork问题

此外，为了避免fork特性导致的线程锁死锁问题，删除了一些没有必要的锁，仅保留run api和cmd api的线程锁设计

未来实现了swanlab-core后，可以改为多个进程共用一个core服务端，不再需要重新`init`了。

顺便更改了一下一些钩子函数名称以及增加了对应的端到端测试