### PR TITLE
Feat/terminal proxy

### DIFF
--- a/swanlab/sdk/internal/bus/events.py
+++ b/swanlab/sdk/internal/bus/events.py
@@ -62,7 +62,6 @@ class ConfigEvent:
 class ConsoleEvent:
     """控制台输出事件"""
 
-    epoch: int
     line: str
     stream: StreamType
     timestamp: Timestamp

--- a/swanlab/sdk/internal/bus/events.py
+++ b/swanlab/sdk/internal/bus/events.py
@@ -62,6 +62,7 @@ class ConfigEvent:
 class ConsoleEvent:
     """控制台输出事件"""
 
+    epoch: int
     line: str
     stream: StreamType
     timestamp: Timestamp

--- a/swanlab/sdk/internal/pkg/console/__init__.py
+++ b/swanlab/sdk/internal/pkg/console/__init__.py
@@ -102,7 +102,7 @@ def _loguru_build(
     return line, plain
 
 
-def _loguru_print(level_name: str, style: str, *args, **kwargs) -> str:
+def _loguru_print(level_name: str, style: str, *args, write_to_tty: bool = True, **kwargs) -> str:
     """
     构建并打印 loguru 风格日志行，同时返回对应的纯文本字符串供写入日志文件。
     2026-03-14 10:23:45.124 | DEBUG  | module:func:line - message
@@ -119,7 +119,8 @@ def _loguru_print(level_name: str, style: str, *args, **kwargs) -> str:
         console_args=console_args,
         file_args=file_args,
     )
-    c.print(line, **kwargs)
+    if write_to_tty:
+        c.print(line, **kwargs)
     return plain
 
 
@@ -134,13 +135,13 @@ def print(*args, **kwargs):  # noqa: A001
     c.print(*args, **kwargs)
 
 
-def debug(*args, write_to_file: bool = True, **kwargs):
+def debug(*args, write_to_file: bool = True, write_to_tty: bool = True, **kwargs):
     """发送调试消息（仅 SWANLAB_DEBUG=true 时输出）
     格式：2026-03-14 10:23:45.124 | DEBUG    | module:func:line - message
     """
     if not helper.DEBUG:
         return
-    plain = _loguru_print("debug", "grey54", *args, **kwargs)
+    plain = _loguru_print("debug", "grey54", *args, write_to_tty=write_to_tty, **kwargs)
     if write_to_file:
         log.debug(plain)
 
@@ -166,11 +167,11 @@ def warning(*args, **kwargs):
     log.warning(plain)
 
 
-def error(*args, write_to_file: bool = True, **kwargs):
+def error(*args, write_to_file: bool = True, write_to_tty: bool = True, **kwargs):
     """发生错误
     格式：2026-03-14 10:23:45.124 | ERROR    | module:func:line - message
     """
-    plain = _loguru_print("error", "red", *args, **kwargs)
+    plain = _loguru_print("error", "red", *args, write_to_tty=write_to_tty, **kwargs)
     if write_to_file:
         log.error(plain)
 
@@ -179,6 +180,7 @@ def trace(
     *args,
     max_frames: int = 2,
     write_to_file: bool = True,
+    write_to_tty: bool = True,
     level_name: Literal["error", "debug"] = "error",
     **kwargs,
 ):
@@ -193,6 +195,7 @@ def trace(
         *args: 前缀消息
         max_frames: 终端显示的最大栈帧数，默认 2
         write_to_file: 是否写入日志文件，默认 True
+        write_to_tty: 是否在终端打印，默认 True
         level_name: 日志级别，"error" 或 "debug"，默认 "error"
     """
     import traceback
@@ -217,7 +220,13 @@ def trace(
     file_msg = f"{prefix}: {full_tb}" if prefix else full_tb
 
     log_fn = error if level_name == "error" else debug
-    log_fn(console_args=(console_msg,), file_args=(file_msg,), write_to_file=write_to_file, **kwargs)
+    log_fn(
+        console_args=(console_msg,),
+        file_args=(file_msg,),
+        write_to_file=write_to_file,
+        write_to_tty=write_to_tty,
+        **kwargs,
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/swanlab/sdk/internal/pkg/safe/__init__.py
+++ b/swanlab/sdk/internal/pkg/safe/__init__.py
@@ -6,7 +6,7 @@
 1. safe.decorator: 以装饰器的形式装饰一个函数，在函数内部捕获所有异常并返回None
 2. safe.block: 以 with 的形式使用这个装饰器，在 with 语句块中捕获异常
 
-在设计上这两个API是对console.trace的封装，console.trace会追踪当前调用栈，在终端打印简短信息，在日志文件中打印详细信息，并将详细信息写入日志文件
+在设计上这两个API是对console.trace的封装，console.trace会追踪当前调用栈，在终端打印简短信息，在日志文件中打印详细信息
 """
 
 import sys
@@ -33,7 +33,8 @@ def decorator(
     *exceptions: Type[BaseException],
     level: Literal["debug", "error"] = "error",
     message: Optional[str],
-    write: bool = True,
+    write_to_file: bool = True,
+    write_to_tty: bool = True,
     on_error: Optional[Callable[[BaseException], None]] = None,
 ):
     """
@@ -42,9 +43,10 @@ def decorator(
 
     Args:
         *exceptions: 要捕获的异常类型，默认捕获所有 Exception
-        level: 错误日志的级别，默认为error，可选debug，遵循console本身的level等级机制，如果为debug且不在debug模式，message和write都无效
+        level: 错误日志的级别，默认为error，可选debug，遵循console本身的level等级机制，如果为debug且不在debug模式，message和write_to_file都无效
         message: 错误信息，必传，如果传入None，则不打印错误信息
-        write: 是否将错误信息写入日志，默认为 True，如果message为None，无论write是否为True，都不写入日志
+        write_to_file: 是否将错误信息写入日志文件，默认为 True
+        write_to_tty: 是否在终端打印错误信息，默认为 True
         on_error: 异常发生时执行的回调函数，默认为 None
     """
     catch_types = exceptions if exceptions else (Exception,)
@@ -58,7 +60,7 @@ def decorator(
                 return func(*args, **kwargs)
             except catch_types as e:
                 if message is not None:
-                    console.trace(message, write_to_file=write, level_name=level)
+                    console.trace(message, write_to_file=write_to_file, write_to_tty=write_to_tty, level_name=level)
                 if on_error is not None:
                     on_error(e)
 
@@ -72,7 +74,8 @@ def block(
     *exceptions: Type[BaseException],
     level: Literal["debug", "error"] = "error",
     message: Optional[str],
-    write: bool = True,
+    write_to_file: bool = True,
+    write_to_tty: bool = True,
     on_error: Optional[Callable[[BaseException], None]] = None,
 ) -> Generator[None, None, None]:
     """
@@ -80,9 +83,10 @@ def block(
 
     Args:
         *exceptions: 要捕获的异常类型，默认捕获所有 Exception
-        level: 错误日志的级别，默认为error，可选debug，遵循console本身的level等级机制，如果为debug且不在debug模式，message和write都无效
+        level: 错误日志的级别，默认为error，可选debug，遵循console本身的level等级机制，如果为debug且不在debug模式，message和write_to_file都无效
         message: 错误信息，必传，如果传入None，则不打印错误信息
-        write: 是否将错误信息写入日志，默认为 True
+        write_to_file: 是否将错误信息写入日志文件，默认为 True
+        write_to_tty: 是否在终端打印错误信息，默认为 True
         on_error: 异常发生时执行的回调函数，默认为 None
 
     Example:
@@ -94,6 +98,6 @@ def block(
         yield
     except catch_types as e:
         if message is not None:
-            console.trace(message, write_to_file=write, level_name=level)
+            console.trace(message, write_to_file=write_to_file, write_to_tty=write_to_tty, level_name=level)
         if on_error is not None:
             on_error(e)

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -25,8 +25,8 @@ from swanlab.proto.swanlab.run.v1.run_pb2 import FinishRecord
 from swanlab.sdk.internal.bus import MetricLogEvent, ScalarDefineEvent
 from swanlab.sdk.internal.context import RunContext
 from swanlab.sdk.internal.pkg import adapter, console, fork, safe
-from swanlab.sdk.internal.run import components, system
-from swanlab.sdk.internal.run.components.config import Config, deactivate_run_config
+from swanlab.sdk.internal.run.components import Components
+from swanlab.sdk.internal.run.components.config import Config
 from swanlab.sdk.internal.run.transforms import Audio, Image, Text, Video, normalize_media_input
 from swanlab.sdk.typings.run import AsyncLogType, FinishType, ModeType
 from swanlab.sdk.typings.run.column import ScalarXAxisType
@@ -109,11 +109,9 @@ class Run:
         # 外部API锁，防止并发调用
         self._api_lock = threading.RLock()
         # 运行时组件
-        self._asynctask, self._consumer, self._emitter, self._config = components.new(self._ctx)
+        self._components = Components(ctx)
         # 回调器
         self._callbacker = self._ctx.callbacker
-        # self._monitor is not None 则代表硬件监控开启
-        self._monitor: Optional[system.Monitor] = None
 
         # 2. 注册副作用
         # 设置全局运行实例
@@ -127,11 +125,9 @@ class Run:
         self._original_sigint_handler = signal.getsignal(signal.SIGINT)
         signal.signal(signal.SIGINT, self._handle_sigint)
 
-        # 3. 初始化完成
+        # 3. 启动组件 + 初始化日志
         self._callbacker.on_run_initialized(self._ctx.run_dir, self.path)
-        self._monitor = system.create_monitor(self._ctx, self._emitter)
-        self._consumer.start()
-        # 初始化日志模块：非 disabled 模式绑定文件，disabled 模式禁用持久化
+        self._components.start()
         console.init(bind_to=self._ctx.debug_dir if self.mode != "disabled" else None)
 
     # ----------------------------------
@@ -248,7 +244,7 @@ class Run:
 
     @cached_property
     def config(self) -> Config:
-        return self._config
+        return self._components.config
 
     @property
     def _passive(self) -> bool:
@@ -316,7 +312,7 @@ class Run:
         flatten_data = fmt.flatten_dict(this_data)
 
         # 推送日志事件
-        self._emitter.emit(MetricLogEvent(data=flatten_data, step=next_step, timestamp=ts))
+        self._components.emitter.emit(MetricLogEvent(data=flatten_data, step=next_step, timestamp=ts))
 
     @with_api("run.async_log()")
     def async_log(
@@ -399,7 +395,7 @@ class Run:
                 "fork mode is not yet supported, please looking forward to the `swanlab-core` release"
             )
 
-        return self._asynctask.submit(
+        return self._components.asynctask.submit(
             func,
             args=args,
             kwargs=kwargs,
@@ -541,7 +537,7 @@ class Run:
         if chart_name and not (chart_name := fmt.safe_validate_chart_name(chart_name)):
             return console.error(f"Invalid chart_name for define scalar: {original_chart_name}, must be a string.")
 
-        self._emitter.emit(
+        self._components.emitter.emit(
             ScalarDefineEvent(
                 key=this_key,
                 name=name,
@@ -577,38 +573,20 @@ class Run:
         if state == "crashed" and error is None:
             console.warning("Crashed reason has been set to 'unknown' due to missing error message.")
             error = "unknown"
-        # 2. 运行结束前，结束其他依赖于运行实例的线程
-        # 2.1 等待所有 async_log 任务完成
-        console.debug("Waiting for async_log tasks to complete...")
-        self._asynctask.shutdown(timeout=async_log_timeout)
-        # 2.2 停止硬件监控
-        if self._monitor is not None:
-            console.debug("Stopping hardware monitor...")
-            self._monitor.stop()
-
-        # 3. 运行结束，清理相关组件状态
+        # 2. 运行结束，清理组件
         self._state = this_state
-        # 停止时间
+        # 停止所有组件（async_log → monitor → terminal → config → consumer）
+        self._components.stop(async_log_timeout=async_log_timeout)
         ts = Timestamp()
         ts.GetCurrentTime()
-        # 3.1 TODO: goodbye message
-
-        # 3.2 TODO: 停止终端代理
-
-        # 3.3 解绑config对象
-        deactivate_run_config()
-        # 3.4 停止消费者线程
-        console.debug("SwanLab Run is finishing, waiting for logs to flush...")
-        self._consumer.stop()
-        self._consumer.join()
-        # 3.5 停止Core线程
+        # 3. 停止Core线程
         finish_resp = self._ctx.core.deliver_run_finish(
             FinishRecord(state=adapter.state[this_state], error=error, finished_at=ts)
         )
         if not finish_resp.success:
             console.error(finish_resp.message)
         console.debug(f"SwanLab Run has finished with state: {self._state}, cleanup...")
-        # 3.5 清理副作用
+        # 4. 清理副作用
         console.debug("Cleanup system hook...")
         atexit.unregister(self._handle_atexit)
         sys.excepthook = self._sys_origin_excepthook

--- a/swanlab/sdk/internal/run/components/__init__.py
+++ b/swanlab/sdk/internal/run/components/__init__.py
@@ -2,49 +2,151 @@
 @author: cunyue
 @file: __init__.py
 @time: 2026/4/19 18:59
-@description: Run 组件工厂，提供 Run 所需组件的创建和初始化
+@description: Run 组件工厂与生命周期管理
 """
 
-from typing import Tuple
+from __future__ import annotations
+
+from typing import Optional
 
 from swanlab.sdk.internal.bus import EmitterProtocol, RunEmitter
 from swanlab.sdk.internal.context import RunContext
+from swanlab.sdk.internal.pkg import console, fork
+from swanlab.sdk.internal.run import system
 from swanlab.sdk.internal.run.components.asynctask import AsyncTaskManager
 from swanlab.sdk.internal.run.components.builder import RecordBuilder
-from swanlab.sdk.internal.run.components.config import Config, create_run_config, create_unbound_run_config
+from swanlab.sdk.internal.run.components.config import (
+    Config,
+    create_run_config,
+    create_unbound_run_config,
+    deactivate_run_config,
+)
 from swanlab.sdk.internal.run.components.consumer import BackgroundConsumer, ConsumerProtocol
-from swanlab.sdk.internal.run.components.null import NullConsumer, NullEmitter
+from swanlab.sdk.internal.run.components.null import NullConsumer, NullEmitter, NullTerminalProxy
+from swanlab.sdk.internal.run.components.terminal import TerminalProxy, TerminalProxyProtocol
 
 __all__ = [
-    "new",
+    "Components",
     "Config",
     "ConsumerProtocol",
+    "TerminalProxyProtocol",
     "AsyncTaskManager",
     "RecordBuilder",
     "BackgroundConsumer",
     "NullConsumer",
     "NullEmitter",
+    "NullTerminalProxy",
 ]
 
 
-def new(ctx: RunContext) -> Tuple[AsyncTaskManager, ConsumerProtocol, EmitterProtocol, Config]:
+class Components:
+    """Run 运行时组件容器，统一管理所有组件的创建与生命周期。
+
+    职责：
+    - 创建所有运行时组件（工厂模式）
+    - 编排组件启动顺序
+    - 编排组件停止顺序
+
+    Run 只持有 Components 引用，通过属性访问需要的组件。
     """
-    创建 Run 运行所需必要组件
-    :param ctx: 运行上下文
-    :return: 任务管理器，消费者，系统监控，配置
-    """
-    a = AsyncTaskManager()
-    b = RecordBuilder(ctx)
-    e = _factory_emitter(ctx)
-    c = _factory_consumer(ctx, e, b)
-    return a, c, e, _factory_config(ctx, e)
+
+    def __init__(self, ctx: RunContext) -> None:
+        self._ctx = ctx
+        self._init_pid = fork.current_pid()
+
+        # 核心组件
+        self._asynctask = AsyncTaskManager()
+        self._builder = RecordBuilder(ctx)
+        self._emitter = _factory_emitter(ctx)
+        self._consumer = _factory_consumer(ctx, self._emitter, self._builder)
+        self._config = _factory_config(ctx, self._emitter)
+
+        # 附加组件（延迟创建，在 start() 中初始化）
+        self._monitor: Optional[system.Monitor] = None
+        self._terminal: TerminalProxyProtocol = _factory_terminal(ctx, self._emitter, self._init_pid)
+
+    # ----------------------------------
+    # 组件访问
+    # ----------------------------------
+
+    @property
+    def asynctask(self) -> AsyncTaskManager:
+        return self._asynctask
+
+    @property
+    def consumer(self) -> ConsumerProtocol:
+        return self._consumer
+
+    @property
+    def emitter(self) -> EmitterProtocol:
+        return self._emitter
+
+    @property
+    def config(self) -> Config:
+        return self._config
+
+    @property
+    def monitor(self) -> Optional[system.Monitor]:
+        return self._monitor
+
+    @property
+    def terminal(self) -> TerminalProxyProtocol:
+        return self._terminal
+
+    # ----------------------------------
+    # 生命周期：启动
+    # ----------------------------------
+
+    def start(self) -> None:
+        """启动所有组件，按依赖顺序编排。"""
+        ctx = self._ctx
+
+        # 1. 启动硬件监控（依赖 emitter）
+        self._monitor = system.create_monitor(ctx, self._emitter)
+
+        # 2. 启动终端代理（依赖 emitter）
+        self._terminal.install()
+
+        # 3. 启动消费者线程（消费 emitter 队列）
+        self._consumer.start()
+
+    # ----------------------------------
+    # 生命周期：停止
+    # ----------------------------------
+
+    def stop(self, async_log_timeout: float | None = None) -> None:
+        """停止所有组件，按反向依赖顺序编排。
+
+        :param async_log_timeout: async_log 任务等待超时
+        """
+        # 1. 等待异步任务完成
+        console.debug("Waiting for async_log tasks to complete...")
+        self._asynctask.shutdown(timeout=async_log_timeout)
+
+        # 2. 停止硬件监控
+        if self._monitor is not None:
+            console.debug("Stopping hardware monitor...")
+            self._monitor.stop()
+
+        # 3. 停止终端代理（可能发射最后的 ConsoleEvent）
+        console.debug("Stopping terminal proxy...")
+        self._terminal.uninstall()
+
+        # 4. 解绑 config
+        deactivate_run_config()
+
+        # 5. 停止消费者线程（消费剩余事件包括最后的 ConsoleEvent）
+        console.debug("SwanLab Run is finishing, waiting for logs to flush...")
+        self._consumer.stop()
+        self._consumer.join()
+
+
+# ==========================================
+# 工厂函数
+# ==========================================
 
 
 def _factory_emitter(ctx: RunContext) -> EmitterProtocol:
-    """emitter对象工厂
-
-    :param ctx: 运行上下文，包含配置信息和运行时状态
-    """
     if ctx.config.settings.mode == "disabled":
         return NullEmitter()
     return RunEmitter()
@@ -55,25 +157,24 @@ def _factory_consumer(
     e: EmitterProtocol,
     b: RecordBuilder,
 ) -> ConsumerProtocol:
-    """consumer对象工厂
-
-    :param ctx: 运行上下文
-    :param e: 事件发射器
-    :param b: 构建器
-    """
     if ctx.config.settings.mode == "disabled":
         return NullConsumer(ctx, e.queue, b)
     return BackgroundConsumer(ctx, e.queue, b)
 
 
 def _factory_config(ctx: RunContext, e: EmitterProtocol) -> Config:
-    """
-    config 对象工厂函数
-
-    :param ctx: 运行上下文
-    :param e: 事件发射器，绑定 config 时用于发出 ConfigEvent
-    """
-
     if ctx.config.settings.mode == "disabled":
         return create_unbound_run_config()
     return create_run_config(ctx.config_file, e.emit)
+
+
+def _factory_terminal(ctx: RunContext, e: EmitterProtocol, init_pid: int) -> TerminalProxyProtocol:
+    settings = ctx.config.settings
+    if settings.mode == "disabled" or settings.console.proxy_type == "none":
+        return NullTerminalProxy()
+    return TerminalProxy(
+        emitter=e,
+        proxy_type=settings.console.proxy_type,
+        max_log_length=settings.console.max_log_length,
+        init_pid=init_pid,
+    )

--- a/swanlab/sdk/internal/run/components/builder/__init__.py
+++ b/swanlab/sdk/internal/run/components/builder/__init__.py
@@ -2,7 +2,7 @@
 @author: cunyue
 @file: __init__.py
 @time: 2026/3/13
-@description: protobuf Record 工厂，覆盖所有 record_type
+@description: protobuf Record 工厂组件，覆盖除了生命周期以外的所有 record_type
 """
 
 from functools import singledispatchmethod

--- a/swanlab/sdk/internal/run/components/config/__init__.py
+++ b/swanlab/sdk/internal/run/components/config/__init__.py
@@ -2,7 +2,7 @@
 @author: cunyue
 @file: __init__.py
 @time: 2026/3/14
-@description: SwanLab 实验配置模块
+@description: SwanLab 配置组件，主要负责同步实验配置，为用户提供 swanlab.config 的交互体验
 
 生命周期：
   未绑定（bindctx 调用前）：所有写操作仅保留在内存，不触发 IO 和事件

--- a/swanlab/sdk/internal/run/components/null.py
+++ b/swanlab/sdk/internal/run/components/null.py
@@ -10,6 +10,7 @@ from queue import Queue
 from swanlab.sdk.internal.bus import EmitterProtocol, EventPayload, RunQueue
 
 from .consumer import ConsumerProtocol
+from .terminal import TerminalProxyProtocol
 
 
 class NullEmitter(EmitterProtocol):
@@ -36,4 +37,14 @@ class NullConsumer(ConsumerProtocol):
         pass
 
     def join(self) -> None:
+        pass
+
+
+class NullTerminalProxy(TerminalProxyProtocol):
+    """空终端代理，install/uninstall 为 no-op"""
+
+    def install(self) -> None:
+        pass
+
+    def uninstall(self) -> None:
         pass

--- a/swanlab/sdk/internal/run/components/terminal/__init__.py
+++ b/swanlab/sdk/internal/run/components/terminal/__init__.py
@@ -65,9 +65,6 @@ class TerminalProxy(TerminalProxyProtocol):
         self._max_log_length = max_log_length
         self._init_pid = init_pid
 
-        # 行计数器
-        self._epoch: int = 0
-
         # 双 Emulator
         self._stdout_emulator = TerminalEmulator()
         self._stderr_emulator = TerminalEmulator()
@@ -235,5 +232,4 @@ class TerminalProxy(TerminalProxyProtocol):
 
         ts = Timestamp()
         ts.GetCurrentTime()
-        self._emitter.emit(ConsoleEvent(epoch=self._epoch, line=line, stream=stream, timestamp=ts))
-        self._epoch += 1
+        self._emitter.emit(ConsoleEvent(line=line, stream=stream, timestamp=ts))

--- a/swanlab/sdk/internal/run/components/terminal/__init__.py
+++ b/swanlab/sdk/internal/run/components/terminal/__init__.py
@@ -144,7 +144,11 @@ class TerminalProxy(TerminalProxyProtocol):
             self._worker_thread.join(timeout=5)
             self._worker_thread = None
 
-        # 4. 最终 flush
+        # 4. 强制提交 pending 行
+        self._stdout_emulator.finalize()
+        self._stderr_emulator.finalize()
+
+        # 5. 最终 flush
         self._flush()
 
         self._installed = False
@@ -228,10 +232,6 @@ class TerminalProxy(TerminalProxyProtocol):
         # 截断
         if len(line) > self._max_log_length:
             line = line[: self._max_log_length]
-
-        # 跳过空行
-        if not line:
-            return
 
         ts = Timestamp()
         ts.GetCurrentTime()

--- a/swanlab/sdk/internal/run/components/terminal/__init__.py
+++ b/swanlab/sdk/internal/run/components/terminal/__init__.py
@@ -6,6 +6,10 @@
 
 生命周期：
     install() → [运行中] → uninstall()
+
+架构：
+    主线程 → StreamCapture → queue → emulator 线程 → emulator.write() → _flush()
+    只发射 committed 行（光标已通过 \\n 离开），跳过 \\r 覆盖的中间状态。
 """
 
 from __future__ import annotations
@@ -42,8 +46,6 @@ class TerminalProxy(TerminalProxyProtocol):
 
     stdout 和 stderr 各使用独立的 TerminalEmulator，确保 stream 字段准确。
     """
-
-    _FLUSH_INTERVAL: float = 1.0  # 秒，周期性 flush 间隔
 
     def __init__(
         self,
@@ -83,8 +85,7 @@ class TerminalProxy(TerminalProxyProtocol):
         self._stderr_capture: StreamCapture | None = None
 
         # 后台线程
-        self._emulator_thread: threading.Thread | None = None
-        self._flush_thread: threading.Thread | None = None
+        self._worker_thread: threading.Thread | None = None
 
     # ----------------------------------
     # 生命周期
@@ -112,21 +113,13 @@ class TerminalProxy(TerminalProxyProtocol):
             )
             self._stderr_capture.install()
 
-        # 2. 启动模拟器写入线程
-        self._emulator_thread = threading.Thread(
-            target=self._emulator_write_loop,
-            name="SwanLab·TerminalWriter",
+        # 2. 启动工作线程（emulator 写入 + flush）
+        self._worker_thread = threading.Thread(
+            target=self._worker_loop,
+            name="SwanLab·TerminalProxy",
             daemon=True,
         )
-        self._emulator_thread.start()
-
-        # 3. 启动周期性 flush 线程
-        self._flush_thread = threading.Thread(
-            target=self._flush_loop,
-            name="SwanLab·TerminalFlush",
-            daemon=True,
-        )
-        self._flush_thread.start()
+        self._worker_thread.start()
 
         self._installed = True
 
@@ -146,18 +139,13 @@ class TerminalProxy(TerminalProxyProtocol):
         # 2. 通知线程停止
         self._stopped.set()
 
-        # 3. 等待模拟器线程排空队列
-        if self._emulator_thread is not None:
-            self._emulator_thread.join(timeout=5)
-            self._emulator_thread = None
+        # 3. 等待工作线程排空队列
+        if self._worker_thread is not None:
+            self._worker_thread.join(timeout=5)
+            self._worker_thread = None
 
         # 4. 最终 flush
         self._flush()
-
-        # 5. 等待 flush 线程
-        if self._flush_thread is not None:
-            self._flush_thread.join(timeout=2)
-            self._flush_thread = None
 
         self._installed = False
 
@@ -172,21 +160,23 @@ class TerminalProxy(TerminalProxyProtocol):
         self._stderr_queue.put(text)
 
     # ----------------------------------
-    # 模拟器写入线程
+    # 工作线程
     # ----------------------------------
 
-    def _emulator_write_loop(self) -> None:
-        """后台线程：从队列读取数据，写入模拟器。"""
+    def _worker_loop(self) -> None:
+        """后台线程：从队列读取数据，写入模拟器，立即 flush。"""
         while True:
             stdout_items = self._drain_queue(self._stdout_queue)
             if stdout_items:
-                with safe.block(message="Terminal emulator stdout write error"):
-                    self._stdout_emulator.write("".join(stdout_items))
+                self._stdout_emulator.write("".join(stdout_items))
 
             stderr_items = self._drain_queue(self._stderr_queue)
             if stderr_items:
-                with safe.block(message="Terminal emulator stderr write error"):
-                    self._stderr_emulator.write("".join(stderr_items))
+                self._stderr_emulator.write("".join(stderr_items))
+
+            # 有数据写入就 flush
+            if stdout_items or stderr_items:
+                self._flush()
 
             # 退出条件：已停止且队列排空
             if self._stopped.is_set() and self._stdout_queue.empty() and self._stderr_queue.empty():
@@ -208,21 +198,15 @@ class TerminalProxy(TerminalProxyProtocol):
         return items
 
     # ----------------------------------
-    # Flush 线程
+    # Flush
     # ----------------------------------
-
-    def _flush_loop(self) -> None:
-        """后台线程：周期性读取模拟器 diff 并发射 ConsoleEvent。"""
-        while not self._stopped.is_set():
-            self._flush()
-            self._stopped.wait(self._FLUSH_INTERVAL)
 
     def _flush(self) -> None:
         """读取双模拟器 diff，发射 ConsoleEvent。
 
-        只发射新增行（is_new_line=True），跳过 \r 覆盖的中间状态。
+        只发射新增行（is_new_line=True），跳过 \\r 覆盖的中间状态。
         """
-        with safe.block(message="Terminal proxy flush error"):
+        with safe.block(message="Terminal proxy flush error", write_to_tty=False):
             # stdout diff
             for line_text, is_new_line in self._stdout_emulator.read():
                 if not is_new_line:

--- a/swanlab/sdk/internal/run/components/terminal/__init__.py
+++ b/swanlab/sdk/internal/run/components/terminal/__init__.py
@@ -63,6 +63,9 @@ class TerminalProxy(TerminalProxyProtocol):
         self._max_log_length = max_log_length
         self._init_pid = init_pid
 
+        # 行计数器
+        self._epoch: int = 0
+
         # 双 Emulator
         self._stdout_emulator = TerminalEmulator()
         self._stderr_emulator = TerminalEmulator()
@@ -248,4 +251,5 @@ class TerminalProxy(TerminalProxyProtocol):
 
         ts = Timestamp()
         ts.GetCurrentTime()
-        self._emitter.emit(ConsoleEvent(line=line, stream=stream, timestamp=ts))
+        self._emitter.emit(ConsoleEvent(epoch=self._epoch, line=line, stream=stream, timestamp=ts))
+        self._epoch += 1

--- a/swanlab/sdk/internal/run/components/terminal/__init__.py
+++ b/swanlab/sdk/internal/run/components/terminal/__init__.py
@@ -1,0 +1,251 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2026/4/19 20:26
+@description: 终端代理组件 — 拦截 stdout/stderr，经终端模拟器处理，发射 ConsoleEvent
+
+生命周期：
+    install() → [运行中] → uninstall()
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Literal, Protocol
+
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from swanlab.proto.swanlab.system.v1.console_pb2 import StreamType
+from swanlab.sdk.internal.bus import ConsoleEvent, EmitterProtocol
+from swanlab.sdk.internal.pkg import safe
+
+from .capture import StreamCapture
+from .emulator import TerminalEmulator
+
+__all__ = ["TerminalProxyProtocol", "TerminalProxy"]
+
+
+class TerminalProxyProtocol(Protocol):
+    """终端代理协议"""
+
+    def install(self) -> None: ...
+
+    def uninstall(self) -> None: ...
+
+
+class TerminalProxy(TerminalProxyProtocol):
+    """终端代理组件。
+
+    拦截 stdout/stderr 输出，通过终端模拟器处理 ANSI 序列和 \\r 覆盖，
+    提取完整行后发射 ConsoleEvent 到事件总线。
+
+    stdout 和 stderr 各使用独立的 TerminalEmulator，确保 stream 字段准确。
+    """
+
+    _FLUSH_INTERVAL: float = 1.0  # 秒，周期性 flush 间隔
+
+    def __init__(
+        self,
+        emitter: EmitterProtocol,
+        proxy_type: Literal["all", "stdout", "stderr", "none"],
+        max_log_length: int,
+        init_pid: int,
+    ) -> None:
+        """
+        :param emitter: 事件总线发射器
+        :param proxy_type: 捕获哪些流
+        :param max_log_length: 每行最大字符数
+        :param init_pid: 创建时 PID，用于 fork 检测
+        """
+        self._emitter = emitter
+        self._proxy_type = proxy_type
+        self._max_log_length = max_log_length
+        self._init_pid = init_pid
+
+        # 双 Emulator
+        self._stdout_emulator = TerminalEmulator()
+        self._stderr_emulator = TerminalEmulator()
+
+        # 双队列
+        self._stdout_queue: queue.Queue[str] = queue.Queue()
+        self._stderr_queue: queue.Queue[str] = queue.Queue()
+
+        # 线程控制
+        self._stopped = threading.Event()
+        self._installed = False
+
+        # Capture 实例
+        self._stdout_capture: StreamCapture | None = None
+        self._stderr_capture: StreamCapture | None = None
+
+        # 后台线程
+        self._emulator_thread: threading.Thread | None = None
+        self._flush_thread: threading.Thread | None = None
+
+    # ----------------------------------
+    # 生命周期
+    # ----------------------------------
+
+    def install(self) -> None:
+        """启动终端代理：安装 capture，启动后台线程。"""
+        if self._installed or self._proxy_type == "none":
+            return
+
+        # 1. 安装 StreamCapture
+        if self._proxy_type in ("all", "stdout"):
+            self._stdout_capture = StreamCapture(
+                stream_name="stdout",
+                on_write=self._on_stdout_write,
+                init_pid=self._init_pid,
+            )
+            self._stdout_capture.install()
+
+        if self._proxy_type in ("all", "stderr"):
+            self._stderr_capture = StreamCapture(
+                stream_name="stderr",
+                on_write=self._on_stderr_write,
+                init_pid=self._init_pid,
+            )
+            self._stderr_capture.install()
+
+        # 2. 启动模拟器写入线程
+        self._emulator_thread = threading.Thread(
+            target=self._emulator_write_loop,
+            name="SwanLab·TerminalWriter",
+            daemon=True,
+        )
+        self._emulator_thread.start()
+
+        # 3. 启动周期性 flush 线程
+        self._flush_thread = threading.Thread(
+            target=self._flush_loop,
+            name="SwanLab·TerminalFlush",
+            daemon=True,
+        )
+        self._flush_thread.start()
+
+        self._installed = True
+
+    def uninstall(self) -> None:
+        """停止终端代理：卸载 capture，等待线程排空，最终 flush。"""
+        if not self._installed:
+            return
+
+        # 1. 卸载 capture（停止拦截 write）
+        if self._stdout_capture is not None:
+            self._stdout_capture.uninstall()
+            self._stdout_capture = None
+        if self._stderr_capture is not None:
+            self._stderr_capture.uninstall()
+            self._stderr_capture = None
+
+        # 2. 通知线程停止
+        self._stopped.set()
+
+        # 3. 等待模拟器线程排空队列
+        if self._emulator_thread is not None:
+            self._emulator_thread.join(timeout=5)
+            self._emulator_thread = None
+
+        # 4. 最终 flush
+        self._flush()
+
+        # 5. 等待 flush 线程
+        if self._flush_thread is not None:
+            self._flush_thread.join(timeout=2)
+            self._flush_thread = None
+
+        self._installed = False
+
+    # ----------------------------------
+    # Write 回调（由 StreamCapture 在主线程调用）
+    # ----------------------------------
+
+    def _on_stdout_write(self, text: str, stream_type: StreamType) -> None:
+        self._stdout_queue.put(text)
+
+    def _on_stderr_write(self, text: str, stream_type: StreamType) -> None:
+        self._stderr_queue.put(text)
+
+    # ----------------------------------
+    # 模拟器写入线程
+    # ----------------------------------
+
+    def _emulator_write_loop(self) -> None:
+        """后台线程：从队列读取数据，写入模拟器。"""
+        while True:
+            stdout_items = self._drain_queue(self._stdout_queue)
+            if stdout_items:
+                with safe.block(message="Terminal emulator stdout write error"):
+                    self._stdout_emulator.write("".join(stdout_items))
+
+            stderr_items = self._drain_queue(self._stderr_queue)
+            if stderr_items:
+                with safe.block(message="Terminal emulator stderr write error"):
+                    self._stderr_emulator.write("".join(stderr_items))
+
+            # 退出条件：已停止且队列排空
+            if self._stopped.is_set() and self._stdout_queue.empty() and self._stderr_queue.empty():
+                return
+
+            if not stdout_items and not stderr_items:
+                self._stopped.wait(0.1)
+
+    @staticmethod
+    def _drain_queue(q: queue.Queue[str]) -> list[str]:
+        """批量排空队列。"""
+        items: list[str] = []
+        try:
+            items.append(q.get_nowait())
+            while True:
+                items.append(q.get_nowait())
+        except queue.Empty:
+            pass
+        return items
+
+    # ----------------------------------
+    # Flush 线程
+    # ----------------------------------
+
+    def _flush_loop(self) -> None:
+        """后台线程：周期性读取模拟器 diff 并发射 ConsoleEvent。"""
+        while not self._stopped.is_set():
+            self._flush()
+            self._stopped.wait(self._FLUSH_INTERVAL)
+
+    def _flush(self) -> None:
+        """读取双模拟器 diff，发射 ConsoleEvent。
+
+        只发射新增行（is_new_line=True），跳过 \r 覆盖的中间状态。
+        """
+        with safe.block(message="Terminal proxy flush error"):
+            # stdout diff
+            for line_text, is_new_line in self._stdout_emulator.read():
+                if not is_new_line:
+                    continue
+                self._emit_line(line_text, StreamType.STREAM_TYPE_STDOUT)
+
+            # stderr diff
+            for line_text, is_new_line in self._stderr_emulator.read():
+                if not is_new_line:
+                    continue
+                self._emit_line(line_text, StreamType.STREAM_TYPE_STDERR)
+
+    # ----------------------------------
+    # ConsoleEvent 发射
+    # ----------------------------------
+
+    def _emit_line(self, line: str, stream: StreamType) -> None:
+        """发射一行 ConsoleEvent，应用 max_log_length 截断。"""
+        # 截断
+        if len(line) > self._max_log_length:
+            line = line[: self._max_log_length]
+
+        # 跳过空行
+        if not line:
+            return
+
+        ts = Timestamp()
+        ts.GetCurrentTime()
+        self._emitter.emit(ConsoleEvent(line=line, stream=stream, timestamp=ts))

--- a/swanlab/sdk/internal/run/components/terminal/capture.py
+++ b/swanlab/sdk/internal/run/components/terminal/capture.py
@@ -96,15 +96,16 @@ class StreamCapture:
         original_write = cast(Callable[[str], int], self._original_write)
         assert original_write is not None
         on_write = self._on_write
-        init_pid = self._init_pid
+        # install 时确定是否 fork，后续不再判断
+        is_forked = fork.is_forked(self._init_pid)
         stream_type = self._stream_type
 
         def write_wrapper(data) -> int:
             # 1. Passthrough: 始终先调用原始 write
             n = original_write(data)
 
-            # 2. Fork 安全: fork 子进程静默跳过
-            if fork.is_forked(init_pid):
+            # 2. Fork 子进程静默跳过
+            if is_forked:
                 return n
 
             # 3. 重入保护
@@ -115,6 +116,7 @@ class StreamCapture:
                 _is_writing = True
                 _in_callback.set(True)
 
+            # noinspection PyBroadException
             try:
                 # 4. 解码 bytes → str
                 if isinstance(data, bytes):

--- a/swanlab/sdk/internal/run/components/terminal/capture.py
+++ b/swanlab/sdk/internal/run/components/terminal/capture.py
@@ -1,0 +1,142 @@
+"""
+@author: cunyue
+@file: capture.py
+@time: 2026/4/20
+@description: stdout/stderr write 拦截 — 按需启动/停止，重入保护，fork 安全
+
+设计要点：
+- Passthrough-first: 先调用原始 write，再通知回调
+- 按需启动: install() 时替换 write，uninstall() 时恢复，不影响全局
+- 重入保护: RLock + _is_writing + ContextVar 防止回调内 write 死循环
+- Fork 安全: PID guard 静默跳过 + fork.register() 重置锁
+- 异常安全: 回调异常静默吞掉，绝不让 callback 错误传播到用户 print()
+"""
+
+from __future__ import annotations
+
+import contextvars
+import sys
+import threading
+from typing import Callable, Literal
+
+from swanlab.proto.swanlab.system.v1.console_pb2 import StreamType
+from swanlab.sdk.internal.pkg import fork
+
+# ----------------------------------
+# 模块级重入保护状态
+# ----------------------------------
+
+_module_rlock = threading.RLock()
+_is_writing: bool = False
+_in_callback: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_swanlab_console_in_callback",
+    default=False,
+)
+
+
+class StreamCapture:
+    """拦截 sys.stdout 或 sys.stderr 的 write 方法。
+
+    install() 时替换流对象的 write 方法为包装器：
+    1. 调用原始 write (passthrough)
+    2. 调用 on_write 回调
+
+    uninstall() 时恢复原始 write 方法。
+    """
+
+    def __init__(
+        self,
+        stream_name: Literal["stdout", "stderr"],
+        on_write: Callable[[str, StreamType], None],
+        init_pid: int,
+    ) -> None:
+        """
+        :param stream_name: "stdout" 或 "stderr"
+        :param on_write: 回调函数 callback(written_text, stream_type)
+        :param init_pid: 构造时的 PID，用于 fork 检测
+        """
+        self._stream_name = stream_name
+        self._on_write = on_write
+        self._init_pid = init_pid
+        self._original_write: Callable | None = None
+        self._installed = False
+        self._fork_reset_callback: Callable[[], None] | None = None
+
+        # 预计算 stream_type
+        self._stream_type = StreamType.STREAM_TYPE_STDOUT if stream_name == "stdout" else StreamType.STREAM_TYPE_STDERR
+
+    def install(self) -> None:
+        """替换 sys.stdout.write 或 sys.stderr.write。"""
+        if self._installed:
+            return
+        stream = getattr(sys, self._stream_name)
+        self._original_write = stream.write
+        stream.write = self._make_wrapper()  # type: ignore[method-assign]
+        self._installed = True
+        # 注册 fork 清理回调
+        self._fork_reset_callback = _reset_locks_in_child
+        fork.register(self._fork_reset_callback)
+
+    def uninstall(self) -> None:
+        """恢复原始 write 方法。"""
+        if not self._installed:
+            return
+        stream = getattr(sys, self._stream_name)
+        stream.write = self._original_write  # type: ignore[method-assign]
+        self._original_write = None
+        self._installed = False
+        # 注销 fork 回调
+        if self._fork_reset_callback is not None:
+            fork.unregister(self._fork_reset_callback)
+            self._fork_reset_callback = None
+
+    def _make_wrapper(self):
+        """创建 write() 包装器。"""
+        original_write = self._original_write
+        on_write = self._on_write
+        init_pid = self._init_pid
+        stream_type = self._stream_type
+        assert original_write is not None
+
+        def write_wrapper(data) -> int:
+            # 1. Passthrough: 始终先调用原始 write
+            n = original_write(data)
+
+            # 2. Fork 安全: fork 子进程静默跳过
+            if fork.is_forked(init_pid):
+                return n
+
+            # 3. 重入保护
+            global _is_writing
+            with _module_rlock:
+                if _is_writing or _in_callback.get():
+                    return n
+                _is_writing = True
+                _in_callback.set(True)
+
+            try:
+                # 4. 解码 bytes → str
+                if isinstance(data, bytes):
+                    text = data[:n].decode("utf-8", errors="replace")
+                else:
+                    text = data[:n]
+                # 5. 调用回调
+                on_write(text, stream_type)
+            except Exception:
+                # 静默吞掉异常，绝不影响用户的 print()
+                pass
+            finally:
+                with _module_rlock:
+                    _is_writing = False
+                    _in_callback.set(False)
+
+            return n
+
+        return write_wrapper
+
+
+def _reset_locks_in_child() -> None:
+    """Fork 回调：在子进程中重置锁状态。"""
+    global _module_rlock, _is_writing
+    _module_rlock = threading.RLock()
+    _is_writing = False

--- a/swanlab/sdk/internal/run/components/terminal/capture.py
+++ b/swanlab/sdk/internal/run/components/terminal/capture.py
@@ -20,7 +20,7 @@ import threading
 from typing import Callable, Literal, cast
 
 from swanlab.proto.swanlab.system.v1.console_pb2 import StreamType
-from swanlab.sdk.internal.pkg import fork
+from swanlab.sdk.internal.pkg import fork, safe
 
 # ----------------------------------
 # 模块级重入保护状态
@@ -116,18 +116,15 @@ class StreamCapture:
                 _is_writing = True
                 _in_callback.set(True)
 
-            # noinspection PyBroadException
             try:
-                # 4. 解码 bytes → str
-                if isinstance(data, bytes):
-                    text = data[:n].decode("utf-8", errors="replace")
-                else:
-                    text = data[:n]
-                # 5. 调用回调
-                on_write(text, stream_type)
-            except Exception:
-                # 静默吞掉异常，绝不影响用户的 print()
-                pass
+                with safe.block(message="StreamCapture on_write error", write_to_tty=False):
+                    # 4. 解码 bytes → str
+                    if isinstance(data, bytes):
+                        text = data[:n].decode("utf-8", errors="replace")
+                    else:
+                        text = data[:n]
+                    # 5. 调用回调
+                    on_write(text, stream_type)
             finally:
                 with _module_rlock:
                     _is_writing = False

--- a/swanlab/sdk/internal/run/components/terminal/capture.py
+++ b/swanlab/sdk/internal/run/components/terminal/capture.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import contextvars
 import sys
 import threading
-from typing import Callable, Literal
+from typing import Callable, Literal, cast
 
 from swanlab.proto.swanlab.system.v1.console_pb2 import StreamType
 from swanlab.sdk.internal.pkg import fork
@@ -92,11 +92,12 @@ class StreamCapture:
 
     def _make_wrapper(self):
         """创建 write() 包装器。"""
-        original_write = self._original_write
+        # cast make PyCharm happy
+        original_write = cast(Callable[[str], int], self._original_write)
+        assert original_write is not None
         on_write = self._on_write
         init_pid = self._init_pid
         stream_type = self._stream_type
-        assert original_write is not None
 
         def write_wrapper(data) -> int:
             # 1. Passthrough: 始终先调用原始 write

--- a/swanlab/sdk/internal/run/components/terminal/capture.py
+++ b/swanlab/sdk/internal/run/components/terminal/capture.py
@@ -7,16 +7,15 @@
 设计要点：
 - Passthrough-first: 先调用原始 write，再通知回调
 - 按需启动: install() 时替换 write，uninstall() 时恢复，不影响全局
-- 重入保护: RLock + _is_writing + ContextVar 防止回调内 write 死循环
-- Fork 安全: PID guard 静默跳过 + fork.register() 重置锁
-- 异常安全: 回调异常静默吞掉，绝不让 callback 错误传播到用户 print()
+- 重入保护: ContextVar 防止同线程回调内 write 死循环，不同线程可并发
+- Fork 安全: 每次 write 动态检查 PID，install 后 fork 的子进程自动跳过
+- 异常安全: safe.block 捕获回调异常，写日志文件但不打终端，绝不影响用户 print()
 """
 
 from __future__ import annotations
 
 import contextvars
 import sys
-import threading
 from typing import Callable, Literal, cast
 
 from swanlab.proto.swanlab.system.v1.console_pb2 import StreamType
@@ -26,8 +25,6 @@ from swanlab.sdk.internal.pkg import fork, safe
 # 模块级重入保护状态
 # ----------------------------------
 
-_module_rlock = threading.RLock()
-_is_writing: bool = False
 _in_callback: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "_swanlab_console_in_callback",
     default=False,
@@ -60,7 +57,6 @@ class StreamCapture:
         self._init_pid = init_pid
         self._original_write: Callable | None = None
         self._installed = False
-        self._fork_reset_callback: Callable[[], None] | None = None
 
         # 预计算 stream_type
         self._stream_type = StreamType.STREAM_TYPE_STDOUT if stream_name == "stdout" else StreamType.STREAM_TYPE_STDERR
@@ -73,9 +69,6 @@ class StreamCapture:
         self._original_write = stream.write
         stream.write = self._make_wrapper()  # type: ignore[method-assign]
         self._installed = True
-        # 注册 fork 清理回调
-        self._fork_reset_callback = _reset_locks_in_child
-        fork.register(self._fork_reset_callback)
 
     def uninstall(self) -> None:
         """恢复原始 write 方法。"""
@@ -85,36 +78,27 @@ class StreamCapture:
         stream.write = self._original_write  # type: ignore[method-assign]
         self._original_write = None
         self._installed = False
-        # 注销 fork 回调
-        if self._fork_reset_callback is not None:
-            fork.unregister(self._fork_reset_callback)
-            self._fork_reset_callback = None
 
     def _make_wrapper(self):
         """创建 write() 包装器。"""
-        # cast make PyCharm happy
         original_write = cast(Callable[[str], int], self._original_write)
         assert original_write is not None
         on_write = self._on_write
-        # install 时确定是否 fork，后续不再判断
-        is_forked = fork.is_forked(self._init_pid)
+        init_pid = self._init_pid
         stream_type = self._stream_type
 
         def write_wrapper(data) -> int:
             # 1. Passthrough: 始终先调用原始 write
             n = original_write(data)
 
-            # 2. Fork 子进程静默跳过
-            if is_forked:
+            # 2. Fork 子进程动态检查（install 后 fork 的子进程自动跳过）
+            if fork.is_forked(init_pid):
                 return n
 
-            # 3. 重入保护
-            global _is_writing
-            with _module_rlock:
-                if _is_writing or _in_callback.get():
-                    return n
-                _is_writing = True
-                _in_callback.set(True)
+            # 3. 重入保护：仅防同线程递归，不同线程可并发
+            if _in_callback.get():
+                return n
+            _in_callback.set(True)
 
             try:
                 with safe.block(message="StreamCapture on_write error", write_to_tty=False):
@@ -126,17 +110,8 @@ class StreamCapture:
                     # 5. 调用回调
                     on_write(text, stream_type)
             finally:
-                with _module_rlock:
-                    _is_writing = False
-                    _in_callback.set(False)
+                _in_callback.set(False)
 
             return n
 
         return write_wrapper
-
-
-def _reset_locks_in_child() -> None:
-    """Fork 回调：在子进程中重置锁状态。"""
-    global _module_rlock, _is_writing
-    _module_rlock = threading.RLock()
-    _is_writing = False

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -344,13 +344,9 @@ class TerminalEmulator:
     def num_lines(self) -> int:
         if self._num_lines_cache is not None:
             return self._num_lines_cache
-        ret = 0
-        if self._buffer:
-            n = max(self._buffer.keys())
-            for i in range(n, -1, -1):
-                if self._get_line_len(i):
-                    ret = i + 1
-                    break
+        # 考虑已提交的行、光标所在的行以及缓冲区中已有的行
+        max_idx = max(self._buffer.keys()) if self._buffer else -1
+        ret = max(max_idx + 1, self._committed_lines, self._cursor.y + 1)
         self._num_lines_cache = ret
         return ret
 

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -164,9 +164,19 @@ class TerminalEmulator:
         self._committed_lines: int = 0
 
     def finalize(self) -> None:
-        """将所有行标记为 committed，使 read() 返回 pending 行。"""
-        if self.num_lines > self._committed_lines:
-            self._committed_lines = self.num_lines
+        """将所有行标记为 committed，使 read() 返回 pending 行。
+        尾部空行不提交，避免发射无意义的空行事件。
+        """
+        while self.num_lines > self._committed_lines:
+            last = self._get_plain_line(self.num_lines - 1)
+            if last:
+                self._committed_lines = self.num_lines
+                break
+            # 尾部空行，回退
+            if self.num_lines - 1 in self._buffer:
+                del self._buffer[self.num_lines - 1]
+            self._cursor.y = min(self._cursor.y, self.num_lines - 2)
+            self._num_lines_cache = None
 
     # ----------------------------------
     # 光标操作
@@ -342,6 +352,9 @@ class TerminalEmulator:
 
     @property
     def num_lines(self) -> int:
+        """
+        返回当前缓冲区中已提交的行数
+        """
         if self._num_lines_cache is not None:
             return self._num_lines_cache
         # 考虑已提交的行、光标所在的行以及缓冲区中已有的行

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -353,7 +353,7 @@ class TerminalEmulator:
     @property
     def num_lines(self) -> int:
         """
-        返回当前缓冲区中已提交的行数
+        当前有多少行（含空行）
         """
         if self._num_lines_cache is not None:
             return self._num_lines_cache

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -163,6 +163,11 @@ class TerminalEmulator:
         # 光标当前所在行是"进行中"的，不算 committed
         self._committed_lines: int = 0
 
+    def finalize(self) -> None:
+        """将所有行标记为 committed，使 read() 返回 pending 行。"""
+        if self.num_lines > self._committed_lines:
+            self._committed_lines = self.num_lines
+
     # ----------------------------------
     # 光标操作
     # ----------------------------------
@@ -262,6 +267,8 @@ class TerminalEmulator:
         """分发 CSI 命令。单个 CSI 解析异常不影响后续序列处理。"""
         with safe.block(message="Terminal emulator CSI parse error", write_to_tty=False):
             if command == "m":
+                # 只取首个参数；SGR 多参数（如 \033[31;1m）暂不逐个遍历，
+                # 因为 read() 只消费 Char.data 纯文本，样式属性目前无消费者
                 p = params.split(";")[0]
                 if not p:
                     p = "0"
@@ -365,7 +372,7 @@ class TerminalEmulator:
             return ""
         line = self._buffer[n]
         line_len = self._get_line_len(n)
-        return "".join(line[i].data for i in range(line_len)).rstrip()
+        return "".join(line[i].data for i in range(line_len))
 
     def read(self) -> List[Tuple[str, bool]]:
         """返回自上次 read() 以来的增量 diff。
@@ -381,15 +388,13 @@ class TerminalEmulator:
 
         # 计算新增的已完成行
         for i in range(self._prev_num_lines, min(self._committed_lines, num_lines)):
-            line = self._get_plain_line(i)
-            if line:
-                result.append((line, True))
+            result.append((self._get_plain_line(i), True))
 
         # 进行中的行（光标当前所在行，可能被 \r 覆盖）
         # 只有当进行中的行内容发生了变化时才返回
         if num_lines > self._committed_lines:
             pending_line = self._get_plain_line(num_lines - 1)
-            if pending_line and pending_line != self._prev_last_line:
+            if pending_line != self._prev_last_line:
                 result.append((pending_line, False))
 
         # 滚动缓冲区

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -149,7 +149,7 @@ class TerminalEmulator:
     - \\b → 退格 (cursor left)
     """
 
-    _MAX_LINES = 100
+    _MAX_LINES = 1024
 
     def __init__(self) -> None:
         self._buffer: defaultdict[int, defaultdict[int, Char]] = defaultdict(lambda: defaultdict(lambda: _default_char))

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -1,0 +1,411 @@
+"""
+@author: cunyue
+@file: emulator.py
+@time: 2026/4/20
+@description: 终端模拟器 — 2D 字符缓冲区 + ANSI CSI 解析
+
+基于 wandb TerminalEmulator 的设计，做了以下调整：
+- 移除 numpy 依赖，纯 Python 实现，因为SwanLab不需要重建ANSI序列
+- read() 返回结构化 [(纯文本行, is_new_line), ...] 而非带 \r 的原始字符串
+- _get_plain_line() 剥离 ANSI 码，ConsoleEvent.line 为纯文本
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+from collections import defaultdict
+from functools import cached_property
+from typing import Callable, List, Tuple
+
+# ==========================================
+# ANSI 常量
+# ==========================================
+
+ANSI_CSI_RE = re.compile(r"\001?\033\[((?:\d|;)*)([a-zA-Z])\002?")
+ANSI_OSC_RE = re.compile(r"\001?\033]([^\a]*)(\a)\002?")
+
+SEP_RE = re.compile(r"\r|\n|" + "|".join([chr(i) for i in range(2**8) if repr(chr(i)).startswith("'\\x")]))
+
+ANSI_FG = list(map(str, itertools.chain(range(30, 40), range(90, 98))))
+ANSI_BG = list(map(str, itertools.chain(range(40, 50), range(100, 108))))
+
+ANSI_FG_DEFAULT = "39"
+ANSI_BG_DEFAULT = "49"
+ANSI_RESET = "0"
+
+ANSI_STYLES = {
+    "1": "bold",
+    "2": "/bold",
+    "3": "italics",
+    "4": "underscore",
+    "5": "blink",
+    "7": "reverse",
+    "9": "strikethrough",
+    "22": "/bold",
+    "23": "/italics",
+    "24": "/underscore",
+    "25": "/blink",
+    "27": "/reverse",
+    "29": "/strikethrough",
+}
+
+# ==========================================
+# Char / Cursor
+# ==========================================
+
+
+class Char:
+    """单字符单元，包含前景/背景色和文本样式属性。"""
+
+    __slots__ = (
+        "data",
+        "fg",
+        "bg",
+        "bold",
+        "italics",
+        "underscore",
+        "blink",
+        "strikethrough",
+        "reverse",
+    )
+
+    def __init__(
+        self,
+        data: str = " ",
+        fg: str = ANSI_FG_DEFAULT,
+        bg: str = ANSI_BG_DEFAULT,
+        bold: bool = False,
+        italics: bool = False,
+        underscore: bool = False,
+        blink: bool = False,
+        strikethrough: bool = False,
+        reverse: bool = False,
+    ) -> None:
+        self.data = data
+        self.fg = fg
+        self.bg = bg
+        self.bold = bold
+        self.italics = italics
+        self.underscore = underscore
+        self.blink = blink
+        self.strikethrough = strikethrough
+        self.reverse = reverse
+
+    def reset(self) -> None:
+        """重置样式属性为默认值，保留 data。"""
+        default = self.__class__()
+        for k in self.__slots__[1:]:
+            setattr(self, k, getattr(default, k))
+
+    def copy(self, **kwargs: object) -> Char:
+        """浅拷贝，可选覆盖部分字段。"""
+        attrs = {k: kwargs.get(k, getattr(self, k)) for k in self.__slots__}
+        return self.__class__(**attrs)  # type: ignore
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Char):
+            return NotImplemented
+        return all(getattr(self, k) == getattr(other, k) for k in self.__slots__)
+
+
+_default_char = Char()
+
+
+class Cursor:
+    """2D 光标，跟踪位置和继承的字符样式。"""
+
+    __slots__ = ("x", "y", "char")
+
+    def __init__(self, x: int = 0, y: int = 0, char: Char | None = None) -> None:
+        if char is None:
+            char = Char()
+        self.x = x
+        self.y = y
+        self.char = char
+
+
+# ==========================================
+# TerminalEmulator
+# ==========================================
+
+
+class TerminalEmulator:
+    """终端模拟器 — 正常终端是将输出写入到tty，这里是将输出写入到事件发射器
+    字符存储在 2D 矩阵中，由光标索引
+
+    支持的 ANSI CSI 序列：
+    - 光标移动：A (上), B (下), C (右), D (左), H/f (定位)
+    - 行擦除：K
+    - 屏幕擦除：J
+    - 插入行：L
+    - 颜色/样式：m (SGR)
+
+    控制字符：
+    - \\r → 归位 (carriage return)
+    - \\n → 换行 (linefeed)
+    - \\b → 退格 (cursor left)
+    """
+
+    _MAX_LINES = 100
+
+    def __init__(self) -> None:
+        self._buffer: defaultdict[int, defaultdict[int, Char]] = defaultdict(lambda: defaultdict(lambda: _default_char))
+        self._cursor = Cursor()
+        self._num_lines_cache: int | None = None
+
+        # Diff 追踪
+        self._prev_num_lines: int = 0
+        self._prev_last_line: str = ""
+        # 已提交的行数（光标已通过 \n 离开的行）
+        # 光标当前所在行是"进行中"的，不算 committed
+        self._committed_lines: int = 0
+
+    # ----------------------------------
+    # 光标操作
+    # ----------------------------------
+
+    def cursor_up(self, n: int = 1) -> None:
+        n = min(n, self._cursor.y)
+        self._cursor.y -= n
+
+    def cursor_down(self, n: int = 1) -> None:
+        self._cursor.y += n
+
+    def cursor_left(self, n: int = 1) -> None:
+        n = min(n, self._cursor.x)
+        self._cursor.x -= n
+
+    def cursor_right(self, n: int = 1) -> None:
+        self._cursor.x += n
+
+    def carriage_return(self) -> None:
+        self._cursor.x = 0
+
+    def cursor_position(self, line: int, column: int) -> None:
+        self._cursor.x = max(column, 1) - 1
+        self._cursor.y = max(line, 1) - 1
+
+    def linefeed(self) -> None:
+        # 当前行已通过 \n 完成，更新 committed 边界
+        self._committed_lines = max(self._committed_lines, self._cursor.y + 1)
+        self.cursor_down()
+        self.carriage_return()
+
+    @cached_property
+    def _cursor_fns(self) -> dict[str, Callable[[int], None]]:
+        return {
+            "A": self.cursor_up,
+            "B": self.cursor_down,
+            "C": self.cursor_right,
+            "D": self.cursor_left,
+        }
+
+    # ----------------------------------
+    # 擦除
+    # ----------------------------------
+
+    def erase_line(self, mode: int = 0) -> None:
+        curr_line = self._buffer[self._cursor.y]
+        if mode == 0:
+            for i in range(self._cursor.x, self._get_line_len(self._cursor.y)):
+                if i in curr_line:
+                    del curr_line[i]
+        elif mode == 1:
+            for i in range(self._cursor.x + 1):
+                if i in curr_line:
+                    del curr_line[i]
+        else:
+            curr_line.clear()
+
+    def erase_screen(self, mode: int = 0) -> None:
+        if mode == 0:
+            for i in range(self._cursor.y + 1, self.num_lines):
+                if i in self._buffer:
+                    del self._buffer[i]
+            self.erase_line(mode)
+        elif mode == 1:
+            for i in range(self._cursor.y):
+                if i in self._buffer:
+                    del self._buffer[i]
+            self.erase_line(mode)
+        elif mode in (2, 3):
+            self._buffer.clear()
+
+    def insert_lines(self, n: int = 1) -> None:
+        for i in range(self.num_lines - 1, self._cursor.y, -1):
+            self._buffer[i + n] = self._buffer[i]
+        for i in range(self._cursor.y + 1, self._cursor.y + 1 + n):
+            if i in self._buffer:
+                del self._buffer[i]
+
+    # ----------------------------------
+    # 写入
+    # ----------------------------------
+
+    def write(self, data: str) -> None:
+        """处理一块终端输出（纯文本 + ANSI 序列）。"""
+        self._num_lines_cache = None
+        data = self._remove_osc(data)
+        prev_end = 0
+        for match in ANSI_CSI_RE.finditer(data):
+            start, end = match.span()
+            text = data[prev_end:start]
+            prev_end = end
+            self._write_text(text)
+            self._handle_csi(*match.groups())
+        self._write_text(data[prev_end:])
+
+    def _handle_csi(self, params: str, command: str) -> None:
+        """分发 CSI 命令。"""
+        # noinspection PyBroadException
+        try:
+            if command == "m":
+                p = params.split(";")[0]
+                if not p:
+                    p = "0"
+                if p in ANSI_FG:
+                    self._cursor.char.fg = p
+                elif p in ANSI_BG:
+                    self._cursor.char.bg = p
+                elif p == ANSI_RESET:
+                    self._cursor.char.reset()
+                elif p in ANSI_STYLES:
+                    style = ANSI_STYLES[p]
+                    off = style.startswith("/")
+                    if off:
+                        style = style[1:]
+                    setattr(self._cursor.char, style, not off)
+            else:
+                cursor_fn = self._cursor_fns.get(command)
+                if cursor_fn:
+                    cursor_fn(int(params) if params else 1)
+                elif command == "J":
+                    p = int(params.split(";")[0]) if params else 0
+                    self.erase_screen(p)
+                elif command == "K":
+                    p = int(params.split(";")[0]) if params else 0
+                    self.erase_line(p)
+                elif command == "L":
+                    p = int(params) if params else 1
+                    self.insert_lines(p)
+                elif command in "Hf":
+                    p = params.split(";")
+                    if len(p) == 2:
+                        self.cursor_position(int(p[0]), int(p[1]))
+                    elif len(p) == 1 and p[0]:
+                        self.cursor_position(int(p[0]), 1)
+                    else:
+                        self.cursor_position(1, 1)
+        except Exception:
+            pass
+
+    def _write_text(self, text: str) -> None:
+        """处理包含 \\r/\\n/\\b 分隔符的文本。"""
+        prev_end = 0
+        for match in SEP_RE.finditer(text):
+            start, end = match.span()
+            self._write_plain_text(text[prev_end:start])
+            prev_end = end
+            c = match.group()
+            if c == "\n":
+                self.linefeed()
+            elif c == "\r":
+                self.carriage_return()
+            elif c == "\b":
+                self.cursor_left()
+            else:
+                continue
+        self._write_plain_text(text[prev_end:])
+
+    def _write_plain_text(self, plain_text: str) -> None:
+        """在当前光标位置写入纯文本。"""
+        self._buffer[self._cursor.y].update(
+            [(self._cursor.x + i, self._cursor.char.copy(data=c)) for i, c in enumerate(plain_text)]
+        )
+        self._cursor.x += len(plain_text)
+
+    @staticmethod
+    def _remove_osc(text: str) -> str:
+        """移除 OSC (Operating System Command) 序列。"""
+        return re.sub(ANSI_OSC_RE, "", text)
+
+    # ----------------------------------
+    # 读取
+    # ----------------------------------
+
+    @property
+    def num_lines(self) -> int:
+        if self._num_lines_cache is not None:
+            return self._num_lines_cache
+        ret = 0
+        if self._buffer:
+            n = max(self._buffer.keys())
+            for i in range(n, -1, -1):
+                if self._get_line_len(i):
+                    ret = i + 1
+                    break
+        self._num_lines_cache = ret
+        return ret
+
+    def _get_line_len(self, n: int) -> int:
+        if n not in self._buffer:
+            return 0
+        line = self._buffer[n]
+        if not line:
+            return 0
+        max_idx = max(line.keys())
+        for i in range(max_idx, -1, -1):
+            if line[i] != _default_char:
+                return i + 1
+        return 0
+
+    def _get_plain_line(self, n: int) -> str:
+        """返回第 n 行的纯文本（ANSI 码已剥离，尾部空白已修剪）。"""
+        if n not in self._buffer:
+            return ""
+        line = self._buffer[n]
+        line_len = self._get_line_len(n)
+        return "".join(line[i].data for i in range(line_len)).rstrip()
+
+    def read(self) -> List[Tuple[str, bool]]:
+        """返回自上次 read() 以来的增量 diff。
+
+        返回 [(line_text, is_new_line), ...] 列表：
+        - is_new_line=True: 已完成的行（光标已通过 \n 离开）
+        - is_new_line=False: 进行中的行（光标还在该行，可能被 \r 覆盖）
+
+        读取后，若总行数超过 _MAX_LINES，自动滚动缓冲区。
+        """
+        num_lines = self.num_lines
+        result: List[Tuple[str, bool]] = []
+
+        # 计算新增的已完成行
+        for i in range(self._prev_num_lines, min(self._committed_lines, num_lines)):
+            line = self._get_plain_line(i)
+            if line:
+                result.append((line, True))
+
+        # 进行中的行（光标当前所在行，可能被 \r 覆盖）
+        # 只有当进行中的行内容发生了变化时才返回
+        if num_lines > self._committed_lines:
+            pending_line = self._get_plain_line(num_lines - 1)
+            if pending_line and pending_line != self._prev_last_line:
+                result.append((pending_line, False))
+
+        # 滚动缓冲区
+        if num_lines > self._MAX_LINES:
+            shift = num_lines - self._MAX_LINES
+            for i in range(shift, num_lines):
+                self._buffer[i - shift] = self._buffer[i]
+            for i in range(self._MAX_LINES, max(self._buffer.keys()) + 1):
+                if i in self._buffer:
+                    del self._buffer[i]
+            self._cursor.y -= min(self._cursor.y, shift)
+            self._committed_lines -= min(self._committed_lines, shift)
+            self._num_lines_cache = self._MAX_LINES
+            num_lines = self._MAX_LINES
+
+        self._prev_num_lines = min(self._committed_lines, num_lines)
+        self._prev_last_line = self._get_plain_line(num_lines - 1) if num_lines > 0 else ""
+        return result

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -18,6 +18,8 @@ from collections import defaultdict
 from functools import cached_property
 from typing import Callable, List, Tuple
 
+from swanlab.sdk.internal.pkg import safe
+
 # ==========================================
 # ANSI 常量
 # ==========================================
@@ -257,9 +259,8 @@ class TerminalEmulator:
         self._write_text(data[prev_end:])
 
     def _handle_csi(self, params: str, command: str) -> None:
-        """分发 CSI 命令。"""
-        # noinspection PyBroadException
-        try:
+        """分发 CSI 命令。单个 CSI 解析异常不影响后续序列处理。"""
+        with safe.block(message="Terminal emulator CSI parse error", write_to_tty=False):
             if command == "m":
                 p = params.split(";")[0]
                 if not p:
@@ -297,8 +298,6 @@ class TerminalEmulator:
                         self.cursor_position(int(p[0]), 1)
                     else:
                         self.cursor_position(1, 1)
-        except Exception:
-            pass
 
     def _write_text(self, text: str) -> None:
         """处理包含 \\r/\\n/\\b 分隔符的文本。"""

--- a/swanlab/sdk/internal/run/components/terminal/emulator.py
+++ b/swanlab/sdk/internal/run/components/terminal/emulator.py
@@ -297,7 +297,7 @@ class TerminalEmulator:
             else:
                 cursor_fn = self._cursor_fns.get(command)
                 if cursor_fn:
-                    cursor_fn(int(params) if params else 1)
+                    cursor_fn(int(params.split(";")[0]) if params else 1)
                 elif command == "J":
                     p = int(params.split(";")[0]) if params else 0
                     self.erase_screen(p)
@@ -305,7 +305,7 @@ class TerminalEmulator:
                     p = int(params.split(";")[0]) if params else 0
                     self.erase_line(p)
                 elif command == "L":
-                    p = int(params) if params else 1
+                    p = int(params.split(";")[0]) if params else 1
                     self.insert_lines(p)
                 elif command in "Hf":
                     p = params.split(";")

--- a/swanlab/sdk/internal/run/system/__init__.py
+++ b/swanlab/sdk/internal/run/system/__init__.py
@@ -3,6 +3,8 @@
 @file: __init__.py.py
 @time: 2026/3/11 17:55
 @description: SwanLab SDK 内部系统组件，如硬件监控、元数据采集、终端日志收集等
+与core设计理念一致，未来作为单独微服务实现
+TODO: 改个名字：probe
 """
 
 import sys

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -732,34 +732,34 @@ class TestInitFactoryDispatch:
 
     def test_disabled_uses_null_emitter(self):
         run = init(mode="disabled")
-        assert isinstance(run._emitter, NullEmitter)
+        assert isinstance(run._components.emitter, NullEmitter)
 
     @pytest.mark.parametrize("mode", ["local", "offline"])
     def test_non_disabled_uses_run_emitter(self, mode):
         run = init(mode=cast(ModeType, mode))
-        assert isinstance(run._emitter, RunEmitter)
+        assert isinstance(run._components.emitter, RunEmitter)
 
     def test_disabled_null_emitter_discards_events(self):
         """NullEmitter.emit() 丢弃事件，队列始终为空"""
         run = init(mode="disabled")
-        run._emitter.emit("test-event")  # type: ignore
-        assert run._emitter.queue.empty()
+        run._components.emitter.emit("test-event")  # type: ignore
+        assert run._components.emitter.queue.empty()
 
     def test_non_disabled_run_emitter_enqueues_events(self):
         """RunEmitter.emit() 将事件放入队列"""
         run = init(mode="local")
-        run._emitter.emit("test-event")  # type: ignore
-        assert not run._emitter.queue.empty()
-        assert run._emitter.queue.get_nowait() == "test-event"
+        run._components.emitter.emit("test-event")  # type: ignore
+        assert not run._components.emitter.queue.empty()
+        assert run._components.emitter.queue.get_nowait() == "test-event"
 
     def test_disabled_uses_null_consumer(self):
         run = init(mode="disabled")
-        assert isinstance(run._consumer, NullConsumer)
+        assert isinstance(run._components.consumer, NullConsumer)
 
     @pytest.mark.parametrize("mode", ["local", "offline"])
     def test_non_disabled_uses_background_consumer(self, mode):
         run = init(mode=cast(ModeType, mode))
-        assert isinstance(run._consumer, BackgroundConsumer)
+        assert isinstance(run._components.consumer, BackgroundConsumer)
 
     def test_disabled_config_is_unbound(self):
         """disabled 模式 Config 不绑定文件，写操作仅内存"""
@@ -779,4 +779,4 @@ class TestInitFactoryDispatch:
 
     def test_disabled_monitor_is_none(self):
         run = init(mode="disabled")
-        assert run._monitor is None
+        assert run._components.monitor is None

--- a/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
+++ b/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
@@ -1,0 +1,575 @@
+"""
+@author: cunyue
+@file: test_emulator.py
+@time: 2026/4/21
+@description: 终端模拟器单元测试
+
+测试策略：
+    - 优先通过公共接口 write() + read() 验证行为
+    - 光标移动等 read() 无法捕获的场景，通过 _get_plain_line / _cursor 辅助验证
+    - 不直接依赖 _buffer / _committed_lines 等内部数据结构
+"""
+
+from __future__ import annotations
+
+from swanlab.sdk.internal.run.components.terminal.emulator import TerminalEmulator
+
+# ==========================================
+# 辅助
+# ==========================================
+
+
+def _feed(em: TerminalEmulator, data: str) -> list[tuple[str, bool]]:
+    """写入数据后立即读取 diff。"""
+    em.write(data)
+    return em.read()
+
+
+def _line(em: TerminalEmulator, n: int) -> str:
+    """获取第 n 行纯文本（辅助验证，非公共 API）。"""
+    return em._get_plain_line(n)
+
+
+# ==========================================
+# 基础写入 & read() 语义
+# ==========================================
+
+
+class TestWriteRead:
+    def test_single_line(self):
+        assert _feed(TerminalEmulator(), "Hello\n") == [("Hello", True)]
+
+    def test_multiple_lines(self):
+        assert _feed(TerminalEmulator(), "A\nB\nC\n") == [
+            ("A", True),
+            ("B", True),
+            ("C", True),
+        ]
+
+    def test_no_trailing_newline_is_pending(self):
+        """没有 \n 的行是进行中（is_new_line=False）。"""
+        assert _feed(TerminalEmulator(), "Hello") == [("Hello", False)]
+
+    def test_empty_lines_skipped(self):
+        """空行不产出。"""
+        assert _feed(TerminalEmulator(), "A\n\nB\n") == [("A", True), ("B", True)]
+
+    def test_empty_write(self):
+        assert _feed(TerminalEmulator(), "") == []
+
+    def test_incremental_read(self):
+        """多次写入 + 读取，diff 互不影响。"""
+        em = TerminalEmulator()
+        assert _feed(em, "A\n") == [("A", True)]
+        assert _feed(em, "B\n") == [("B", True)]
+
+    def test_read_without_write_is_empty(self):
+        em = TerminalEmulator()
+        _feed(em, "A\n")
+        assert em.read() == []
+
+    def test_crlf(self):
+        """Windows 风格 \r\n：\r 回行首，\n 换行。"""
+        assert _feed(TerminalEmulator(), "A\r\nB\r\n") == [("A", True), ("B", True)]
+
+    def test_pending_then_committed(self):
+        """进行中行 → 补 \n → 变为已完成。"""
+        em = TerminalEmulator()
+        assert _feed(em, "A") == [("A", False)]
+        # 补 \n 后 A 从 pending 变为 committed
+        assert _feed(em, "\n") == [("A", True)]
+
+    def test_mixed_committed_and_pending(self):
+        assert _feed(TerminalEmulator(), "A\nB\nC") == [
+            ("A", True),
+            ("B", True),
+            ("C", False),
+        ]
+
+    def test_long_line(self):
+        """超长单行（无 \n）仍然正确。"""
+        text = "X" * 10000
+        assert _feed(TerminalEmulator(), text) == [(text, False)]
+
+    def test_unicode(self):
+        """中文 / emoji 不影响行分割。"""
+        assert _feed(TerminalEmulator(), "你好\n🌍\n") == [
+            ("你好", True),
+            ("🌍", True),
+        ]
+
+
+# ==========================================
+# \r — 回车
+# ==========================================
+
+
+class TestCarriageReturn:
+    def test_overwrite_prefix(self):
+        """\r 回行首后覆盖前缀，尾部保留。"""
+        assert _feed(TerminalEmulator(), "abcdef\rxy\n") == [("xycdef", True)]
+
+    def test_full_overwrite(self):
+        """\r 回行首后覆盖整行。"""
+        assert _feed(TerminalEmulator(), "abc\rxyz\n") == [("xyz", True)]
+
+    def test_r_then_newline(self):
+        assert _feed(TerminalEmulator(), "foo\rbar\n") == [("bar", True)]
+
+    def test_consecutive_cr(self):
+        """连续多次 \r 不带内容，再写入。"""
+        assert _feed(TerminalEmulator(), "foo\r\r\rbar\n") == [("bar", True)]
+
+    def test_cr_clear_then_newline(self):
+        """\r + 擦除 + \n → 空行不产出。"""
+        em = TerminalEmulator()
+        em.write("some text\r\033[K\n")
+        # \r 回行首，\033[K 擦除到行尾，\n 换行 → 空行被跳过
+        assert em.read() == []
+
+    def test_cr_without_overwrite_keeps_tail(self):
+        """\r 回行首，写入更短内容，原尾部保留。"""
+        assert _feed(TerminalEmulator(), "abcdef\rxy\n") == [("xycdef", True)]
+
+
+# ==========================================
+# \b — 退格
+# ==========================================
+
+
+class TestBackspace:
+    def test_overwrite_previous_char(self):
+        assert _feed(TerminalEmulator(), "abc\bX\n") == [("abX", True)]
+
+    def test_at_line_start_noop(self):
+        """行首退格不移动光标。"""
+        assert _feed(TerminalEmulator(), "\bA\n") == [("A", True)]
+
+    def test_multiple_backspace(self):
+        assert _feed(TerminalEmulator(), "abcde\b\bXY\n") == [("abcXY", True)]
+
+    def test_excessive_backspace_clamped(self):
+        """退格超过行首被钳制，多余退格无效。"""
+        em = TerminalEmulator()
+        em.write("AB\b\b\b\bX\n")
+        # AB 后光标在 x=2，退格到 x=0，后续退格无效 → X 覆盖 A → XB
+        assert em.read() == [("XB", True)]
+
+
+# ==========================================
+# CSI 光标移动
+# ==========================================
+
+
+class TestCursorMovement:
+    def test_cursor_up(self):
+        """CSI A — 光标上移后写入。"""
+        em = TerminalEmulator()
+        em.write("Line1\nLine2\n")
+        em.read()
+        # 光标在 y=2,x=0（linefeed 后），上移1行到 y=1,x=0
+        em.write("\033[A**")
+        # 在 Line2 行首覆盖写入 ** → **ne2
+        assert _line(em, 1) == "**ne2"
+
+    def test_cursor_up_n(self):
+        """CSI nA — 上移 n 行。"""
+        em = TerminalEmulator()
+        em.write("A\nB\nC\n")
+        em.read()
+        # 光标在 y=3,x=0，上移2行到 y=1,x=0
+        em.write("\033[2A*")
+        assert em._cursor.y == 1
+        # x=0 处写入 *，覆盖 B → "*"
+        assert _line(em, 1) == "*"
+
+    def test_cursor_up_clamped_at_top(self):
+        """上移不超过第 0 行。"""
+        em = TerminalEmulator()
+        em.write("A\nB\n")
+        em.read()
+        em.write("\033[99A*")
+        assert em._cursor.y == 0
+
+    def test_cursor_down(self):
+        """CSI B — 光标下移，x 保持不变。"""
+        em = TerminalEmulator()
+        em.write("AB")
+        em.read()
+        # cursor at (0, 2)，下移后写入
+        em.write("\033[BX\n")
+        assert _line(em, 1) == "  X"  # x=2 位置写入 X
+
+    def test_cursor_right(self):
+        """CSI C — 光标右移跳过字符。"""
+        assert _feed(TerminalEmulator(), "AB\033[2CX\n") == [("AB  X", True)]
+
+    def test_cursor_left(self):
+        """CSI D — 光标左移后覆盖。"""
+        assert _feed(TerminalEmulator(), "ABCDE\033[2DXY\n") == [("ABCXY", True)]
+
+    def test_cursor_left_default_one(self):
+        """CSI D 无参数默认左移 1 格。"""
+        assert _feed(TerminalEmulator(), "AB\033[DX\n") == [("AX", True)]
+
+    def test_cursor_left_clamped(self):
+        """左移不超过行首。"""
+        assert _feed(TerminalEmulator(), "\033[99DX\n") == [("X", True)]
+
+
+# ==========================================
+# CSI H/f — 光标定位
+# ==========================================
+
+
+class TestCursorPosition:
+    def test_row_and_column(self):
+        """CSI row;colH 定位。"""
+        em = TerminalEmulator()
+        em.write("\033[2;5H*")
+        assert em._cursor.y == 1
+        assert em._cursor.x == 5
+
+    def test_row_only(self):
+        """CSI rowH — 列默认 1。"""
+        em = TerminalEmulator()
+        em.write("\033[3H*")
+        assert em._cursor.y == 2
+        assert em._cursor.x == 1
+
+    def test_home(self):
+        """CSI H — 无参数回到 (1,1)。"""
+        em = TerminalEmulator()
+        em.write("Some text\033[H*")
+        assert em._cursor.y == 0
+        assert em._cursor.x == 1
+
+    def test_f_equals_h(self):
+        """CSI f 等同于 CSI H。"""
+        em = TerminalEmulator()
+        em.write("\033[2;3f*")
+        assert em._cursor.y == 1
+        assert em._cursor.x == 3
+
+    def test_zero_params_clamped_to_one(self):
+        """参数 0 被钳制为 1。"""
+        em = TerminalEmulator()
+        em.write("\033[0;0H*")
+        assert em._cursor.y == 0
+        assert em._cursor.x == 1
+
+
+# ==========================================
+# CSI K — 行擦除
+# ==========================================
+
+
+class TestEraseLine:
+    def test_erase_to_end_default(self):
+        """CSI K 默认 mode=0：擦除光标到行尾。"""
+        em = TerminalEmulator()
+        em.write("ABCDE\033[2D\033[K\n")
+        # 光标左移2格到位置3(C处)，\033[K 擦除位置3~行尾 → 保留 ABC
+        assert em.read() == [("ABC", True)]
+
+    def test_erase_to_end_explicit(self):
+        """CSI 0K 显式 mode=0。"""
+        em = TerminalEmulator()
+        em.write("ABCDE\033[2D\033[0K\n")
+        assert em.read() == [("ABC", True)]
+
+    def test_erase_from_start(self):
+        """CSI 1K — 擦除行首到光标（含光标位）。"""
+        em = TerminalEmulator()
+        em.write("ABCDE\033[2D\033[1K\n")
+        # 光标在位置 3，擦除 0~3(含) → 保留位置 4 的 E，前导空格
+        assert em.read() == [("    E", True)]
+
+    def test_erase_full_line(self):
+        """CSI 2K — 擦除整行。"""
+        em = TerminalEmulator()
+        em.write("ABCDE\033[2K\n")
+        assert em.read() == []
+
+
+# ==========================================
+# CSI J — 屏幕擦除
+# ==========================================
+
+
+class TestEraseScreen:
+    def test_erase_below(self):
+        """CSI 0J — 擦除光标下方。"""
+        em = TerminalEmulator()
+        em.write("A\nB\nC\n")
+        em.read()
+        em.write("\033[2A\033[J")
+        # 光标移到 y=1，擦除 y=1 之后 → C 被清除
+        assert _line(em, 0) == "A"
+        assert _line(em, 2) == ""
+
+    def test_erase_above(self):
+        """CSI 1J — 擦除光标上方。"""
+        em = TerminalEmulator()
+        em.write("A\nB\nC\n")
+        em.read()
+        em.write("\033[1J")
+        # 光标在 y=3，擦除 y=0~2
+        assert _line(em, 0) == ""
+
+    def test_erase_all(self):
+        """CSI 2J — 擦除全部。"""
+        em = TerminalEmulator()
+        em.write("A\nB\nC\n")
+        em.read()
+        em.write("\033[2J")
+        assert em.num_lines == 0
+
+
+# ==========================================
+# CSI L — 插入行
+# ==========================================
+
+
+class TestInsertLines:
+    def test_insert_pushes_content_down(self):
+        """CSI L — 插入空行，下方内容下推。"""
+        em = TerminalEmulator()
+        em.write("A\nB\nC\n")
+        em.read()
+        # 光标在 y=3，上移到 y=1
+        em.write("\033[2A")
+        assert em._cursor.y == 1
+        em.write("\033[L")
+        # y=1 内容保留(B)，y=2 被清空，原 C 推到 y=3
+        assert _line(em, 1) == "B"
+        assert _line(em, 2) == ""
+        assert _line(em, 3) == "C"
+
+    def test_insert_multiple(self):
+        """CSI nL — 插入多行。"""
+        em = TerminalEmulator()
+        em.write("A\nB\nC\n")
+        em.read()
+        em.write("\033[3A")  # 上移到 y=0
+        em.write("\033[2L")
+        # y=0 内容保留(A)，y=1~2 清空，原 B/C 推到 y=3~4
+        assert _line(em, 0) == "A"
+        assert _line(em, 1) == ""
+        assert _line(em, 2) == ""
+        assert _line(em, 3) == "B"
+        assert _line(em, 4) == "C"
+
+
+# ==========================================
+# CSI m — 颜色/样式（SGR）
+# ==========================================
+
+
+class TestSGR:
+    def test_foreground_color_ignored_in_plain_text(self):
+        """read() 返回纯文本，颜色信息不影响。"""
+        assert _feed(TerminalEmulator(), "\033[31mRed\033[0m\n") == [("Red", True)]
+
+    def test_bold_ignored_in_plain_text(self):
+        assert _feed(TerminalEmulator(), "\033[1mBold\033[0m\n") == [("Bold", True)]
+
+    def test_reset(self):
+        assert _feed(TerminalEmulator(), "\033[1;31mX\033[0mY\n") == [("XY", True)]
+
+    def test_no_params_defaults_to_reset(self):
+        assert _feed(TerminalEmulator(), "\033[1mX\033[mY\n") == [("XY", True)]
+
+    def test_sgr_does_not_break_line_splitting(self):
+        """样式切换不会打断行内容。"""
+        assert _feed(TerminalEmulator(), "\033[31mA\033[32mB\n") == [("AB", True)]
+
+
+# ==========================================
+# OSC 移除
+# ==========================================
+
+
+class TestOSCRemoval:
+    def test_osc_stripped(self):
+        assert _feed(TerminalEmulator(), "\033]0;title\007Hello\n") == [("Hello", True)]
+
+    def test_osc_in_middle(self):
+        assert _feed(TerminalEmulator(), "A\033]0;x\007B\n") == [("AB", True)]
+
+    def test_multiple_osc(self):
+        assert _feed(TerminalEmulator(), "\033]0;a\007X\033]1;b\007Y\n") == [("XY", True)]
+
+
+# ==========================================
+# 进度条场景（tqdm 风格）— 核心业务场景
+# ==========================================
+
+
+class TestProgressBar:
+    def test_r_overwrite_progress_bar(self):
+        """\r 反复覆盖，只有最终 \n 的行被 committed。"""
+        em = TerminalEmulator()
+        em.write("Epoch 1/10\r")
+        assert em.read() == [("Epoch 1/10", False)]
+
+        em.write("Epoch 2/10\r")
+        assert em.read() == [("Epoch 2/10", False)]
+
+        em.write("Epoch 3/10\n")
+        assert em.read() == [("Epoch 3/10", True)]
+
+    def test_tqdm_style_full_cycle(self):
+        """完整 tqdm 周期：多次 \r 更新 → 最终 \n。"""
+        em = TerminalEmulator()
+        em.write("  0%|          | 0/100 it/s\r")
+        r1 = em.read()
+        assert all(not is_new for _, is_new in r1)
+
+        em.write("100%|##########| 100/100 done\n")
+        r2 = em.read()
+        assert all(is_new for _, is_new in r2)
+        assert r2 == [("100%|##########| 100/100 done", True)]
+
+    def test_progress_bar_then_print(self):
+        """进度条完成后紧接 print 输出。"""
+        em = TerminalEmulator()
+        em.write("Training started\n")
+        assert em.read() == [("Training started", True)]
+
+        em.write("  0%|  | 0/10\r")
+        em.read()
+
+        em.write("100%|##| 10/10\n")
+        assert em.read() == [("100%|##| 10/10", True)]
+
+    def test_identical_pending_not_reduplicated(self):
+        """连续写入相同的进行中行，不重复返回。"""
+        em = TerminalEmulator()
+        em.write("same\r")
+        assert em.read() == [("same", False)]
+
+        em.write("same\r")
+        assert em.read() == []
+
+    def test_pending_cleared_to_empty(self):
+        """进行中行被 \r + 擦除清空后换行 → 空行不产出。"""
+        em = TerminalEmulator()
+        em.write("some text\r")
+        em.read()
+
+        em.write("\033[K\n")
+        # 空行被跳过
+        assert em.read() == []
+
+    def test_flush_skips_pending_lines(self):
+        """_flush 场景：只有 is_new_line=True 的行被发射。"""
+        em = TerminalEmulator()
+        em.write("pending line\r")
+        diff = em.read()
+        assert [t for t, is_new in diff if is_new] == []
+        assert [t for t, is_new in diff if not is_new] == ["pending line"]
+
+        em.write("committed line\n")
+        diff = em.read()
+        assert [t for t, is_new in diff if is_new] == ["committed line"]
+
+
+# ==========================================
+# 缓冲区滚动
+# ==========================================
+
+
+class TestScrollBuffer:
+    def test_overflow_truncates_oldest(self):
+        em = TerminalEmulator()
+        for i in range(em._MAX_LINES + 10):
+            em.write(f"Line {i}\n")
+        em.read()
+        assert em.num_lines <= em._MAX_LINES
+
+    def test_preserves_recent_lines(self):
+        em = TerminalEmulator()
+        total = em._MAX_LINES + 5
+        for i in range(total):
+            em.write(f"Line {i}\n")
+        em.read()
+        assert _line(em, em.num_lines - 1) == f"Line {total - 1}"
+
+    def test_cursor_adjusted_after_scroll(self):
+        em = TerminalEmulator()
+        for i in range(em._MAX_LINES + 10):
+            em.write(f"Line {i}\n")
+        em.read()
+        assert em._cursor.y >= 0
+
+
+# ==========================================
+# 边界 & 异常
+# ==========================================
+
+
+class TestEdgeCases:
+    def test_malformed_csi_no_crash(self):
+        """损坏的 CSI 序列不应崩溃，最终正常文本仍能产出。"""
+        em = TerminalEmulator()
+        em.write("\033[99999m")  # 超大参数 → try/except 静默跳过
+        em.write("ok\n")
+        result = em.read()
+        # ok 被正确产出
+        assert ("ok", True) in result
+
+    def test_null_byte(self):
+        """空字节不崩溃。"""
+        em = TerminalEmulator()
+        em.write("A\x00B\n")
+        # \x00 被 SEP_RE 匹配为控制字符，被 skip
+        result = em.read()
+        assert len(result) > 0
+
+    def test_only_control_chars(self):
+        """纯控制字符输入。"""
+        em = TerminalEmulator()
+        em.write("\r\n\r\n")
+        assert em.read() == []
+
+    def test_consecutive_newlines(self):
+        em = TerminalEmulator()
+        em.write("\n\n\n")
+        assert em.read() == []
+
+    def test_large_write(self):
+        """大批量写入不崩溃。"""
+        em = TerminalEmulator()
+        for i in range(200):
+            em.write(f"Line {i}\n")
+        result = em.read()
+        assert len(result) > 0
+
+    def test_unicode_with_ansi(self):
+        """中文 + ANSI 颜色。"""
+        assert _feed(TerminalEmulator(), "\033[31m你好\033[0m\n") == [("你好", True)]
+
+
+# ==========================================
+# 组合场景
+# ==========================================
+
+
+class TestCombinations:
+    def test_color_then_overwrite(self):
+        assert _feed(TerminalEmulator(), "\033[31mRed\033[0m\rGreen\n") == [("Green", True)]
+
+    def test_mixed_control_chars(self):
+        """\b + \r 组合。"""
+        assert _feed(TerminalEmulator(), "ABC\bD\rEF\n") == [("EFD", True)]
+
+    def test_write_after_clear(self):
+        """擦除屏幕后继续写入。"""
+        em = TerminalEmulator()
+        em.write("A\nB\n")
+        em.read()
+        em.write("\033[2J")
+        assert em.num_lines == 0
+        em.write("New\n")
+        assert em.read() == [("New", True)]

--- a/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
+++ b/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
@@ -320,10 +320,14 @@ class TestEraseScreen:
         """CSI 2J — 擦除全部。"""
         em = TerminalEmulator()
         em.write("A\nB\nC\n")
+        assert em.num_lines == 4  # A, B, C + 空行
         em.read()
         em.write("\033[2J")
-        # buffer 已清，但 committed_lines 仍为 3
-        assert em.num_lines == 3
+        # buffer 已清，但是历史行数还是4行
+        assert em.num_lines == 4
+        em.write("D")
+        assert em.num_lines == 4
+        assert em.read() == [("D", False)]
 
 
 # ==========================================
@@ -417,7 +421,7 @@ class TestProgressBar:
         assert em.read() == [("Epoch 2/10", False)]
 
         em.write("Epoch 3/10\n")
-        assert em.read() == [("Epoch 3/10", True)]
+        assert em.read() == [("Epoch 3/10", True), ("", False)]
 
     def test_tqdm_style_full_cycle(self):
         """完整 tqdm 周期：多次 \r 更新 → 最终 \n。"""
@@ -428,8 +432,8 @@ class TestProgressBar:
 
         em.write("100%|##########| 100/100 done\n")
         r2 = em.read()
-        assert all(is_new for _, is_new in r2)
-        assert r2 == [("100%|##########| 100/100 done", True)]
+        assert all(is_new for _, is_new in r2[:-1])  # 最后一行永远是空行
+        assert r2[0] == ("100%|##########| 100/100 done", True)
 
     def test_progress_bar_then_print(self):
         """进度条完成后紧接 print 输出。"""
@@ -441,7 +445,8 @@ class TestProgressBar:
         em.read()
 
         em.write("100%|##| 10/10\n")
-        assert em.read() == [("100%|##| 10/10", True)]
+        result = em.read()
+        assert result[0] == ("100%|##| 10/10", True)
 
     def test_identical_pending_not_reduplicated(self):
         """连续写入相同的进行中行，不重复返回。"""
@@ -453,14 +458,14 @@ class TestProgressBar:
         assert em.read() == []
 
     def test_pending_cleared_to_empty(self):
-        """进行中行被 \r + 擦除清空后换行 → 空行不产出。"""
+        """进行中行被 \r + 擦除清空后换行 → 空行 committed。"""
         em = TerminalEmulator()
         em.write("some text\r")
         em.read()
 
         em.write("\033[K\n")
-        # 空行被跳过
-        assert em.read() == []
+        # 空行 committed + 新空行 pending
+        assert em.read() == [("", True), ("", False)]
 
     def test_flush_skips_pending_lines(self):
         """_flush 场景：只有 is_new_line=True 的行被发射。"""
@@ -494,7 +499,8 @@ class TestScrollBuffer:
         for i in range(total):
             em.write(f"Line {i}\n")
         em.read()
-        assert _line(em, em.num_lines - 1) == f"Line {total - 1}"
+        # 滚动后最后一行有内容（可能不是最后一行，因为空行也在）
+        assert _line(em, em.num_lines - 2) == f"Line {total - 1}"
 
     def test_cursor_adjusted_after_scroll(self):
         em = TerminalEmulator()
@@ -531,12 +537,17 @@ class TestEdgeCases:
         """纯控制字符输入。"""
         em = TerminalEmulator()
         em.write("\r\n\r\n")
-        assert em.read() == []
+        # 两次 \r\n 产生两个空行 committed + 一个空行 pending
+        result = em.read()
+        assert all(line == "" for line, _ in result)
 
     def test_consecutive_newlines(self):
         em = TerminalEmulator()
         em.write("\n\n\n")
-        assert em.read() == []
+        # 3个 \n 产生3个空行 committed + 1个空行 pending
+        result = em.read()
+        assert all(line == "" for line, _ in result)
+        assert sum(1 for _, is_new in result if is_new) == 3
 
     def test_large_write(self):
         """大批量写入不崩溃。"""
@@ -570,9 +581,11 @@ class TestCombinations:
         em.write("A\nB\n")
         em.read()
         em.write("\033[2J")
-        assert em.num_lines == 2  # committed_lines 仍在，buffer 已清
+        assert em.num_lines == 3  # A, B + 空行(cursor)
         em.write("New\n")
-        assert em.read() == [("New", True)]
+        # 清屏后写 New，New 在新行 committed
+        result = em.read()
+        assert ("New", True) in result
 
 
 class TestFinalize:

--- a/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
+++ b/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
@@ -27,7 +27,7 @@ def _feed(em: TerminalEmulator, data: str) -> list[tuple[str, bool]]:
 
 def _line(em: TerminalEmulator, n: int) -> str:
     """获取第 n 行纯文本（辅助验证，非公共 API）。"""
-    return em._get_plain_line(n)
+    return em._get_plain_line(n)  # noqa
 
 
 # ==========================================
@@ -77,7 +77,7 @@ class TestWriteRead:
         em = TerminalEmulator()
         assert _feed(em, "A") == [("A", False)]
         # 补 \n 后 A 从 pending 变为 committed
-        assert _feed(em, "\n") == [("A", True)]
+        assert _feed(em, "\n") == [("A", True), ("", False)]
 
     def test_mixed_committed_and_pending(self):
         assert _feed(TerminalEmulator(), "A\nB\nC") == [
@@ -121,11 +121,10 @@ class TestCarriageReturn:
         assert _feed(TerminalEmulator(), "foo\r\r\rbar\n") == [("bar", True)]
 
     def test_cr_clear_then_newline(self):
-        """\r + 擦除 + \n → 空行不产出。"""
+        """\r + 擦除 + \n → 空行 committed。"""
         em = TerminalEmulator()
         em.write("some text\r\033[K\n")
-        # \r 回行首，\033[K 擦除到行尾，\n 换行 → 空行被跳过
-        assert em.read() == []
+        assert em.read() == [("", True)]
 
     def test_cr_without_overwrite_keeps_tail(self):
         """\r 回行首，写入更短内容，原尾部保留。"""
@@ -289,7 +288,7 @@ class TestEraseLine:
         """CSI 2K — 擦除整行。"""
         em = TerminalEmulator()
         em.write("ABCDE\033[2K\n")
-        assert em.read() == []
+        assert em.read() == [("", True)]
 
 
 # ==========================================
@@ -323,7 +322,8 @@ class TestEraseScreen:
         em.write("A\nB\nC\n")
         em.read()
         em.write("\033[2J")
-        assert em.num_lines == 0
+        # buffer 已清，但 committed_lines 仍为 3
+        assert em.num_lines == 3
 
 
 # ==========================================
@@ -570,7 +570,7 @@ class TestCombinations:
         em.write("A\nB\n")
         em.read()
         em.write("\033[2J")
-        assert em.num_lines == 0
+        assert em.num_lines == 2  # committed_lines 仍在，buffer 已清
         em.write("New\n")
         assert em.read() == [("New", True)]
 
@@ -585,9 +585,15 @@ class TestFinalize:
         assert em.read() == [("pending line", True)]
 
     def test_only_pending_emitted(self):
-        """finalize 只发射 pending 行，已 committed 的不重复。"""
+        """finalize 只发射有内容的 pending 行，忽略尾部空行。"""
         em = TerminalEmulator()
         em.write("line1\nline2\npending")
         assert em.read() == [("line1", True), ("line2", True), ("pending", False)]
         em.finalize()
         assert em.read() == [("pending", True)]
+        # 尾部空行场景
+        em2 = TerminalEmulator()
+        em2.write("A\nB\n\nC")
+        em2.read()
+        em2.finalize()
+        assert em2.read() == [("C", True)]

--- a/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
+++ b/tests/unit/sdk/internal/run/components/terminal/test_emulator.py
@@ -50,9 +50,9 @@ class TestWriteRead:
         """没有 \n 的行是进行中（is_new_line=False）。"""
         assert _feed(TerminalEmulator(), "Hello") == [("Hello", False)]
 
-    def test_empty_lines_skipped(self):
-        """空行不产出。"""
-        assert _feed(TerminalEmulator(), "A\n\nB\n") == [("A", True), ("B", True)]
+    def test_empty_lines_preserved(self):
+        """空行保留，不跳过。"""
+        assert _feed(TerminalEmulator(), "A\n\nB\n") == [("A", True), ("", True), ("B", True)]
 
     def test_empty_write(self):
         assert _feed(TerminalEmulator(), "") == []
@@ -573,3 +573,21 @@ class TestCombinations:
         assert em.num_lines == 0
         em.write("New\n")
         assert em.read() == [("New", True)]
+
+
+class TestFinalize:
+    def test_pending_to_committed(self):
+        """finalize 将 pending 行变为 committed。"""
+        em = TerminalEmulator()
+        em.write("pending line")
+        assert em.read() == [("pending line", False)]
+        em.finalize()
+        assert em.read() == [("pending line", True)]
+
+    def test_only_pending_emitted(self):
+        """finalize 只发射 pending 行，已 committed 的不重复。"""
+        em = TerminalEmulator()
+        em.write("line1\nline2\npending")
+        assert em.read() == [("line1", True), ("line2", True), ("pending", False)]
+        em.finalize()
+        assert em.read() == [("pending", True)]


### PR DESCRIPTION
重新实现了 SwanLab 终端代理，现在的策略是实现一个终端模拟器（缓冲区），在写入后在其他线程立即解析一次终端代理日志，然后发送事件。

> 这样的好处是对进度条有个比较完备的支持。

为了避免极端情况下“代理捕捉---> 出现错误、打印终端 ---> 代理捕捉 ---> 出现错误、打印终端”的死循环，这里对于with safe.block 改进为可选打印tty，在当前场景下，仅输出错误到日志文件。

---

此外，除了系统信息采集和core，其余组件全部视为python原生组件，以Components包裹