### PR TITLE
feat: add time filter

### DIFF
--- a/swanlab/core_python/api/experiment/__init__.py
+++ b/swanlab/core_python/api/experiment/__init__.py
@@ -100,9 +100,9 @@ def get_project_experiments(
             if key in special_filter_config:
                 config = special_filter_config[key]
                 filter_value = (
-                    list(value)
+                    [str(v) for v in value]
                     if key == "tags" and isinstance(value, (list, tuple))
-                    else [value]
+                    else [str(value)]
                 )
                 parsed_filters.append(
                     {
@@ -132,7 +132,7 @@ def get_project_experiments(
                         if parse_column_type(key) == "STABLE"
                         else key.split(".", 1)[-1],
                         "active": True,
-                        "value": [value],
+                        "value": [str(value)],
                         "op": "EQ",
                         "type": parse_column_type(key),
                     }

--- a/swanlab/core_python/api/experiment/__init__.py
+++ b/swanlab/core_python/api/experiment/__init__.py
@@ -5,7 +5,7 @@
 @description: 定义实验相关的后端API接口
 """
 
-from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Literal, Union, Any
 
 from swanlab.core_python.api.type import RunType
 
@@ -66,7 +66,7 @@ def get_project_experiments(
     client: "Client",
     *,
     path: str,
-    filters: Dict[str, object] = None,
+    filters: Dict[str, Any] = None,
 ) -> Union[List[RunType], Dict[str, List[RunType]]]:
     """
     获取指定项目下的所有实验信息
@@ -88,6 +88,9 @@ def get_project_experiments(
         "username": {"key": "user.username", "op": "EQ"},
         "job_type": {"key": "job", "op": "EQ"},
     }
+
+    time_filter_config =  ("createdAt", "updatedAt", "finishedAt")
+    time_op_config = ("EQ", "NEQ", "GTE", "LTE", "IN", "NOT IN", "CONTAIN")
 
     parsed_filters = []
 
@@ -111,6 +114,17 @@ def get_project_experiments(
                         "type": "STABLE",
                     }
                 )
+            elif key in time_filter_config:
+                op = value.get("op", "GTE")
+                time_value = [value.get("value", "2025-01-01T00:00:00.000Z")]
+                time_filter = {
+                    "type": "STABLE",
+                    "key": key,
+                    "op": op,
+                    "value": time_value,
+                    "active": True
+                }
+                parsed_filters.append(time_filter)
             else:
                 # 常规字段处理
                 parsed_filters.append(

--- a/swanlab/core_python/api/experiment/__init__.py
+++ b/swanlab/core_python/api/experiment/__init__.py
@@ -79,6 +79,8 @@ def get_project_experiments(
         - 'name': 按实验名筛选，值为字符串
         - 'username': 按创建人筛选，值为字符串
         - 'job_type': 按任务类型筛选，值为字符串
+        - 'createdAt'/'updatedAt'/'finishedAt': 按时间筛选，值为列表，
+          列表元素为 {"op": "GTE"|"LTE"|"EQ"|..., "value": "ISO8601时间字符串"}
     """
     # 特殊筛选条件配置：用户侧 key -> 后端 key 和操作符
     special_filter_config = {
@@ -89,17 +91,14 @@ def get_project_experiments(
         "job_type": {"key": "job", "op": "EQ"},
     }
 
-    time_filter_config =  ("createdAt", "updatedAt", "finishedAt")
-    time_op_config = ("EQ", "NEQ", "GTE", "LTE", "IN", "NOT IN", "CONTAIN")
+    time_filter_config = ("createdAt", "updatedAt", "finishedAt")
 
     parsed_filters = []
 
     if filters:
         for key, value in filters.items():
             if key in special_filter_config:
-                # 特殊字段处理
                 config = special_filter_config[key]
-                # tags 需要转换为列表
                 filter_value = (
                     list(value)
                     if key == "tags" and isinstance(value, (list, tuple))
@@ -115,16 +114,16 @@ def get_project_experiments(
                     }
                 )
             elif key in time_filter_config:
-                op = value.get("op", "GTE")
-                time_value = [value.get("value", "2025-01-01T00:00:00.000Z")]
-                time_filter = {
-                    "type": "STABLE",
-                    "key": key,
-                    "op": op,
-                    "value": time_value,
-                    "active": True
-                }
-                parsed_filters.append(time_filter)
+                if not isinstance(value, list):
+                    value = [value]
+                for item in value:
+                    parsed_filters.append({
+                        "type": "STABLE",
+                        "key": key,
+                        "op": item["op"],
+                        "value": [item["value"]],
+                        "active": True,
+                    })
             else:
                 # 常规字段处理
                 parsed_filters.append(


### PR DESCRIPTION
## Desctiption

> ⚠️ **注意：临时兼容字段，未来 0.8.0+ 的的 OpenAPI 不会按照这种方式传值**

为 `api.runs()` 的 `filters` 参数增加了时间筛选支持，同时重构了筛选条件的解析逻辑，支持多种筛选类型。

## 变更内容

- **时间筛选**：支持按 `createdAt`、`updatedAt`、`finishedAt` 字段进行时间范围筛选，使用列表格式传入多个条件

## 使用示例

```python
import swanlab

api = swanlab.Api()

runs = api.runs(
    path='nexisato/my-awesome-project',
    filters={
        "createdAt": [{
            "op": "GTE",
            "value": "2025-12-11T00:00:00.000Z"
        }, {
            "op": "LTE",
            "value": "2026-02-03T00:00:00.000Z"
        }]
    })

for run in runs:
    print(run.name)
```

### 时间筛选参数说明

时间筛选值为**列表格式**，列表中每个元素是一个筛选条件对象：

```json
"createdAt": [
  {"op": "GTE", "value": "2025-12-11T00:00:00.000Z"},
  {"op": "LTE", "value": "2026-02-03T00:00:00.000Z"}
]
```

- **`op`**：比较操作符，支持 `EQ`（等于）、`NEQ`（不等于）、`GTE`（大于等于）、`LTE`（小于等于）
- **`value`**：ISO 8601 格式的时间字符串，格式为 `YYYY-MM-DDTHH:mm:ss.000Z`（UTC 时区）

可筛选的时间字段：
- `createdAt`：实验创建时间
- `updatedAt`：实验更新时间
- `finishedAt`：实验结束时间

