### PR TITLE
refactor: CoreProtocol mode dispatch and CorePython lifecycle

### DIFF
--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -410,7 +410,7 @@ def send_webhook(ctx: RunContext) -> Tuple[bool, bool]:
     return True, True
 
 
-def ensure_run_dir(log_dir: Path, run_id: str, max_retries: int = 10, retry_interval: float = 0.5) -> Path:
+def ensure_run_dir(log_dir: Path, run_id: str, max_retries: int = 10, retry_interval: float = 1.0) -> Path:
     """
     原子化地创建一个不与已有目录冲突的 run_dir。
 
@@ -424,12 +424,14 @@ def ensure_run_dir(log_dir: Path, run_id: str, max_retries: int = 10, retry_inte
     :return: 创建成功的 run_dir 路径
     :raises RuntimeError: 超过最大重试次数仍无法创建唯一目录
     """
-    for _ in range(max_retries):
+    for i in range(max_retries):
         run_dir = log_dir / _generate_run_dir_name(run_id)
         try:
             fs.safe_mkdir(run_dir, ensure_clean=True)
             return run_dir
         except FileExistsError:
+            if i == max_retries - 1:
+                break
             time.sleep(retry_interval)
     raise RuntimeError(f"Failed to create a unique run directory after {max_retries} attempts")
 

--- a/swanlab/sdk/internal/context/components/core/__init__.py
+++ b/swanlab/sdk/internal/context/components/core/__init__.py
@@ -5,29 +5,12 @@
 @description: SwanLab 核心模块
 """
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
-from swanlab.proto.swanlab.record.v1.record_pb2 import Record
-from swanlab.proto.swanlab.run.v1.run_pb2 import FinishRecord, FinishResponse, StartRecord, StartResponse
 from swanlab.sdk.protocol import CoreEnum, CoreProtocol
 
 if TYPE_CHECKING:
     from swanlab.sdk.internal.context import RunContext
-
-
-class NullCore(CoreProtocol):
-    """空 Core，所有方法为 no-op"""
-
-    def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
-        return StartResponse(success=True, message="I'm a teapot.", run=start_record)
-
-    def publish(self, records: List[Record]) -> None: ...
-
-    def fork(self) -> "NullCore":
-        raise NotImplementedError("NullCore does not support fork, you should not reach here?")
-
-    def deliver_run_finish(self, finish_record: FinishRecord) -> FinishResponse:
-        return FinishResponse(success=True, message="I'm a teapot.")
 
 
 # TODO: 未来实现core以后，python版本依旧会有一段时间的同时存在时间。后续实现一种机制，选择不同的core实现
@@ -39,9 +22,6 @@ def create_core(ctx: "RunContext") -> CoreProtocol:
 
     :param ctx: 运行上下文，包含配置信息和运行时状态
     """
-    if ctx.config.settings.mode == "disabled":
-        return NullCore(ctx)
-
     if core_enum == CoreEnum.CORE_PYTHON:
         from swanlab.sdk.internal.core_python import CorePython
 

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -28,7 +28,7 @@ from swanlab.sdk.internal.core_python.api.experiment import create_or_resume_exp
 from swanlab.sdk.internal.core_python.api.project import get_or_create_project, get_project
 from swanlab.sdk.internal.core_python.store import DataStoreWriter
 from swanlab.sdk.internal.core_python.transport import Transport
-from swanlab.sdk.internal.pkg import adapter, safe
+from swanlab.sdk.internal.pkg import adapter, console, helper, safe
 from swanlab.sdk.protocol import CoreProtocol
 from swanlab.utils.experiment import generate_color, generate_name
 
@@ -53,6 +53,17 @@ class CorePython(CoreProtocol):
         self._project: Optional[str] = None
         self._cuid: Optional[str] = None
 
+    @property
+    def _alive(self):
+        return self._store is not None or self._transport is not None
+
+    # ---------------------------------- start 方法 ----------------------------------
+
+    def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
+        if self._alive:
+            raise RuntimeError("Failed to start run: already started")
+        return super().deliver_run_start(start_record)
+
     def _start_store(self, resp: StartResponse):
         self._store = DataStoreWriter()
         self._store.open(str(self._ctx.run_file))
@@ -63,11 +74,6 @@ class CorePython(CoreProtocol):
         resp = StartResponse(success=True, message=message, run=start_record)
         self._start_store(resp)
         return resp
-
-    def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
-        if self._store is not None or self._transport is not None:
-            raise RuntimeError("Failed to start run: already started")
-        return super().deliver_run_start(start_record)
 
     def _start_when_local(self, start_record: StartRecord) -> StartResponse:
         return self._start_without_cloud(start_record, "OK, but use local")
@@ -137,14 +143,29 @@ class CorePython(CoreProtocol):
 
     # ---------------------------------- publish 方法 ----------------------------------
 
+    def publish(self, records: List[Record]) -> None:
+        if not self._alive:
+            console.warning("CorePython is not started, skipping record publishing.")
+            return
+        super().publish(records)
+
+    def _publish_store(self, records: List[Record]) -> None:
+        assert self._store is not None, "store must be initialized before publishing"
+        for record in records:
+            self._store.write(record.SerializeToString())
+            if helper.DEBUG:
+                console.debug("Write record:", record.WhichOneof("record_type"))
+
     def _publish_when_local(self, records: List[Record]) -> None:
