### PR TITLE
Fix/transport

### DIFF
--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -162,7 +162,9 @@ class UploadWarningThrottle:
     INTERVAL: float = 30.0
 
     def __init__(self) -> None:
-        self._last_warn_at: float = 0.0
+        # 用 -INTERVAL 而非 0.0，确保 time.monotonic() 返回值小于 INTERVAL 时
+        # （如 CI 容器刚启动）仍能首次触发 warn()
+        self._last_warn_at: float = -self.INTERVAL
         self._in_failure: bool = False
 
     def warn(self, message: str = "Upload failed due to network or server issues, retrying automatically.") -> None:
@@ -175,7 +177,8 @@ class UploadWarningThrottle:
     def reset(self, message: str = "Upload recovered, resuming normally.") -> None:
         if self._in_failure:
             console.info(message)
-        self._last_warn_at = 0.0
+        # 同 __init__，用 -INTERVAL 保证 reset 后下次 warn() 立刻触发
+        self._last_warn_at = -self.INTERVAL
         self._in_failure = False
 
 

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -26,7 +26,7 @@ class Transport:
     - 清空 buffer 后在锁外委托 Dispatch，不阻塞生产者
     """
 
-    BATCH_INTERVAL: float = 1.0
+    BATCH_INTERVAL: float = 5.0
     FINISH_JOIN_TIMEOUT: int = 30
     THREAD_NAME: str = "SwanLab·Transport"
 
@@ -73,8 +73,7 @@ class Transport:
         if not records:
             return
         with self._cond:
-            if self._buf.extend(records) > 0:
-                self._cond.notify()
+            self._buf.extend(records)
 
     def finish(self) -> None:
         """

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -19,11 +19,12 @@ from .sender import HttpRecordSender
 
 class Transport:
     """
-    事件驱动的 Record Action 线程。
+    定时攒批的 Record Action 线程。
 
     用 Condition 驱动上传事件：
-    - put() 时 notify() 立刻唤醒线程，延迟接近 0
-    - wait(timeout=batch_interval) 保证最大攒批间隔
+    - put() 仅写入 buffer，不唤醒线程
+    - wait(timeout=batch_interval) 周期性唤醒线程，攒批后统一 drain
+    - finish() 时 notify_all() 立刻唤醒线程排空剩余 buffer
     - 清空 buffer 后在锁外委托 Dispatch，不阻塞生产者
     """
 
@@ -68,7 +69,7 @@ class Transport:
         self._started = True
 
     def put(self, records: List[Record]) -> None:
