### PR TITLE
feat: add SwanLab environment probe and integration

### DIFF
--- a/swanlab/sdk/internal/probe_python/__init__.py
+++ b/swanlab/sdk/internal/probe_python/__init__.py
@@ -14,7 +14,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from swanlab.proto.swanlab.system.v1.env_pb2 import CondaRecord, MetadataRecord, RequirementsRecord
 from swanlab.sdk.internal.context import RunContext
 from swanlab.sdk.internal.pkg import fs
-from swanlab.sdk.internal.probe_python.environment import conda, git, requirements, runtime
+from swanlab.sdk.internal.probe_python.environment import conda, git, requirements, runtime, swanlab
 from swanlab.sdk.internal.probe_python.hardware_vendor.apple import Apple
 from swanlab.sdk.internal.probe_python.hardware_vendor.cpu import CPU
 from swanlab.sdk.internal.probe_python.hardware_vendor.memory import Memory
@@ -39,6 +39,8 @@ class ProbePython(ProbeProtocol):
         runtime_snapshot = runtime.get() if settings.environment.runtime else None
         conda_snapshot = conda.get() if settings.environment.conda else None
         requirements_snapshot = requirements.get() if settings.environment.requirements else None
+        swanlab_snapshot = swanlab.get(self._ctx) if settings.environment.swanlab else None
+
         # 2. 系统硬件信息采集，只有在硬件采集和监控都不开启时才不采集
         hardware_snapshot = None
         if settings.environment.hardware or settings.monitor.enable:
@@ -62,6 +64,7 @@ class ProbePython(ProbeProtocol):
             hardware=hardware_snapshot,
             git=git_snapshot,
             runtime=runtime_snapshot,
+            swanlab=swanlab_snapshot,
         )
         system_shim = SystemShim.from_snapshot(metadata, platform=sys.platform)
         # 如果硬采集被设置为False，删除硬件信息

--- a/swanlab/sdk/internal/probe_python/environment/swanlab.py
+++ b/swanlab/sdk/internal/probe_python/environment/swanlab.py
@@ -11,7 +11,7 @@ from swanlab.sdk.internal.pkg.helper import get_swanlab_version
 from swanlab.sdk.typings.probe_python import SwanLabSnapshot
 
 
-@safe.decorator(level="debug", message="Failed to get conda environment")
+@safe.decorator(level="debug", message="Failed to get swanlab environment")
 def get(ctx: RunContext) -> SwanLabSnapshot:
     """获取 SwanLab 信息快照"""
     return SwanLabSnapshot(version=get_swanlab_version(), run_dir=str(ctx.run_dir))

--- a/swanlab/sdk/internal/probe_python/environment/swanlab.py
+++ b/swanlab/sdk/internal/probe_python/environment/swanlab.py
@@ -1,0 +1,17 @@
+"""
+@author: cunyue
+@file: swanlab.py
+@time: 2026/4/24 12:52
+@description: SwanLab 信息采集模块
+"""
+
+from swanlab.sdk.internal.context import RunContext
+from swanlab.sdk.internal.pkg import safe
+from swanlab.sdk.internal.pkg.helper import get_swanlab_version
+from swanlab.sdk.typings.probe_python import SwanLabSnapshot
+
+
+@safe.decorator(level="debug", message="Failed to get conda environment")
+def get(ctx: RunContext) -> SwanLabSnapshot:
+    """获取 SwanLab 信息快照"""
+    return SwanLabSnapshot(version=get_swanlab_version(), run_dir=str(ctx.run_dir))

--- a/swanlab/sdk/internal/settings/metadata.py
+++ b/swanlab/sdk/internal/settings/metadata.py
@@ -55,7 +55,7 @@ class EnvironmentSettings(BaseModel):
 
     swanlab: bool = True
     """Controls the tracking of SwanLab metadata. 
-    When True, captures the SwanLab version, the current working directory and so on.
+    When True, captures the SwanLab version, the SwanLab run directory and so on.
     """
 
     # TODO: There are some gpu/npu specific environment variables that can be collected, such as CUDA_VISIBLE_DEVICES, ROC_VISIBLE_DEVICES, etc.

--- a/swanlab/sdk/internal/settings/metadata.py
+++ b/swanlab/sdk/internal/settings/metadata.py
@@ -53,6 +53,11 @@ class EnvironmentSettings(BaseModel):
     When True, captures the current branch, latest commit hash, and remote URL. This helps tightly link the experiment run to a specific version of your codebase.
     """
 
+    swanlab: bool = True
+    """Controls the tracking of SwanLab metadata. 
+    When True, captures the SwanLab version, the current working directory and so on.
+    """
+
     # TODO: There are some gpu/npu specific environment variables that can be collected, such as CUDA_VISIBLE_DEVICES, ROC_VISIBLE_DEVICES, etc.
 
     model_config = ConfigDict(frozen=True)

--- a/swanlab/sdk/typings/probe_python/__init__.py
+++ b/swanlab/sdk/typings/probe_python/__init__.py
@@ -191,6 +191,17 @@ class HardwareSnapshot(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class SwanLabSnapshot(BaseModel):
+    """SwanLab 相关的系统快照"""
+
+    version: Optional[str] = None
+    """SwanLab 包版本"""
+    run_dir: Optional[str] = None
+    """SwanLab 运行时目录"""
+
+    model_config = ConfigDict(frozen=True)
+
+
 # ──────────────────────────────────────────────
 # MetadataSnapshot：完整的系统快照
 # ──────────────────────────────────────────────
@@ -206,6 +217,7 @@ class MetadataSnapshot(BaseModel):
     hardware: Optional[HardwareSnapshot] = None
     runtime: Optional[RuntimeSnapshot] = None
     git: Optional[GitSnapshot] = None
+    swanlab: Optional[SwanLabSnapshot] = None
 
     def del_hardware(self):
         return self.model_copy(update={"hardware": None})


### PR DESCRIPTION
引入一个新的swanlab环境探针，通过swanlab.sdk.internal.probe_python.environment.swanlab.get捕获SwanLab元数据（版本号和运行目录）。添加SwanLabSnapshot类型注解，并在MetadataSnapshot中设置可选的swanlab字段。在EnvironmentSettings中默认启用该功能（swanlab: True），并将快照收集集成到ProbePython中，从而确保swanlab快照能被采集并附加到元数据中。