-        pass
+        self._publish_store(records)
 
     def _publish_when_offline(self, records: List[Record]) -> None:
-        pass
+        self._publish_store(records)
 
     def _publish_when_cloud(self, records: List[Record]) -> None:
-        pass
+        self._publish_store(records)
+        assert self._transport is not None, "transport must be initialized before publishing"
+        self._transport.put(records)
 
     # ---------------------------------- fork 方法 ----------------------------------
 
@@ -152,6 +173,11 @@ class CorePython(CoreProtocol):
         raise RuntimeError("CorePython.fork() should not be called (designed for swanlab-core).")
 
     # ---------------------------------- finish 方法 ----------------------------------
+
+    def deliver_run_finish(self, finish_record: FinishRecord) -> FinishResponse:
+        if not self._alive:
+            raise RuntimeError("Failed to finish run: not started")
+        return super().deliver_run_finish(finish_record)
 
     def _finish_store(self, record: Record):
         assert self._store is not None, "store must be initialized before shutdown"

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -12,6 +12,10 @@
 实现 CoreProtocol，当前为纯 Python 实现。
 未来由 swanlab-core（Go 二进制）替代时，此模块整体被替换，
 BackgroundConsumer 等调用方无需修改。
+
+
+Core 同时需要根据不同模式处理不同的业务，这是设计模式决定的
+值得说明的是，在当前的上层设计中，publish方法在disabled模式下永远不会触发，但是考虑到设计完整性，我们增加了相关业务逻辑判断
 """
 
 from typing import List, Optional

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -54,17 +54,13 @@ class CorePython(CoreProtocol):
         self._cuid: Optional[str] = None
         self._started: bool = False
 
-    @property
-    def _alive(self):
-        return self._store is not None or self._transport is not None
-
     # ---------------------------------- start 方法 ----------------------------------
 
     def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
         if self._started:
             raise RuntimeError("Failed to start run: already started")
         resp = super().deliver_run_start(start_record)
-        self._started = True
+        self._started = resp.success
         return resp
 
     def _start_store(self, resp: StartResponse):
@@ -147,7 +143,7 @@ class CorePython(CoreProtocol):
     # ---------------------------------- publish 方法 ----------------------------------
 
     def publish(self, records: List[Record]) -> None:
-        if not self._alive:
+        if not self._started:
             console.warning("CorePython is not started, skipping record publishing.")
             return
         super().publish(records)

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -85,14 +85,14 @@ class CorePython(CoreProtocol):
         return self._start_without_cloud(start_record, "OK, but use offline")
 
     def _start_when_cloud(self, start_record: StartRecord) -> StartResponse:
-        resp = self._deliver_run_start(start_record)
+        resp = self._report_run_start(start_record)
         self._start_store(resp)
         # Transport initialization is part of startup in cloud mode.
         # Fail fast on error instead of degrading silently.
         self._transport = Transport()
         return resp
 
-    def _deliver_run_start(self, record: StartRecord) -> StartResponse:
+    def _report_run_start(self, record: StartRecord) -> StartResponse:
         """
         运行开始
         :param record: 运行开始记录
@@ -211,14 +211,14 @@ class CorePython(CoreProtocol):
         assert self._transport is not None, "transport must be initialized before finishing"
         self._transport.finish()
         self._transport = None
-        resp = self._deliver_run_finish(finish_record)
+        resp = self._report_run_finish(finish_record)
         # 如果仅仅是与后端同步出现问题，则换一个让用户安心一些的提示信息
         if resp is None:
             return FinishResponse(success=False, message="Failed to finish run, but it has been saved locally.")
         return resp
 
     @safe.decorator(message="run finish error")