-        """追加 records 到 buffer 并唤醒线程。"""
+        """追加 records 到 buffer，等待下次 batch_interval 唤醒时统一处理。"""
         if self._finished:
             console.warning("Transport has already been finished.")
             return

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -6,6 +6,7 @@
 """
 
 import threading
+import time
 from typing import Callable, List, Optional
 
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
@@ -46,6 +47,7 @@ class Transport:
         self._started = False
         self._thread: Optional[threading.Thread] = None
         self._sender_closed = False
+        self._throttle = UploadWarningThrottle()
 
         # Transport 持有 sender，负责创建/注入/关闭
         self._sender = sender if sender is not None else HttpRecordSender()
@@ -116,7 +118,6 @@ class Transport:
 
     def _loop(self) -> None:
         pending: List[Record] = []
-        network_warning_emitted = False
         try:
             while True:
                 with self._cond:
@@ -139,7 +140,7 @@ class Transport:
 
                 if is_success:
                     pending = []
-                    network_warning_emitted = False
+                    self._throttle.reset()
                     with self._cond:
                         if self._buf:
                             pending = self._buf.drain()
@@ -147,14 +148,35 @@ class Transport:
                             return
                 else:
                     pending = retry_records
-                    if not network_warning_emitted:
-                        console.warning("Upload failed, network seems unavailable.")
-                        network_warning_emitted = True
+                    self._throttle.warn()
                     with self._cond:
                         # 失败后退避等待；notify()/notify_all() 可提前唤醒，但不会丢掉 pending。
                         self._cond.wait(timeout=self._batch_interval)
         finally:
             self._close_sender()
+
+
+class UploadWarningThrottle:
+    """控制上传失败警告的打印频率，成功后重置并提示恢复。"""
+
+    INTERVAL: float = 30.0
+
+    def __init__(self) -> None:
+        self._last_warn_at: float = 0.0
+        self._in_failure: bool = False
+
+    def warn(self, message: str = "Upload failed due to network or server issues, retrying automatically.") -> None:
+        self._in_failure = True
+        now = time.monotonic()
+        if now - self._last_warn_at >= self.INTERVAL:
+            console.warning(message)
+            self._last_warn_at = now
+
+    def reset(self, message: str = "Upload recovered, resuming normally.") -> None:
+        if self._in_failure:
+            console.info(message)
+        self._last_warn_at = 0.0
+        self._in_failure = False
 
 
 __all__ = [

--- a/tests/unit/sdk/internal/core_python/transport/test_throttle.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_throttle.py
@@ -1,0 +1,42 @@
+import time
+from unittest.mock import patch
+
+from swanlab.sdk.internal.core_python.transport.thread import UploadWarningThrottle
+
+
+def test_warn_throttles_within_interval():
+    """间隔内重复 warn() 不重复打印，超过间隔后再次打印。"""
+    t = UploadWarningThrottle()
+    t.INTERVAL = 0.01
+    with patch("swanlab.sdk.internal.core_python.transport.thread.console.warning") as mock:
+        t.warn()
+        t.warn()
+    mock.assert_called_once()
+
+    time.sleep(0.02)
+    with patch("swanlab.sdk.internal.core_python.transport.thread.console.warning") as mock:
+        t.warn()
+    mock.assert_called_once()
+
+
+def test_reset_clears_throttle_and_prints_recovery():
+    """失败状态下 reset() 打印恢复消息，之后 warn() 不再被节流。"""
+    t = UploadWarningThrottle()
+    with patch("swanlab.sdk.internal.core_python.transport.thread.console.warning"):
+        t.warn()
+
+    with patch("swanlab.sdk.internal.core_python.transport.thread.console.info") as mock_info:
+        t.reset()
+    mock_info.assert_called_once()
+
+    with patch("swanlab.sdk.internal.core_python.transport.thread.console.warning") as mock_warn:
+        t.warn()
+    mock_warn.assert_called_once()
+
+
+def test_reset_without_failure_no_recovery():
+    """未进入失败状态时 reset() 不打印恢复消息。"""
+    t = UploadWarningThrottle()
+    with patch("swanlab.sdk.internal.core_python.transport.thread.console.info") as mock_info:
+        t.reset()
+    mock_info.assert_not_called()

--- a/tests/unit/sdk/internal/core_python/transport/test_transport.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_transport.py
@@ -8,10 +8,10 @@ from swanlab.sdk.internal.core_python.transport.thread import Transport
 
 
 def test_transport_defaults():
-    """默认 batch_interval = 1.0。"""
+    """默认 batch_interval = 5.0。"""
     t = Transport(auto_start=False)
     assert t._batch_interval == Transport.BATCH_INTERVAL
-    assert t._batch_interval == 1.0
+    assert t._batch_interval == 5.0
 
 
 def test_transport_custom_batch_interval():

--- a/tests/unit/sdk/internal/core_python/transport/test_transport.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_transport.py
@@ -122,7 +122,7 @@ def test_transport_finish_drains_remaining(make_scalar_record):
             dispatched.extend(records)
             return True, []
 
-    t = Transport(auto_start=False)
+    t = Transport(batch_interval=0.01, auto_start=False)
     t._dispatcher = FakeDispatch()  # type: ignore
     t.start()
     records = [make_scalar_record(step=1), make_scalar_record(step=2)]
@@ -146,11 +146,11 @@ def test_transport_finish_does_not_close_sender_before_thread_stops():
     sender.close.assert_not_called()
 
 
-# ─────────────────── 事件驱动 ───────────────────
+# ─────────────────── 定时攒批 ───────────────────
 
 
-def test_transport_put_wakes_thread_immediately(make_scalar_record):
-    """put() 后线程立刻唤醒，不等 timeout。"""
+def test_transport_drains_on_batch_interval(make_scalar_record):
+    """put() 后线程在 batch_interval 超时后自动 drain 并 dispatch。"""
     dispatched = []
     event = threading.Event()
 
@@ -160,14 +160,13 @@ def test_transport_put_wakes_thread_immediately(make_scalar_record):
             event.set()
             return True, []
 
-    t = Transport(batch_interval=10.0, auto_start=False)
+    t = Transport(batch_interval=0.01, auto_start=False)
     t._dispatcher = FakeDispatch()  # type: ignore
     t.start()
     record = make_scalar_record(step=1)
     record.num = 1
     t.put([record])
-    # batch_interval=10 但 put 应立刻唤醒，0.5s 足够验证
-    event.wait(timeout=2.0)
+    assert event.wait(timeout=2.0)
     t.finish()
     assert len(dispatched) == 1
 
@@ -186,12 +185,12 @@ def test_transport_integration_auto_start(make_scalar_record):
             event.set()
             return True, []
 
-    t = Transport(auto_start=True)
+    t = Transport(batch_interval=0.01, auto_start=True)
     t._dispatcher = FakeDispatch()  # type: ignore
     record = make_scalar_record(step=1)
     record.num = 1
     t.put([record])
-    event.wait(timeout=2.0)
+    assert event.wait(timeout=2.0)
     t.finish()
     assert len(dispatched) == 1
 
@@ -221,7 +220,7 @@ def test_transport_keeps_pending_records_and_warns_after_retry_exhaustion(make_s
     first.num = 1
     second.num = 2
 
-    with patch("swanlab.sdk.internal.core_python.transport.thread.console.warning") as mock_warning:
+    with patch("swanlab.sdk.internal.core_python.transport.thread.UploadWarningThrottle.warn") as mock_warn:
         t.put([first])
         time.sleep(0.05)
         t.put([second])
@@ -231,4 +230,4 @@ def test_transport_keeps_pending_records_and_warns_after_retry_exhaustion(make_s
     assert attempts[0] == [1]
     assert attempts[1] == [1]
     assert attempts[2] == [2]
-    mock_warning.assert_called_once()
+    mock_warn.assert_called_once()

--- a/tests/unit/sdk/internal/probe_python/environment/test_environment_runtime.py
+++ b/tests/unit/sdk/internal/probe_python/environment/test_environment_runtime.py
@@ -80,7 +80,19 @@ class TestGetPid:
 
     def test_get_pid_returns_none_on_error(self):
         """os.getpid 异常时返回 None"""
-        with patch("os.getpid", side_effect=RuntimeError("mock error")):
+        call_count = 0
+
+        def fake_getpid():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("mock error")
+            return 12345
+
+        # 仅首次调用抛异常，后续调用正常返回。
+        # 原因：os.getpid 被 CPython logging.LogRecord 内部调用，@safe.decorator 捕获异常后打日志时会再次触发 os.getpid，
+        # 如果持续抛异常会导致日志记录本身失败。
+        with patch("os.getpid", side_effect=fake_getpid):
             assert runtime.get_pid() is None
 
 


### PR DESCRIPTION
## Description

改动trasnport的一个设计，原本一旦put后就会发送event通知线程处理，这不太符合tansport作为解决背压的缓冲区设计。现在改为不触发 event ，交给timeout，并且将上传间隔由一秒改为五秒

新增`UploadWarningThrottle`工具，在上传失败的时候节流打印日志避免刷屏。

修复一个测试问题