### PR TITLE
chore: console log lifecycle refactor and test improvements

### DIFF
--- a/swanlab/sdk/internal/pkg/console/__init__.py
+++ b/swanlab/sdk/internal/pkg/console/__init__.py
@@ -18,7 +18,7 @@ from rich.text import Text
 from .. import helper
 from . import log
 
-__all__ = ["debug", "info", "warning", "error", "trace", "c"]
+__all__ = ["debug", "info", "warning", "error", "trace", "c", "init", "reset"]
 
 c = Console()
 _name = "swanlab"
@@ -218,3 +218,18 @@ def trace(
 
     log_fn = error if level_name == "error" else debug
     log_fn(console_args=(console_msg,), file_args=(file_msg,), write_to_file=write_to_file, **kwargs)
+
+
+# -----------------------------------------------------------------------------
+# 日志文件管理（委托给 log 模块）
+# -----------------------------------------------------------------------------
+
+
+def init(bind_to=None) -> None:
+    """初始化日志模块。bind_to 为日志目录时绑定文件，为 None 时禁用持久化。仅应被 Run 生命周期调用。"""
+    log.init(bind_to)
+
+
+def reset() -> None:
+    """重置日志模块到初始状态。仅应被 Run 生命周期和测试 teardown 调用。"""
+    log.reset()

--- a/swanlab/sdk/internal/pkg/console/log/__init__.py
+++ b/swanlab/sdk/internal/pkg/console/log/__init__.py
@@ -86,14 +86,13 @@ def init(bind_to: Optional[Path] = None) -> None:
     if _initialized:
         return
 
-    _initialized = True
-
     # bind_to=None：disabled 模式，移除 MemoryHandler，日志无 handler 直接丢弃
     if bind_to is None:
         if _memory_handler is not None:
             _logger.removeHandler(_memory_handler)
             _memory_handler.close()
             _memory_handler = None
+        _initialized = True
         return
 
     # bind_to 有值：创建文件 Handler，flush 内存缓冲到文件
@@ -123,6 +122,7 @@ def init(bind_to: Optional[Path] = None) -> None:
 
     # 3. 挂载文件 Handler
     _logger.addHandler(_file_handler)
+    _initialized = True
 
     _logger.debug("Diagnostic log bound to file: %s", log_path)
 

--- a/swanlab/sdk/internal/pkg/console/log/__init__.py
+++ b/swanlab/sdk/internal/pkg/console/log/__init__.py
@@ -15,6 +15,7 @@
 2. 使用独立命名空间 "swanlab.internal"，不污染用户的 logging 配置
 3. 延迟绑定（Lazy Attach）：log_dir 就绪前日志缓冲在内存中，就绪后一次性 flush 到文件
 4. RotatingFileHandler 自动轮转，防止日志文件无限膨胀
+5. init(bind_to=None) 时禁用日志持久化，避免内存泄漏（disabled 模式）
 """
 
 import logging
@@ -23,7 +24,7 @@ from logging.handlers import MemoryHandler, RotatingFileHandler
 from pathlib import Path
 from typing import Optional
 
-__all__ = ["debug", "info", "warning", "error", "critical", "bindfile", "reset"]
+__all__ = ["debug", "info", "warning", "error", "critical", "init", "reset"]
 
 # ---------------------------------------------------------------------------
 # Logger 初始化
@@ -41,11 +42,11 @@ _FORMATTER = logging.Formatter(fmt="%(message)s")
 # ---------------------------------------------------------------------------
 # 内存缓冲 Handler（阶段 1：log_dir 就绪前）
 # capacity 设为 1024 条，足够覆盖 login 阶段的少量请求
-# flushLevel 设为 CRITICAL+1（即永远不会自动 flush），完全由 bindfile() 手动触发
+# flushLevel 设为 CRITICAL+1（即永远不会自动 flush），完全由 init() 手动触发
 # ---------------------------------------------------------------------------
 _memory_handler: Optional[MemoryHandler] = None
 _file_handler: Optional[RotatingFileHandler] = None
-_bound = False
+_initialized = False
 
 # ---------------------------------------------------------------------------
 # 轮转配置常量
@@ -73,55 +74,30 @@ class SecureRotatingFileHandler(RotatingFileHandler):
         return stream
 
 
-def reset() -> None:
+def init(bind_to: Optional[Path] = None) -> None:
     """
-    重置日志模块状态，恢复到初始的内存缓冲模式。
-    释放现有的文件句柄，清除所有已绑定的 Handler。
+    初始化诊断日志模块。
+
+    :param bind_to: 日志目录路径。传入时将日志绑定到文件（flush 内存缓冲到磁盘）；
+                    传入 None 时禁用日志持久化（丢弃所有日志记录，不缓冲到内存）。
     """
-    global _memory_handler, _file_handler, _bound
+    global _memory_handler, _file_handler, _initialized
 
-    # 1. 安全关闭并移除所有现有的 Handlers（防止文件句柄泄露）
-    for handler in _logger.handlers[:]:
-        handler.close()
-        _logger.removeHandler(handler)
-
-    # 2. 重新初始化内存缓冲 Handler
-    _memory_handler = MemoryHandler(
-        capacity=1024,
-        flushLevel=logging.CRITICAL + 1,
-    )
-    _memory_handler.setFormatter(_FORMATTER)
-    _logger.addHandler(_memory_handler)
-
-    # 3. 重置状态标志
-    _file_handler = None
-    _bound = False
-
-
-# 模块首次导入时，执行一次初始化
-reset()
-
-
-def bindfile(log_dir: Path) -> None:
-    """
-    将诊断日志绑定到文件。应在 log_dir 目录创建后调用。
-
-    执行流程：
-    1. 创建 SecureRotatingFileHandler 指向 log_dir/debug.log
-    2. 将内存缓冲中的日志 flush 到文件
-    3. 移除内存缓冲 Handler，后续日志直接写文件
-
-    此方法可安全地重复调用（幂等），第二次调用会被忽略。
-
-    :param log_dir: 日志目录路径，调用方需确保目录已创建
-    :raises FileNotFoundError: 如果 log_dir 不存在
-    """
-    global _memory_handler, _file_handler, _bound
-
-    if _bound:
+    if _initialized:
         return
 
-    log_dir = Path(log_dir)
+    _initialized = True
+
+    # bind_to=None：disabled 模式，移除 MemoryHandler，日志无 handler 直接丢弃
+    if bind_to is None:
+        if _memory_handler is not None:
+            _logger.removeHandler(_memory_handler)
+            _memory_handler.close()
+            _memory_handler = None
+        return
+
+    # bind_to 有值：创建文件 Handler，flush 内存缓冲到文件
+    log_dir = Path(bind_to)
     if not log_dir.exists():
         raise FileNotFoundError(f"Log directory does not exist: {log_dir}")
 
@@ -147,9 +123,37 @@ def bindfile(log_dir: Path) -> None:
 
     # 3. 挂载文件 Handler
     _logger.addHandler(_file_handler)
-    _bound = True
 
     _logger.debug("Diagnostic log bound to file: %s", log_path)
+
+
+def reset() -> None:
+    """
+    重置日志模块状态，恢复到初始的内存缓冲模式。
+    释放现有的文件句柄，清除所有已绑定的 Handler。
+    """
+    global _memory_handler, _file_handler, _initialized
+
+    # 1. 安全关闭并移除所有现有的 Handlers（防止文件句柄泄露）
+    for handler in _logger.handlers[:]:
+        handler.close()
+        _logger.removeHandler(handler)
+
+    # 2. 重新初始化内存缓冲 Handler
+    _memory_handler = MemoryHandler(
+        capacity=1024,
+        flushLevel=logging.CRITICAL + 1,
+    )
+    _memory_handler.setFormatter(_FORMATTER)
+    _logger.addHandler(_memory_handler)
+
+    # 3. 重置状态标志
+    _file_handler = None
+    _initialized = False
+
+
+# 模块首次导入时，执行一次初始化
+reset()
 
 
 # ---------------------------------------------------------------------------

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -44,7 +44,6 @@ from swanlab.sdk.typings.run.transforms.image import ImageDatasType, ImageFilesT
 from swanlab.sdk.typings.run.transforms.text import TextDatasType
 from swanlab.sdk.typings.run.transforms.video import VideoDatasType
 
-from ..pkg.console import log
 from . import utils_fmt as fmt
 from .factory import factory_config, factory_consumer, factory_emitter, factory_monitor
 from .record_builder import RecordBuilder
@@ -147,9 +146,8 @@ class Run:
         self._callbacker.on_run_initialized(self._ctx.run_dir, self.path)
         self._monitor = factory_monitor(self._ctx, self._emitter)
         self._consumer.start()
-        # 绑定日志文件绑定，仅在非禁用模式下绑定
-        if self.mode != "disabled":
-            log.bindfile(self._ctx.debug_dir)
+        # 初始化日志模块：非 disabled 模式绑定文件，disabled 模式禁用持久化
+        console.init(bind_to=self._ctx.debug_dir if self.mode != "disabled" else None)
 
     # ----------------------------------
     # 私有钩子
@@ -639,7 +637,7 @@ class Run:
         deactivate_run_config()
         console.debug("Clean & tidy! ciallo ( ∠・ω< ) ~ ★")
         # 释放日志，本次运行结束
-        log.reset()
+        console.reset()
 
 
 _current_run: Optional[Run] = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import swanlab
 from swanlab.sdk.internal.context import callbacker
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.internal.pkg.console import log
+from swanlab.sdk.internal.pkg import console
 from swanlab.sdk.internal.run import clear_run
 from swanlab.sdk.internal.run.config import reset as reset_config
 from swanlab.sdk.internal.settings import Settings, settings
@@ -60,7 +60,7 @@ def isolate_sdk_environment(tmp_path, monkeypatch):
         client.reset()
 
     # 5. 清理 logger
-    log.reset()
+    console.reset()
 
     # 6. 清理 config
     reset_config()

--- a/tests/unit/sdk/internal/pkg/console/log/test_pkg_log.py
+++ b/tests/unit/sdk/internal/pkg/console/log/test_pkg_log.py
@@ -14,16 +14,16 @@ import swanlab.sdk.internal.pkg.console.log as log_mod
 
 
 def test_log_lifecycle_and_output(tmp_path):
-    """测试核心业务流：缓冲阶段记录 -> 绑定文件触发落盘 -> 直接写入文件"""
+    """测试核心业务流：缓冲阶段记录 -> init 绑定文件触发落盘 -> 直接写入文件"""
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
 
-    # 1. 缓冲阶段（尚未 bindfile）
+    # 1. 缓冲阶段（尚未 init）
     log_mod.debug("buffered debug")
     log_mod.info("buffered info")
 
     # 2. 绑定文件（之前的缓冲应自动落盘）
-    log_mod.bindfile(log_dir)
+    log_mod.init(bind_to=log_dir)
 
     # 3. 绑定后写入（应直接落盘）
     log_mod.warning("direct warning")
@@ -42,23 +42,23 @@ def test_log_lifecycle_and_output(tmp_path):
     assert "direct critical" in content
 
 
-def test_bindfile_invalid_dir(tmp_path):
+def test_init_invalid_dir(tmp_path):
     """测试绑定到不存在的目录时抛出 FileNotFoundError"""
     with pytest.raises(FileNotFoundError, match="Log directory does not exist"):
-        log_mod.bindfile(tmp_path / "not_exist")
+        log_mod.init(bind_to=tmp_path / "not_exist")
 
 
-def test_bindfile_is_idempotent(tmp_path):
-    """测试重复调用 bindfile 的幂等性（不报错且不重复创建资源）"""
+def test_init_is_idempotent(tmp_path):
+    """测试重复调用 init 的幂等性（不报错且不重复创建资源）"""
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
 
     # 第一次绑定
-    log_mod.bindfile(log_dir)
+    log_mod.init(bind_to=log_dir)
     log_mod.info("first bound msg")
 
     # 第二次重复绑定（应静默忽略）
-    log_mod.bindfile(log_dir)
+    log_mod.init(bind_to=log_dir)
     log_mod.info("second bound msg")
 
     content = (log_dir / "debug.log").read_text(encoding="utf-8")
@@ -67,11 +67,43 @@ def test_bindfile_is_idempotent(tmp_path):
     assert "second bound msg" in content
 
 
+def test_init_with_none_discards_logs(tmp_path):
+    """测试 init(bind_to=None) 禁用日志持久化，日志不缓冲到内存"""
+    log_mod.reset()
+    log_mod.init(bind_to=None)
+
+    # 写入日志后，应无 handler 处理（不缓冲、不报错）
+    log_mod.debug("discarded debug")
+    log_mod.warning("discarded warning")
+    log_mod.error("discarded error")
+
+    # logger 无 handler，日志直接丢弃
+    assert log_mod._memory_handler is None
+    assert log_mod._file_handler is None
+    assert len(log_mod._logger.handlers) == 0
+
+    log_mod.reset()
+
+
+def test_init_none_then_reset_restores_buffering(tmp_path):
+    """测试 disabled 模式后 reset 恢复内存缓冲"""
+    log_mod.reset()
+    log_mod.init(bind_to=None)
+
+    # disabled 状态下无 handler
+    assert log_mod._memory_handler is None
+
+    # reset 恢复内存缓冲
+    log_mod.reset()
+    assert log_mod._memory_handler is not None
+    assert len(log_mod._logger.handlers) == 1
+
+
 def test_log_format(tmp_path):
     """测试写入日志文件的内容与传入消息一致（formatter 为纯消息模式）"""
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
-    log_mod.bindfile(log_dir)
+    log_mod.init(bind_to=log_dir)
 
     log_mod.error("check format")
 
@@ -85,7 +117,7 @@ def test_secure_file_permissions(tmp_path):
     log_dir.mkdir()
 
     # 绑定并写入一条日志，确保底层 _open 方法被真实触发
-    log_mod.bindfile(log_dir)
+    log_mod.init(bind_to=log_dir)
     log_mod.info("trigger file creation for permission check")
 
     log_file = log_dir / "debug.log"

--- a/tests/unit/sdk/internal/run/test_async_task.py
+++ b/tests/unit/sdk/internal/run/test_async_task.py
@@ -8,6 +8,7 @@
 import asyncio
 import sys
 import time
+import warnings
 
 import pytest
 
@@ -59,7 +60,10 @@ class TestLazyInit:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="fork is not available on Windows")
     def test_fork_pool_created_on_fork(self, mgr):
-        mgr.submit(_ret42, mode="fork")
+        # Python 3.12+ 在多线程进程中 fork 会触发 DeprecationWarning，此处有意测试 fork 池的懒初始化，抑制该警告
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*multi-threaded.*fork", category=DeprecationWarning)
+            mgr.submit(_ret42, mode="fork")
         assert mgr._fork_pool is not None
         assert mgr._thread_pool is None
         assert mgr._spawn_pool is None
@@ -97,10 +101,12 @@ class TestSubmit:
 
     @pytest.mark.skipif(sys.platform == "win32", reason="fork is not available on Windows")
     def test_fork_success(self, mgr):
-        # func 必须是模块级顶层函数（可 pickle）
+        # Python 3.12+ 在多线程进程中 fork 会触发 DeprecationWarning，此处有意测试 fork 模式的功能，抑制该警告
         results = []
-        f = mgr.submit(_ret42, mode="fork", on_success=lambda r, s: results.append(r))
-        assert f.result() == 42
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*multi-threaded.*fork", category=DeprecationWarning)
+            f = mgr.submit(_ret42, mode="fork", on_success=lambda r, s: results.append(r))
+            assert f.result() == 42
         assert results == [42]
 
     def test_asyncio_coroutine(self):


### PR DESCRIPTION
## Summary

- **console log 生命周期重构**：`bindfile()`/`reset()` → `init(bind_to)`/`reset()`，`init(bind_to=None)` 时移除 MemoryHandler 禁用日志持久化，修复 disabled 模式下日志无限缓冲导致的内存泄漏
- **log 模块封装**：`init`/`reset` 通过 console 公开 API 暴露，外部不再直接访问 log 子模块
- **fork 测试 DeprecationWarning 修复**：Python 3.12+ 多线程进程中 fork 触发的警告已在测试中显式抑制并注释说明
- **factory 分派测试**：在 `test_init_e2e.py` 新增 `TestInitFactoryDispatch`，通过 Run 对象验证 disabled/非 disabled 模式下 Emitter/Consumer/Config/Monitor 组件类型
- **CorePython 单元测试**：新增 13 个测试覆盖各模式 start/publish/finish 行为及防御逻辑

## Test plan

- [x] 891 单元测试全部通过（含 13 个新增 CorePython 测试 + 12 个 factory 分派测试）
- [x] log 模块新增 `init(bind_to=None)` 禁用持久化测试通过
- [x] fork 测试不再触发 Python 3.12+ DeprecationWarning
- [x] CI 通过