-    def _deliver_run_finish(self, record: FinishRecord) -> FinishResponse:
+    def _report_run_finish(self, record: FinishRecord) -> FinishResponse:
         assert self._username is not None and self._project is not None and self._cuid is not None, (
             "Cannot finish cloud run: username, project, or cuid is missing."
         )

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -14,7 +14,7 @@
 BackgroundConsumer 等调用方无需修改。
 """
 
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.proto.swanlab.run.v1.run_pb2 import (
@@ -28,8 +28,7 @@ from swanlab.sdk.internal.core_python.api.experiment import create_or_resume_exp
 from swanlab.sdk.internal.core_python.api.project import get_or_create_project, get_project
 from swanlab.sdk.internal.core_python.store import DataStoreWriter
 from swanlab.sdk.internal.core_python.transport import Transport
-from swanlab.sdk.internal.pkg import adapter, console, helper, safe
-from swanlab.sdk.internal.pkg.safe import block as safe_block
+from swanlab.sdk.internal.pkg import adapter, safe
 from swanlab.sdk.protocol import CoreProtocol
 from swanlab.utils.experiment import generate_color, generate_name
 
@@ -45,103 +44,59 @@ class CorePython(CoreProtocol):
     START_RECORD_NUM = -1
     FINISH_RECORD_NUM = -2
 
-    def __init__(self, ctx: RunContext, upload_callback: Optional[Callable[[int], None]] = None):
+    def __init__(self, ctx: RunContext):
         super().__init__(ctx)
         self._store: Optional[DataStoreWriter] = None
         self._transport: Optional[Transport] = None
         self._mode = ctx.config.settings.mode
-        self._upload_callback = upload_callback
         self._username: Optional[str] = None
         self._project: Optional[str] = None
         self._cuid: Optional[str] = None
 
-    def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
-        if self._store is not None or self._transport is not None:
-            raise RuntimeError("CorePython has already been started.")
-        # 1. 向后端同步运行开始事件
-        resp = self._run_start(start_record)
-        if resp is None:
-            return StartResponse(success=False, message="Failed to start run.")
-        # 2. 启动组件
-        if self._mode != "disabled":
-            self._store = DataStoreWriter()
-            self._store.open(str(self._ctx.run_file))
-            record = Record(num=self.START_RECORD_NUM, start=resp.run)
-            self._store.write(record.SerializeToString())
-        if self._mode == "cloud":
-            self._transport = Transport(upload_callback=self._upload_callback)
+    def _start_store(self, resp: StartResponse):
+        self._store = DataStoreWriter()
+        self._store.open(str(self._ctx.run_file))
+        record = Record(num=self.START_RECORD_NUM, start=resp.run)
+        self._store.write(record.SerializeToString())
+
+    def _start_without_cloud(self, start_record: StartRecord, message: str) -> StartResponse:
+        resp = StartResponse(success=True, message=message, run=start_record)
+        self._start_store(resp)
         return resp
 
-    def publish(self, records: List[Record]) -> None:
-        if self._store is None and self._transport is None:
-            console.warning("CorePython is not started, skipping record handling.")
-            return
-        with safe_block(message="CorePython publish error"):
-            if self._store is not None:
-                for record in records:
-                    self._store.write(record.SerializeToString())
-                    if helper.DEBUG:
-                        console.debug("Write record:", record.WhichOneof("record_type"))
-            if self._transport is not None:
-                self._transport.put(records)
+    def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
+        if self._store is not None or self._transport is not None:
+            raise RuntimeError("Failed to start run: already started")
+        return super().deliver_run_start(start_record)
 
-    def fork(self) -> "CorePython":
-        raise NotImplementedError(
-            "CorePython.fork() is not implemented. Please waiting for go version, while you should not reach here?"
-        )
+    def _start_when_local(self, start_record: StartRecord) -> StartResponse:
+        return self._start_without_cloud(start_record, "OK, but use local")
 
-    def deliver_run_finish(self, finish_record: FinishRecord) -> FinishResponse:
-        # 1. 构建记录
-        record = Record(
-            num=self.FINISH_RECORD_NUM,
-            finish=FinishRecord(
-                state=finish_record.state, error=finish_record.error, finished_at=finish_record.finished_at
-            ),
-        )
-        # 2. 停止组件
-        if self._transport is not None:
-            self._transport.finish()
-            self._transport = None
-        use_store = self._store is not None
-        if self._store is not None:
-            self._store.write(record.SerializeToString())
-            self._store.close()
-            self._store = None
-        # 3. 向后端同步运行结束事件
-        result = self._run_finish(finish_record)
-        if result is None:
-            # 如果与后端同步失败，根据不同情况，返回不同的响应
-            if use_store:
-                return FinishResponse(
-                    success=False,
-                    message="Failed to sync the run finish event to the server, but it has been saved locally.",
-                )
+    def _start_when_offline(self, start_record: StartRecord) -> StartResponse:
+        return self._start_without_cloud(start_record, "OK, but use offline")
 
-            else:
-                return FinishResponse(
-                    success=False,
-                    message="Failed to sync the run finish event to the server.",
-                )
-        return FinishResponse(success=True, message="Done")
+    def _start_when_cloud(self, start_record: StartRecord) -> StartResponse:
+        resp = self._deliver_run_start(start_record)
+        self._start_store(resp)
+        # Transport initialization is part of startup in cloud mode.
+        # Fail fast on error instead of degrading silently.
+        self._transport = Transport()
+        return resp
 
-    @safe.decorator(message="run start error")
-    def _run_start(self, record: StartRecord) -> StartResponse:
+    def _deliver_run_start(self, record: StartRecord) -> StartResponse:
         """
         运行开始
         :param record: 运行开始记录
         :return: 运行开始响应
         """
-        # 0. 如果不是 cloud 模式则直接返回
-        if self._mode != "cloud":
-            return StartResponse(success=True, message="OK, but no cloud", run=record)
         # 1. 向后端同步运行开始事件
         # 获取当前项目，如果不存在则创建
-        project = get_or_create_project(
+        project_data = get_or_create_project(
             username=record.workspace,
             name=record.project,
             public=record.public,
         )
-        username, project = project["username"], project["name"]
+        username, project = project_data["username"], project_data["name"]
         # 获取当前项目详细信息
         project_info = get_project(username=username, name=project)
         # 获取当前实验
@@ -180,19 +135,58 @@ class CorePython(CoreProtocol):
         start_record.workspace = username
         return StartResponse(success=True, message="OK", run=start_record)
 
-    @safe.decorator(message="run finish error")
-    def _run_finish(self, record: FinishRecord) -> FinishResponse:
-        """
-        运行结束
-        :param record: 运行结束请求
-        :return: 运行结束响应
-        """
-        # 如果不是 cloud 模式则直接返回
-        if self._mode != "cloud":
-            return FinishResponse(success=True, message="OK, but no cloud")
+    # ---------------------------------- publish 方法 ----------------------------------
 
+    def _publish_when_local(self, records: List[Record]) -> None:
+        pass
+
+    def _publish_when_offline(self, records: List[Record]) -> None:
+        pass
+
+    def _publish_when_cloud(self, records: List[Record]) -> None:
+        pass
+
+    # ---------------------------------- fork 方法 ----------------------------------
+
+    def fork(self) -> "CorePython":
+        raise RuntimeError("CorePython.fork() should not be called (designed for swanlab-core).")
+
+    # ---------------------------------- finish 方法 ----------------------------------
+
+    def _finish_store(self, record: Record):
+        assert self._store is not None, "store must be initialized before shutdown"
+        self._store.write(record.SerializeToString())
+        self._store.close()
+        self._store = None
+
+    def _build_finish_record(self, finish_record: FinishRecord):
+        record = Record(num=self.FINISH_RECORD_NUM)
+        record.finish.CopyFrom(finish_record)
+        return record
+
+    def _finish_when_local(self, finish_record: FinishRecord) -> FinishResponse:
+        record = self._build_finish_record(finish_record)
+        self._finish_store(record)
+        return FinishResponse(success=True, message="OK, but use local")
+
+    def _finish_when_offline(self, finish_record: FinishRecord) -> FinishResponse:
+        record = self._build_finish_record(finish_record)
+        self._finish_store(record)
+        return FinishResponse(success=True, message="OK, but use offline")
+
+    def _finish_when_cloud(self, finish_record: FinishRecord) -> FinishResponse:
+        record = self._build_finish_record(finish_record)
+        self._finish_store(record)
+        resp = self._deliver_run_finish(finish_record)
+        # 如果仅仅是与后端同步出现问题，则换一个让用户安心一些的提示信息
+        if resp is None:
+            return FinishResponse(success=False, message="Failed to finish run, but it has been saved locally.")
+        return resp
+
+    @safe.decorator(message="run finish error")
+    def _deliver_run_finish(self, record: FinishRecord) -> FinishResponse:
         assert self._username is not None and self._project is not None and self._cuid is not None, (
-            "Required fields are not set."
+            "Cannot finish cloud run: username, project, or cuid is missing."
         )
         # 向后端同步运行结束事件
         stop_experiment(

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -52,6 +52,7 @@ class CorePython(CoreProtocol):
         self._username: Optional[str] = None
         self._project: Optional[str] = None
         self._cuid: Optional[str] = None
+        self._started: bool = False
 
     @property
     def _alive(self):
@@ -60,9 +61,11 @@ class CorePython(CoreProtocol):
     # ---------------------------------- start 方法 ----------------------------------
 
     def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
-        if self._alive:
+        if self._started:
             raise RuntimeError("Failed to start run: already started")
-        return super().deliver_run_start(start_record)
+        resp = super().deliver_run_start(start_record)
+        self._started = True
+        return resp
 
     def _start_store(self, resp: StartResponse):
         self._store = DataStoreWriter()
@@ -175,9 +178,11 @@ class CorePython(CoreProtocol):
     # ---------------------------------- finish 方法 ----------------------------------
 
     def deliver_run_finish(self, finish_record: FinishRecord) -> FinishResponse:
-        if not self._alive:
+        if not self._started:
             raise RuntimeError("Failed to finish run: not started")
-        return super().deliver_run_finish(finish_record)
+        resp = super().deliver_run_finish(finish_record)
+        self._started = False
+        return resp
 
     def _finish_store(self, record: Record):
         assert self._store is not None, "store must be initialized before shutdown"
@@ -203,6 +208,9 @@ class CorePython(CoreProtocol):
     def _finish_when_cloud(self, finish_record: FinishRecord) -> FinishResponse:
         record = self._build_finish_record(finish_record)
         self._finish_store(record)
+        assert self._transport is not None, "transport must be initialized before finishing"
+        self._transport.finish()
+        self._transport = None
         resp = self._deliver_run_finish(finish_record)
         # 如果仅仅是与后端同步出现问题，则换一个让用户安心一些的提示信息
         if resp is None:

--- a/swanlab/sdk/internal/core_python/transport/dispatch.py
+++ b/swanlab/sdk/internal/core_python/transport/dispatch.py
@@ -10,8 +10,7 @@ from typing import Callable, List, Optional, Sequence, Tuple
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.sdk.internal.core_python.transport.helper import generate_chunks, group_records_by_type
 from swanlab.sdk.internal.core_python.transport.sender import HttpRecordSender
-from swanlab.sdk.internal.pkg import console
-from swanlab.sdk.internal.pkg.safe import block as safe_block
+from swanlab.sdk.internal.pkg import console, safe
 
 # 单次请求最大 record 数
 _MAX_RECORDS_PER_REQUEST = 10_000
@@ -74,7 +73,7 @@ class Dispatch:
         """单 chunk 上传。返回 True 表示成功，False 表示失败。"""
         if self._sender is None:
             raise RuntimeError("sender not set")
-        with safe_block(message=f"record chunk upload failed, record_type={record_type!r}"):
+        with safe.block(message=f"record chunk upload failed, record_type={record_type!r}"):
             self._sender.upload(record_type, chunk)
             return True
         return False

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -9,8 +9,7 @@ import threading
 from typing import Callable, List, Optional
 
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
-from swanlab.sdk.internal.pkg import console
-from swanlab.sdk.internal.pkg.safe import block as safe_block
+from swanlab.sdk.internal.pkg import console, safe
 
 from .buffer import RecordBuffer
 from .dispatch import Dispatch
@@ -136,7 +135,7 @@ class Transport:
                 # 锁外委托给 Dispatch，通过返回值判断成功/失败。
                 # 失败时保留 pending，避免在 drain/prepend 之间来回复制同一批 records。
                 is_success, retry_records = False, pending
-                with safe_block(message="Transport dispatch error"):
+                with safe.block(message="Transport dispatch error"):
                     is_success, retry_records = self._dispatcher(pending)
 
                 if is_success:

--- a/swanlab/sdk/internal/pkg/safe/__init__.py
+++ b/swanlab/sdk/internal/pkg/safe/__init__.py
@@ -3,8 +3,8 @@
 @file: __init__.py
 @time: 2026/4/11 18:45
 @description: 异常处理模块，确保所有异常都被捕获，提供两个API
-1. safe: 以装饰器的形式装饰一个函数，在函数内部捕获所有异常并返回None
-2. safe_block: 以 with 的形式使用这个装饰器，在 with 语句块中捕获异常
+1. safe.decorator: 以装饰器的形式装饰一个函数，在函数内部捕获所有异常并返回None
+2. safe.block: 以 with 的形式使用这个装饰器，在 with 语句块中捕获异常
 
 在设计上这两个API是对console.trace的封装，console.trace会追踪当前调用栈，在终端打印简短信息，在日志文件中打印详细信息，并将详细信息写入日志文件
 """
