### PR TITLE
fix: remove incorrect Python 3.8 classifier inconsistent with requires-python>=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
## Summary

The `pyproject.toml` file has a contradiction:

- `requires-python = ">=3.9"` — Python 3.8 is **not supported**
- Yet classifiers include `'Programming Language :: Python :: 3.8'`

This is misleading to users and package index tools like PyPI, since it incorrectly advertises Python 3.8 compatibility.

## Change

Removes the `'Programming Language :: Python :: 3.8'` classifier entry to align with the actual minimum Python version requirement (`>=3.9`).

Closes #1564

## Checklist
- [x] Fix is minimal and targeted
- [x] No functional code changes, only metadata correction

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>