@@ -86,7 +86,7 @@ def block(
         on_error: 异常发生时执行的回调函数，默认为 None
 
     Example:
-        with safe_block(message="failed to do something"):
+        with safe.block(message="failed to do something"):
             risky_operation()
     """
     catch_types = exceptions if exceptions else (Exception,)

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -128,6 +128,7 @@ class Run:
         self._emitter = factory_emitter(self._ctx)
         self._config = factory_config(self._ctx, self._emitter)
         self._consumer = factory_consumer(self._ctx, self._emitter, self._builder)
+        self._callbacker = self._ctx.callbacker
         # self._monitor is not None 则代表硬件监控开启
         self._monitor: Optional[system.Monitor] = None
 
@@ -143,11 +144,10 @@ class Run:
         signal.signal(signal.SIGINT, self._handle_sigint)
 
         # 3. 初始化完成
-        # 启动硬件监控
+        self._callbacker.on_run_initialized(self._ctx.run_dir, self.path)
         self._monitor = factory_monitor(self._ctx, self._emitter)
-        # 启动后台消费者
         self._consumer.start()
-        # 绑定日志文件
+        # 绑定日志文件绑定，仅在非禁用模式下绑定
         if self.mode != "disabled":
             log.bindfile(self._ctx.debug_dir)
 

--- a/swanlab/sdk/protocol/core.py
+++ b/swanlab/sdk/protocol/core.py
@@ -72,7 +72,7 @@ class CoreProtocol(ABC):
         即发即忘：持久化 + 推上传队列，不等待确认。用于高频数据。
         在这里完成不同模式的发布函数分发
         """
-        with safe.block(message="publish error"):
+        with safe.block(message="publish record error"):
             if self._mode == "cloud":
                 return self._publish_when_cloud(records)
             elif self._mode == "local":

--- a/swanlab/sdk/protocol/core.py
+++ b/swanlab/sdk/protocol/core.py
@@ -16,6 +16,7 @@ from swanlab.proto.swanlab.run.v1.run_pb2 import (
     StartRecord,
     StartResponse,
 )
+from swanlab.sdk.internal.pkg import safe
 
 if TYPE_CHECKING:
     from swanlab.sdk.internal.context import RunContext
@@ -31,23 +32,65 @@ class CoreEnum(str, Enum):
 class CoreProtocol(ABC):
     """
     SwanLab Core 协议
-    协议层作为一个“垫片”，抹平前端与后端实现的差异
+    协议层作为一个"垫片"，抹平前端与后端实现的差异，我们对CoreProtocol的错误处理理念基本与go一致，不raise Error，仅返回处理结果，上层根据返回结果做相应处理
     """
 
     def __init__(self, ctx: "RunContext"):
         self._ctx = ctx
+        self._mode = ctx.config.settings.mode
 
-    @abstractmethod
     def deliver_run_start(self, start_record: StartRecord) -> StartResponse:
         """
         交付运行开始事件，同步事件，等待确认
+        约定应该在此处完成Core相关组件的初始化，在这里完成不同模式的初始化函数分发
         """
-        ...
+        with safe.block(message="run start error"):
+            if self._mode == "cloud":
+                return self._start_when_cloud(start_record)
+            elif self._mode == "local":
+                return self._start_when_local(start_record)
+            elif self._mode == "offline":
+                return self._start_when_offline(start_record)
+            return self._start_when_disabled(start_record)
+        return StartResponse(success=False, message="Failed to start run")
+
+    @staticmethod
+    def _start_when_disabled(start_record: StartRecord) -> StartResponse:
+        return StartResponse(success=True, message="I'm a teapot.", run=start_record)
 
     @abstractmethod
+    def _start_when_local(self, start_record: StartRecord) -> StartResponse: ...
+
+    @abstractmethod
+    def _start_when_offline(self, start_record: StartRecord) -> StartResponse: ...
+
+    @abstractmethod
+    def _start_when_cloud(self, start_record: StartRecord) -> StartResponse: ...
+
     def publish(self, records: List[Record]) -> None:
-        """即发即忘：持久化 + 推上传队列，不等待确认。用于高频数据。"""
-        ...
+        """
+        即发即忘：持久化 + 推上传队列，不等待确认。用于高频数据。
+        在这里完成不同模式的发布函数分发
+        """
+        with safe.block(message="publish error"):
+            if self._mode == "cloud":
+                return self._publish_when_cloud(records)
+            elif self._mode == "local":
+                return self._publish_when_local(records)
+            elif self._mode == "offline":
+                return self._publish_when_offline(records)
+            return self._publish_when_disabled(records)
+
+    def _publish_when_disabled(self, records: List[Record]) -> None: ...
+
+    @abstractmethod
+    def _publish_when_local(self, records: List[Record]) -> None: ...
+
+    @abstractmethod
+    def _publish_when_offline(self, records: List[Record]) -> None: ...
+
+    @abstractmethod
+    def _publish_when_cloud(self, records: List[Record]) -> None: ...
 
     @abstractmethod
     def fork(self) -> "CoreProtocol":
@@ -56,9 +99,30 @@ class CoreProtocol(ABC):
         """
         ...
 
-    @abstractmethod
     def deliver_run_finish(self, finish_record: FinishRecord) -> FinishResponse:
         """
         交付运行结束事件，同步事件，等待确认
+        约定应该在此处完成Core相关组件的清理，在这里完成不同模式的结束函数分发
         """
-        ...
+        with safe.block(message="run finish error"):
+            if self._mode == "cloud":
+                return self._finish_when_cloud(finish_record)
+            elif self._mode == "local":
+                return self._finish_when_local(finish_record)
+            elif self._mode == "offline":
+                return self._finish_when_offline(finish_record)
+            return self._finish_when_disabled()
+        return FinishResponse(success=False, message="Failed to finish run")
+
+    @staticmethod
+    def _finish_when_disabled() -> FinishResponse:
+        return FinishResponse(success=True, message="I'm a teapot.")
+
+    @abstractmethod
+    def _finish_when_local(self, finish_record: FinishRecord) -> FinishResponse: ...
+
+    @abstractmethod
+    def _finish_when_offline(self, finish_record: FinishRecord) -> FinishResponse: ...
+
+    @abstractmethod
+    def _finish_when_cloud(self, finish_record: FinishRecord) -> FinishResponse: ...

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -12,9 +12,11 @@
   - TestInitSettingsPriority : 配置优先级（全局 < 自定义 < 传参）
   - TestInitResumeValidation : resume/id 校验逻辑
   - TestInitCloudMode        : cloud 模式，依赖本文件内的 HTTP mock fixtures
+  - TestInitFactoryDispatch  : 验证 factory 模式按模式分派组件类型
 """
 
 import multiprocessing
+from typing import cast
 
 import pytest
 import responses as responses_lib
@@ -23,9 +25,13 @@ import yaml
 from swanlab.sdk.cmd.init import init
 from swanlab.sdk.cmd.login import login_cli
 from swanlab.sdk.cmd.merge_settings import merge_settings
+from swanlab.sdk.internal.bus.emitter import RunEmitter
 from swanlab.sdk.internal.run import Run, get_run, has_run
 from swanlab.sdk.internal.run.config import config as global_config
+from swanlab.sdk.internal.run.consumer import BackgroundConsumer
+from swanlab.sdk.internal.run.factory import NullConsumer, NullEmitter
 from swanlab.sdk.internal.settings import Settings, settings
+from swanlab.sdk.typings.run import ModeType
 
 # ============================================================
 # Cloud 模式测试常量
@@ -709,3 +715,68 @@ class TestEnsureRunDirE2E:
         assert run._ctx.run_dir.exists()
         assert run._ctx.config.run_dir not in all_conflict_names
         run.finish()
+
+
+# ============================================================
+# TestInitFactoryDispatch
+# 验证 factory 模式按模式分派组件类型的设计约定
+# ============================================================
+
+
+class TestInitFactoryDispatch:
+    """验证 init() 创建的 Run 对象内部组件类型符合 factory 设计约定
+
+    disabled 模式：NullEmitter + NullConsumer + unbound Config + 无 Monitor
+    非 disabled 模式：RunEmitter + BackgroundConsumer + bound Config + 有 Monitor（环境允许时）
+    """
+
+    def test_disabled_uses_null_emitter(self):
+        run = init(mode="disabled")
+        assert isinstance(run._emitter, NullEmitter)
+
+    @pytest.mark.parametrize("mode", ["local", "offline"])
+    def test_non_disabled_uses_run_emitter(self, mode):
+        run = init(mode=cast(ModeType, mode))
+        assert isinstance(run._emitter, RunEmitter)
+
+    def test_disabled_null_emitter_discards_events(self):
+        """NullEmitter.emit() 丢弃事件，队列始终为空"""
+        run = init(mode="disabled")
+        run._emitter.emit("test-event")  # type: ignore
+        assert run._emitter.queue.empty()
+
+    def test_non_disabled_run_emitter_enqueues_events(self):
+        """RunEmitter.emit() 将事件放入队列"""
+        run = init(mode="local")
+        run._emitter.emit("test-event")  # type: ignore
+        assert not run._emitter.queue.empty()
+        assert run._emitter.queue.get_nowait() == "test-event"
+
+    def test_disabled_uses_null_consumer(self):
+        run = init(mode="disabled")
+        assert isinstance(run._consumer, NullConsumer)
+
+    @pytest.mark.parametrize("mode", ["local", "offline"])
+    def test_non_disabled_uses_background_consumer(self, mode):
+        run = init(mode=cast(ModeType, mode))
+        assert isinstance(run._consumer, BackgroundConsumer)
+
+    def test_disabled_config_is_unbound(self):
+        """disabled 模式 Config 不绑定文件，写操作仅内存"""
+        run = init(mode="disabled")
+        run.config["key"] = "value"
+
+        assert run.config["key"] == "value"
+        assert not run._ctx.config_file.exists()
+
+    @pytest.mark.parametrize("mode", ["local", "offline"])
+    def test_non_disabled_config_is_bound(self, mode):
+        """非 disabled 模式 Config 绑定文件，写操作持久化"""
+        run = init(mode=cast(ModeType, mode))
+        run.config["key"] = "value"
+
+        assert run._ctx.config_file.exists()
+
+    def test_disabled_monitor_is_none(self):
+        run = init(mode="disabled")
+        assert run._monitor is None

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -56,7 +56,7 @@ class TestCorePythonStart:
         core = CorePython(ctx)
         record = make_start_record()
         mock_deliver = MagicMock(return_value=StartResponse(success=True, message="OK", run=record))
-        monkeypatch.setattr(core, "_deliver_run_start", mock_deliver)
+        monkeypatch.setattr(core, "_report_run_start", mock_deliver)
 
         resp = core.deliver_run_start(record)
 
@@ -106,11 +106,11 @@ class TestCorePythonFinish:
         core = CorePython(ctx)
 
         mock_start = MagicMock(return_value=StartResponse(success=True, message="OK", run=make_start_record()))
-        monkeypatch.setattr(core, "_deliver_run_start", mock_start)
+        monkeypatch.setattr(core, "_report_run_start", mock_start)
         core.deliver_run_start(make_start_record())
 
         mock_finish = MagicMock(return_value=None)
-        monkeypatch.setattr(core, "_deliver_run_finish", mock_finish)
+        monkeypatch.setattr(core, "_report_run_finish", mock_finish)
         resp = core.deliver_run_finish(FinishRecord())
 
         assert core._store is None

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -1,27 +1,149 @@
-from google.protobuf.timestamp_pb2 import Timestamp
+"""
+@author: cunyue
+@file: test_core_python.py
+@time: 2026/4/19
+@description: CorePython 单元测试
 
-from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnType
-from swanlab.proto.swanlab.metric.data.v1.data_pb2 import DataRecord
-from swanlab.proto.swanlab.metric.data.v1.scalar.scalar_pb2 import ScalarValue
-from swanlab.proto.swanlab.record.v1.record_pb2 import Record
+测试分组：
+  - TestCorePythonStart  : 各模式 deliver_run_start 行为
+  - TestCorePythonPublish: 各模式 publish 行为
+  - TestCorePythonFinish : 各模式 deliver_run_finish 行为
+  - TestCorePythonGuard  : 防御逻辑
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from swanlab.proto.swanlab.run.v1.run_pb2 import FinishRecord, StartRecord, StartResponse
 from swanlab.sdk.internal.context import RunConfig, RunContext
+from swanlab.sdk.internal.core_python import CorePython
 from swanlab.sdk.internal.settings import Settings
 
 
-def make_scalar_record() -> Record:
-    timestamp = Timestamp()
-    timestamp.GetCurrentTime()
-    return Record(
-        metric=DataRecord(
-            key="train/loss",
-            step=1,
-            timestamp=timestamp,
-            type=ColumnType.COLUMN_TYPE_FLOAT,
-            scalar=ScalarValue(number=0.125),
-        )
-    )
+def make_ctx(tmp_path, mode: str) -> RunContext:
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    settings = Settings.model_validate({"mode": mode, "run": {"id": "test-run-id"}})
+    return RunContext(RunConfig(run_dir=run_dir, settings=settings))
 
 
-def make_ctx(tmp_path) -> RunContext:
-    settings = Settings.model_validate({"mode": "cloud", "run": {"id": "test-run-id"}})
-    return RunContext(RunConfig(run_dir=tmp_path, settings=settings))
+def make_start_record() -> StartRecord:
+    return StartRecord(id="test-run-id", project="test-project")
+
+
+# ============================================================
+# TestCorePythonStart
+# ============================================================
+
+
+class TestCorePythonStart:
+    @pytest.mark.parametrize("mode", ["disabled", "local", "offline"])
+    def test_non_cloud_modes(self, tmp_path, mode):
+        ctx = make_ctx(tmp_path, mode)
+        core = CorePython(ctx)
+        resp = core.deliver_run_start(make_start_record())
+
+        assert resp.success is True
+        assert core._transport is None
+        if mode == "disabled":
+            assert core._store is None
+        else:
+            assert core._store is not None
+
+    def test_cloud_mode(self, tmp_path, monkeypatch):
+        ctx = make_ctx(tmp_path, "cloud")
+        core = CorePython(ctx)
+        record = make_start_record()
+        mock_deliver = MagicMock(return_value=StartResponse(success=True, message="OK", run=record))
+        monkeypatch.setattr(core, "_deliver_run_start", mock_deliver)
+
+        resp = core.deliver_run_start(record)
+
+        assert resp.success is True
+        assert core._store is not None
+        assert core._transport is not None
+        mock_deliver.assert_called_once_with(record)
+
+
+# ============================================================
+# TestCorePythonPublish
+# ============================================================
+
+
+class TestCorePythonPublish:
+    def test_disabled_skips_silently(self, tmp_path):
+        ctx = make_ctx(tmp_path, "disabled")
+        core = CorePython(ctx)
+        core.deliver_run_start(make_start_record())
+        core.publish([])
+
+    def test_not_started_skips_silently(self, tmp_path):
+        ctx = make_ctx(tmp_path, "local")
+        core = CorePython(ctx)
+        core.publish([])
+
+
+# ============================================================
+# TestCorePythonFinish
+# ============================================================
+
+
+class TestCorePythonFinish:
+    @pytest.mark.parametrize("mode", ["disabled", "local", "offline"])
+    def test_non_cloud_modes(self, tmp_path, mode):
+        ctx = make_ctx(tmp_path, mode)
+        core = CorePython(ctx)
+        core.deliver_run_start(make_start_record())
+
+        resp = core.deliver_run_finish(FinishRecord())
+
+        assert resp.success is True
+        assert core._store is None
+
+    def test_cloud_closes_store_and_transport(self, tmp_path, monkeypatch):
+        ctx = make_ctx(tmp_path, "cloud")
+        core = CorePython(ctx)
+
+        mock_start = MagicMock(return_value=StartResponse(success=True, message="OK", run=make_start_record()))
+        monkeypatch.setattr(core, "_deliver_run_start", mock_start)
+        core.deliver_run_start(make_start_record())
+
+        mock_finish = MagicMock(return_value=None)
+        monkeypatch.setattr(core, "_deliver_run_finish", mock_finish)
+        resp = core.deliver_run_finish(FinishRecord())
+
+        assert core._store is None
+        assert core._transport is None
+        mock_finish.assert_called_once()
+        assert resp.success is False
+        assert "saved locally" in resp.message
+
+
+# ============================================================
+# TestCorePythonGuard
+# ============================================================
+
+
+class TestCorePythonGuard:
+    def test_double_start_raises(self, tmp_path):
+        ctx = make_ctx(tmp_path, "local")
+        core = CorePython(ctx)
+        core.deliver_run_start(make_start_record())
+
+        with pytest.raises(RuntimeError, match="already started"):
+            core.deliver_run_start(make_start_record())
+
+    def test_finish_before_start_raises(self, tmp_path):
+        ctx = make_ctx(tmp_path, "local")
+        core = CorePython(ctx)
+
+        with pytest.raises(RuntimeError, match="not started"):
+            core.deliver_run_finish(FinishRecord())
+
+    def test_fork_raises(self, tmp_path):
+        ctx = make_ctx(tmp_path, "disabled")
+        core = CorePython(ctx)
+
+        with pytest.raises(RuntimeError, match="should not be called"):
+            core.fork()


### PR DESCRIPTION
## Summary

- **CoreProtocol 模式分派机制**：将 `deliver_run_start`/`publish`/`deliver_run_finish` 从 `@abstractmethod` 重构为模板方法，内置 cloud/local/offline/disabled 四模式分派，每种模式对应独立钩子（`_start_when_cloud`、`_publish_when_local` 等），disabled 提供默认 no-op 实现
- **移除 NullCore**：所有模式统一走 CorePython，`create_core` 工厂不再为 disabled 模式创建 NullCore
- **CorePython 生命周期修复**：
  - 新增 `_started` 标记替代 `_alive` 做守卫判断，修复 disabled 模式 start 后无法 finish 的 bug
  - `_finish_when_cloud` 补上 `transport.finish()` + 置 None，修复 cloud 模式 transport 未关闭的资源泄漏
- **CorePython 模式钩子实现**：6 个模式钩子（3 start + 3 publish + 3 finish），提取 `_start_store`/`_publish_store`/`_finish_store` 等共享逻辑
- **单元测试**：新增 13 个 CorePython 单元测试，覆盖各模式 start/publish/finish 行为及防御逻辑

## Test plan

- [x] 13 个新增 CorePython 单元测试全部通过
- [x] 全量单元测试 877 passed, 21 skipped
- [x] CI 通过