### PR TITLE
refactor: rename ColumnType FLOAT→SCALAR, add ChartType & upload DTOs

### DIFF
--- a/core/proto/swanlab/metric/column/v1/column.pb.go
+++ b/core/proto/swanlab/metric/column/v1/column.pb.go
@@ -26,33 +26,39 @@ type ColumnType int32
 
 const (
 	ColumnType_COLUMN_TYPE_UNSPECIFIED ColumnType = 0
-	ColumnType_COLUMN_TYPE_FLOAT       ColumnType = 1 // 标量
+	ColumnType_COLUMN_TYPE_SCALAR      ColumnType = 1 // 标量
 	ColumnType_COLUMN_TYPE_IMAGE       ColumnType = 2 // 图像
 	ColumnType_COLUMN_TYPE_AUDIO       ColumnType = 3 // 音频
 	ColumnType_COLUMN_TYPE_TEXT        ColumnType = 4 // 文本
 	ColumnType_COLUMN_TYPE_VIDEO       ColumnType = 5 // 视频
 	ColumnType_COLUMN_TYPE_ECHARTS     ColumnType = 6 // ECharts 图表
+	ColumnType_COLUMN_TYPE_OBJECT3D    ColumnType = 7 // 3D 对象
+	ColumnType_COLUMN_TYPE_MOLECULE    ColumnType = 8 // 分子结构
 )
 
 // Enum value maps for ColumnType.
 var (
 	ColumnType_name = map[int32]string{
 		0: "COLUMN_TYPE_UNSPECIFIED",
-		1: "COLUMN_TYPE_FLOAT",
+		1: "COLUMN_TYPE_SCALAR",
 		2: "COLUMN_TYPE_IMAGE",
 		3: "COLUMN_TYPE_AUDIO",
 		4: "COLUMN_TYPE_TEXT",
 		5: "COLUMN_TYPE_VIDEO",
 		6: "COLUMN_TYPE_ECHARTS",
+		7: "COLUMN_TYPE_OBJECT3D",
+		8: "COLUMN_TYPE_MOLECULE",
 	}
 	ColumnType_value = map[string]int32{
 		"COLUMN_TYPE_UNSPECIFIED": 0,
-		"COLUMN_TYPE_FLOAT":       1,
+		"COLUMN_TYPE_SCALAR":      1,
 		"COLUMN_TYPE_IMAGE":       2,
 		"COLUMN_TYPE_AUDIO":       3,
 		"COLUMN_TYPE_TEXT":        4,
 		"COLUMN_TYPE_VIDEO":       5,
 		"COLUMN_TYPE_ECHARTS":     6,
+		"COLUMN_TYPE_OBJECT3D":    7,
+		"COLUMN_TYPE_MOLECULE":    8,
 	}
 )
 
@@ -89,6 +95,7 @@ type ColumnClass int32
 const (
 	ColumnClass_COLUMN_CLASS_UNSPECIFIED ColumnClass = 0
 	ColumnClass_COLUMN_CLASS_CUSTOM      ColumnClass = 1 // 用户自定义列（默认）
+	ColumnClass_COLUMN_CLASS_SYSTEM      ColumnClass = 2 // 系统列
 )
 
 // Enum value maps for ColumnClass.
@@ -96,10 +103,12 @@ var (
 	ColumnClass_name = map[int32]string{
 		0: "COLUMN_CLASS_UNSPECIFIED",
 		1: "COLUMN_CLASS_CUSTOM",
+		2: "COLUMN_CLASS_SYSTEM",
 	}
 	ColumnClass_value = map[string]int32{
 		"COLUMN_CLASS_UNSPECIFIED": 0,
 		"COLUMN_CLASS_CUSTOM":      1,
+		"COLUMN_CLASS_SYSTEM":      2,
 	}
 )
 
@@ -128,6 +137,80 @@ func (x ColumnClass) Number() protoreflect.EnumNumber {
 // Deprecated: Use ColumnClass.Descriptor instead.
 func (ColumnClass) EnumDescriptor() ([]byte, []int) {
 	return file_swanlab_metric_column_v1_column_proto_rawDescGZIP(), []int{1}
+}
+
+// ChartType 图表类型
+type ChartType int32
+
+const (
+	ChartType_CHART_TYPE_UNSPECIFIED ChartType = 0 // 默认情况下，后端根据 column_type 自动推导
+	ChartType_CHART_TYPE_LINE        ChartType = 1
+	ChartType_CHART_TYPE_BAR         ChartType = 2
+	ChartType_CHART_TYPE_SCALAR      ChartType = 3
+	ChartType_CHART_TYPE_IMAGE       ChartType = 4
+	ChartType_CHART_TYPE_AUDIO       ChartType = 5
+	ChartType_CHART_TYPE_TEXT        ChartType = 6
+	ChartType_CHART_TYPE_VIDEO       ChartType = 7
+	ChartType_CHART_TYPE_ECHARTS     ChartType = 8
+	ChartType_CHART_TYPE_OBJECT3D    ChartType = 9
+	ChartType_CHART_TYPE_MOLECULE    ChartType = 10
+)
+
+// Enum value maps for ChartType.
+var (
+	ChartType_name = map[int32]string{
+		0:  "CHART_TYPE_UNSPECIFIED",
+		1:  "CHART_TYPE_LINE",
+		2:  "CHART_TYPE_BAR",
+		3:  "CHART_TYPE_SCALAR",
+		4:  "CHART_TYPE_IMAGE",
+		5:  "CHART_TYPE_AUDIO",
+		6:  "CHART_TYPE_TEXT",
+		7:  "CHART_TYPE_VIDEO",
+		8:  "CHART_TYPE_ECHARTS",
+		9:  "CHART_TYPE_OBJECT3D",
+		10: "CHART_TYPE_MOLECULE",
+	}
+	ChartType_value = map[string]int32{
+		"CHART_TYPE_UNSPECIFIED": 0,
+		"CHART_TYPE_LINE":        1,
+		"CHART_TYPE_BAR":         2,
+		"CHART_TYPE_SCALAR":      3,
+		"CHART_TYPE_IMAGE":       4,
+		"CHART_TYPE_AUDIO":       5,
+		"CHART_TYPE_TEXT":        6,
+		"CHART_TYPE_VIDEO":       7,
+		"CHART_TYPE_ECHARTS":     8,
+		"CHART_TYPE_OBJECT3D":    9,
+		"CHART_TYPE_MOLECULE":    10,
+	}
+)
+
+func (x ChartType) Enum() *ChartType {
+	p := new(ChartType)
+	*p = x
+	return p
+}
+
+func (x ChartType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ChartType) Descriptor() protoreflect.EnumDescriptor {
+	return file_swanlab_metric_column_v1_column_proto_enumTypes[2].Descriptor()
+}
+
+func (ChartType) Type() protoreflect.EnumType {
+	return &file_swanlab_metric_column_v1_column_proto_enumTypes[2]
+}
+
+func (x ChartType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ChartType.Descriptor instead.
+func (ChartType) EnumDescriptor() ([]byte, []int) {
+	return file_swanlab_metric_column_v1_column_proto_rawDescGZIP(), []int{2}
 }
 
 // SectionType section 类型
@@ -170,11 +253,11 @@ func (x SectionType) String() string {
 }
 
 func (SectionType) Descriptor() protoreflect.EnumDescriptor {
-	return file_swanlab_metric_column_v1_column_proto_enumTypes[2].Descriptor()
+	return file_swanlab_metric_column_v1_column_proto_enumTypes[3].Descriptor()
 }
 
 func (SectionType) Type() protoreflect.EnumType {
-	return &file_swanlab_metric_column_v1_column_proto_enumTypes[2]
+	return &file_swanlab_metric_column_v1_column_proto_enumTypes[3]
 }
 
 func (x SectionType) Number() protoreflect.EnumNumber {
@@ -183,7 +266,7 @@ func (x SectionType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SectionType.Descriptor instead.
 func (SectionType) EnumDescriptor() ([]byte, []int) {
-	return file_swanlab_metric_column_v1_column_proto_rawDescGZIP(), []int{2}
+	return file_swanlab_metric_column_v1_column_proto_rawDescGZIP(), []int{3}
 }
 
 // YRange Y 轴显示范围
@@ -263,16 +346,18 @@ type ColumnRecord struct {
 	SectionName string `protobuf:"bytes,5,opt,name=section_name,json=sectionName,proto3" json:"section_name,omitempty"`
 	// Section 类型，默认 PUBLIC
 	SectionType SectionType `protobuf:"varint,6,opt,name=section_type,json=sectionType,proto3,enum=swanlab.metric.column.v1.SectionType" json:"section_type,omitempty"`
-	// Y 轴范围 [min, max]，可选
+	// Y 轴范围 [min, max]，可选，仅折线图有效
 	YRange *YRange `protobuf:"bytes,7,opt,name=y_range,json=yRange,proto3" json:"y_range,omitempty"`
 	// 图表索引，相同 chart_index 的列归入同一图表；不填则新建图表
 	ChartIndex string `protobuf:"bytes,8,opt,name=chart_index,json=chartIndex,proto3" json:"chart_index,omitempty"`
 	// 图表名称，仅对单实验图表生效
 	ChartName string `protobuf:"bytes,9,opt,name=chart_name,json=chartName,proto3" json:"chart_name,omitempty"`
+	// 图表类型，默认根据 column_type 自动推导
+	ChartType ChartType `protobuf:"varint,10,opt,name=chart_type,json=chartType,proto3,enum=swanlab.metric.column.v1.ChartType" json:"chart_type,omitempty"`
 	// 指标名称，仅对单实验图表生效
-	MetricName string `protobuf:"bytes,10,opt,name=metric_name,json=metricName,proto3" json:"metric_name,omitempty"`
+	MetricName string `protobuf:"bytes,11,opt,name=metric_name,json=metricName,proto3" json:"metric_name,omitempty"`
 	// 指标颜色列表，十六进制颜色值，如 "#FF5733"
-	MetricColors  []string `protobuf:"bytes,11,rep,name=metric_colors,json=metricColors,proto3" json:"metric_colors,omitempty"`
+	MetricColors  []string `protobuf:"bytes,12,rep,name=metric_colors,json=metricColors,proto3" json:"metric_colors,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -370,6 +455,13 @@ func (x *ColumnRecord) GetChartName() string {
 	return ""
 }
 
+func (x *ColumnRecord) GetChartType() ChartType {
+	if x != nil {
+		return x.ChartType
+	}
+	return ChartType_CHART_TYPE_UNSPECIFIED
+}
+
 func (x *ColumnRecord) GetMetricName() string {
 	if x != nil {
 		return x.MetricName
@@ -391,7 +483,7 @@ const file_swanlab_metric_column_v1_column_proto_rawDesc = "" +
 	"%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\",\n" +
 	"\x06YRange\x12\x10\n" +
 	"\x03min\x18\x01 \x01(\x01R\x03min\x12\x10\n" +
-	"\x03max\x18\x02 \x01(\x01R\x03max\"\x8d\x04\n" +
+	"\x03max\x18\x02 \x01(\x01R\x03max\"\xd1\x04\n" +
 	"\fColumnRecord\x12H\n" +
 	"\fcolumn_class\x18\x01 \x01(\x0e2%.swanlab.metric.column.v1.ColumnClassR\vcolumnClass\x12E\n" +
 	"\vcolumn_type\x18\x02 \x01(\x0e2$.swanlab.metric.column.v1.ColumnTypeR\n" +
@@ -406,23 +498,41 @@ const file_swanlab_metric_column_v1_column_proto_rawDesc = "" +
 	"\vchart_index\x18\b \x01(\tR\n" +
 	"chartIndex\x12\x1d\n" +
 	"\n" +
-	"chart_name\x18\t \x01(\tR\tchartName\x12\x1f\n" +
-	"\vmetric_name\x18\n" +
-	" \x01(\tR\n" +
+	"chart_name\x18\t \x01(\tR\tchartName\x12B\n" +
+	"\n" +
+	"chart_type\x18\n" +
+	" \x01(\x0e2#.swanlab.metric.column.v1.ChartTypeR\tchartType\x12\x1f\n" +
+	"\vmetric_name\x18\v \x01(\tR\n" +
 	"metricName\x12#\n" +
-	"\rmetric_colors\x18\v \x03(\tR\fmetricColors*\xb4\x01\n" +
+	"\rmetric_colors\x18\f \x03(\tR\fmetricColors*\xe9\x01\n" +
 	"\n" +
 	"ColumnType\x12\x1b\n" +
-	"\x17COLUMN_TYPE_UNSPECIFIED\x10\x00\x12\x15\n" +
-	"\x11COLUMN_TYPE_FLOAT\x10\x01\x12\x15\n" +
+	"\x17COLUMN_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12COLUMN_TYPE_SCALAR\x10\x01\x12\x15\n" +
 	"\x11COLUMN_TYPE_IMAGE\x10\x02\x12\x15\n" +
 	"\x11COLUMN_TYPE_AUDIO\x10\x03\x12\x14\n" +
 	"\x10COLUMN_TYPE_TEXT\x10\x04\x12\x15\n" +
 	"\x11COLUMN_TYPE_VIDEO\x10\x05\x12\x17\n" +
-	"\x13COLUMN_TYPE_ECHARTS\x10\x06*D\n" +
+	"\x13COLUMN_TYPE_ECHARTS\x10\x06\x12\x18\n" +
+	"\x14COLUMN_TYPE_OBJECT3D\x10\a\x12\x18\n" +
+	"\x14COLUMN_TYPE_MOLECULE\x10\b*]\n" +
 	"\vColumnClass\x12\x1c\n" +
 	"\x18COLUMN_CLASS_UNSPECIFIED\x10\x00\x12\x17\n" +
-	"\x13COLUMN_CLASS_CUSTOM\x10\x01*\x8f\x01\n" +
+	"\x13COLUMN_CLASS_CUSTOM\x10\x01\x12\x17\n" +
+	"\x13COLUMN_CLASS_SYSTEM\x10\x02*\x88\x02\n" +
+	"\tChartType\x12\x1a\n" +
+	"\x16CHART_TYPE_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fCHART_TYPE_LINE\x10\x01\x12\x12\n" +
+	"\x0eCHART_TYPE_BAR\x10\x02\x12\x15\n" +
+	"\x11CHART_TYPE_SCALAR\x10\x03\x12\x14\n" +
+	"\x10CHART_TYPE_IMAGE\x10\x04\x12\x14\n" +
+	"\x10CHART_TYPE_AUDIO\x10\x05\x12\x13\n" +
+	"\x0fCHART_TYPE_TEXT\x10\x06\x12\x14\n" +
+	"\x10CHART_TYPE_VIDEO\x10\a\x12\x16\n" +
+	"\x12CHART_TYPE_ECHARTS\x10\b\x12\x17\n" +
+	"\x13CHART_TYPE_OBJECT3D\x10\t\x12\x17\n" +
+	"\x13CHART_TYPE_MOLECULE\x10\n" +
+	"*\x8f\x01\n" +
 	"\vSectionType\x12\x1c\n" +
 	"\x18SECTION_TYPE_UNSPECIFIED\x10\x00\x12\x17\n" +
 	"\x13SECTION_TYPE_PINNED\x10\x01\x12\x17\n" +
@@ -442,25 +552,27 @@ func file_swanlab_metric_column_v1_column_proto_rawDescGZIP() []byte {
 	return file_swanlab_metric_column_v1_column_proto_rawDescData
 }
 
-var file_swanlab_metric_column_v1_column_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
+var file_swanlab_metric_column_v1_column_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
 var file_swanlab_metric_column_v1_column_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_swanlab_metric_column_v1_column_proto_goTypes = []any{
 	(ColumnType)(0),      // 0: swanlab.metric.column.v1.ColumnType
 	(ColumnClass)(0),     // 1: swanlab.metric.column.v1.ColumnClass
-	(SectionType)(0),     // 2: swanlab.metric.column.v1.SectionType
-	(*YRange)(nil),       // 3: swanlab.metric.column.v1.YRange
-	(*ColumnRecord)(nil), // 4: swanlab.metric.column.v1.ColumnRecord
+	(ChartType)(0),       // 2: swanlab.metric.column.v1.ChartType
+	(SectionType)(0),     // 3: swanlab.metric.column.v1.SectionType
+	(*YRange)(nil),       // 4: swanlab.metric.column.v1.YRange
+	(*ColumnRecord)(nil), // 5: swanlab.metric.column.v1.ColumnRecord
 }
 var file_swanlab_metric_column_v1_column_proto_depIdxs = []int32{
 	1, // 0: swanlab.metric.column.v1.ColumnRecord.column_class:type_name -> swanlab.metric.column.v1.ColumnClass
 	0, // 1: swanlab.metric.column.v1.ColumnRecord.column_type:type_name -> swanlab.metric.column.v1.ColumnType
-	2, // 2: swanlab.metric.column.v1.ColumnRecord.section_type:type_name -> swanlab.metric.column.v1.SectionType
-	3, // 3: swanlab.metric.column.v1.ColumnRecord.y_range:type_name -> swanlab.metric.column.v1.YRange
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	3, // 2: swanlab.metric.column.v1.ColumnRecord.section_type:type_name -> swanlab.metric.column.v1.SectionType
+	4, // 3: swanlab.metric.column.v1.ColumnRecord.y_range:type_name -> swanlab.metric.column.v1.YRange
+	2, // 4: swanlab.metric.column.v1.ColumnRecord.chart_type:type_name -> swanlab.metric.column.v1.ChartType
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_swanlab_metric_column_v1_column_proto_init() }
@@ -473,7 +585,7 @@ func file_swanlab_metric_column_v1_column_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_swanlab_metric_column_v1_column_proto_rawDesc), len(file_swanlab_metric_column_v1_column_proto_rawDesc)),
-			NumEnums:      3,
+			NumEnums:      4,
 			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/protos/swanlab/metric/column/v1/column.proto
+++ b/protos/swanlab/metric/column/v1/column.proto
@@ -7,19 +7,39 @@ option go_package = "github.com/swanhubx/swanlab/core/proto/swanlab/metric/colum
 // ColumnType 列的数据类型
 enum ColumnType {
   COLUMN_TYPE_UNSPECIFIED = 0;
-  COLUMN_TYPE_FLOAT       = 1;  // 标量
+  COLUMN_TYPE_SCALAR      = 1;  // 标量
   COLUMN_TYPE_IMAGE       = 2;  // 图像
   COLUMN_TYPE_AUDIO       = 3;  // 音频
   COLUMN_TYPE_TEXT        = 4;  // 文本
   COLUMN_TYPE_VIDEO       = 5;  // 视频
   COLUMN_TYPE_ECHARTS     = 6;  // ECharts 图表
+  COLUMN_TYPE_OBJECT3D    = 7;  // 3D 对象
+  COLUMN_TYPE_MOLECULE    = 8;  // 分子结构
 }
 
 // ColumnClass 列的来源类别
 enum ColumnClass {
   COLUMN_CLASS_UNSPECIFIED = 0;
   COLUMN_CLASS_CUSTOM      = 1;  // 用户自定义列（默认）
+  COLUMN_CLASS_SYSTEM      = 2;  // 系统列
 }
+
+
+// ChartType 图表类型
+enum ChartType {
+  CHART_TYPE_UNSPECIFIED = 0;   // 默认情况下，后端根据 column_type 自动推导
+  CHART_TYPE_LINE        = 1;
+  CHART_TYPE_BAR         = 2;
+  CHART_TYPE_SCALAR      = 3;
+  CHART_TYPE_IMAGE       = 4;
+  CHART_TYPE_AUDIO       = 5;
+  CHART_TYPE_TEXT        = 6;
+  CHART_TYPE_VIDEO       = 7;
+  CHART_TYPE_ECHARTS     = 8;
+  CHART_TYPE_OBJECT3D    = 9;
+  CHART_TYPE_MOLECULE    = 10;
+}
+
 
 // SectionType section 类型
 enum SectionType {
@@ -65,7 +85,7 @@ message ColumnRecord {
   // Section 类型，默认 PUBLIC
   SectionType section_type = 6;
 
-  // Y 轴范围 [min, max]，可选
+  // Y 轴范围 [min, max]，可选，仅折线图有效
   YRange y_range = 7;
 
   // 图表索引，相同 chart_index 的列归入同一图表；不填则新建图表
@@ -74,9 +94,12 @@ message ColumnRecord {
   // 图表名称，仅对单实验图表生效
   string chart_name = 9;
 
+  // 图表类型，默认根据 column_type 自动推导
+  ChartType chart_type = 10;
+
   // 指标名称，仅对单实验图表生效
-  string metric_name = 10;
+  string metric_name = 11;
 
   // 指标颜色列表，十六进制颜色值，如 "#FF5733"
-  repeated string metric_colors = 11;
+  repeated string metric_colors = 12;
 }

--- a/swanlab/proto/swanlab/metric/column/v1/column_pb2.py
+++ b/swanlab/proto/swanlab/metric/column/v1/column_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\"\"\n\x06YRange\x12\x0b\n\x03min\x18\x01 \x01(\x01\x12\x0b\n\x03max\x18\x02 \x01(\x01\"\x8a\x03\n\x0c\x43olumnRecord\x12;\n\x0c\x63olumn_class\x18\x01 \x01(\x0e\x32%.swanlab.metric.column.v1.ColumnClass\x12\x39\n\x0b\x63olumn_type\x18\x02 \x01(\x0e\x32$.swanlab.metric.column.v1.ColumnType\x12\x12\n\ncolumn_key\x18\x03 \x01(\t\x12\x13\n\x0b\x63olumn_name\x18\x04 \x01(\t\x12\x14\n\x0csection_name\x18\x05 \x01(\t\x12;\n\x0csection_type\x18\x06 \x01(\x0e\x32%.swanlab.metric.column.v1.SectionType\x12\x31\n\x07y_range\x18\x07 \x01(\x0b\x32 .swanlab.metric.column.v1.YRange\x12\x13\n\x0b\x63hart_index\x18\x08 \x01(\t\x12\x12\n\nchart_name\x18\t \x01(\t\x12\x13\n\x0bmetric_name\x18\n \x01(\t\x12\x15\n\rmetric_colors\x18\x0b \x03(\t*\xb4\x01\n\nColumnType\x12\x1b\n\x17\x43OLUMN_TYPE_UNSPECIFIED\x10\x00\x12\x15\n\x11\x43OLUMN_TYPE_FLOAT\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_IMAGE\x10\x02\x12\x15\n\x11\x43OLUMN_TYPE_AUDIO\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_TEXT\x10\x04\x12\x15\n\x11\x43OLUMN_TYPE_VIDEO\x10\x05\x12\x17\n\x13\x43OLUMN_TYPE_ECHARTS\x10\x06*D\n\x0b\x43olumnClass\x12\x1c\n\x18\x43OLUMN_CLASS_UNSPECIFIED\x10\x00\x12\x17\n\x13\x43OLUMN_CLASS_CUSTOM\x10\x01*\x8f\x01\n\x0bSectionType\x12\x1c\n\x18SECTION_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13SECTION_TYPE_PINNED\x10\x01\x12\x17\n\x13SECTION_TYPE_HIDDEN\x10\x02\x12\x17\n\x13SECTION_TYPE_PUBLIC\x10\x03\x12\x17\n\x13SECTION_TYPE_SYSTEM\x10\x04\x42JZHgithub.com/swanhubx/swanlab/core/proto/swanlab/metric/column/v1;columnv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\"\"\n\x06YRange\x12\x0b\n\x03min\x18\x01 \x01(\x01\x12\x0b\n\x03max\x18\x02 \x01(\x01\"\xc3\x03\n\x0c\x43olumnRecord\x12;\n\x0c\x63olumn_class\x18\x01 \x01(\x0e\x32%.swanlab.metric.column.v1.ColumnClass\x12\x39\n\x0b\x63olumn_type\x18\x02 \x01(\x0e\x32$.swanlab.metric.column.v1.ColumnType\x12\x12\n\ncolumn_key\x18\x03 \x01(\t\x12\x13\n\x0b\x63olumn_name\x18\x04 \x01(\t\x12\x14\n\x0csection_name\x18\x05 \x01(\t\x12;\n\x0csection_type\x18\x06 \x01(\x0e\x32%.swanlab.metric.column.v1.SectionType\x12\x31\n\x07y_range\x18\x07 \x01(\x0b\x32 .swanlab.metric.column.v1.YRange\x12\x13\n\x0b\x63hart_index\x18\x08 \x01(\t\x12\x12\n\nchart_name\x18\t \x01(\t\x12\x37\n\nchart_type\x18\n \x01(\x0e\x32#.swanlab.metric.column.v1.ChartType\x12\x13\n\x0bmetric_name\x18\x0b \x01(\t\x12\x15\n\rmetric_colors\x18\x0c \x03(\t*\xe9\x01\n\nColumnType\x12\x1b\n\x17\x43OLUMN_TYPE_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_SCALAR\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_IMAGE\x10\x02\x12\x15\n\x11\x43OLUMN_TYPE_AUDIO\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_TEXT\x10\x04\x12\x15\n\x11\x43OLUMN_TYPE_VIDEO\x10\x05\x12\x17\n\x13\x43OLUMN_TYPE_ECHARTS\x10\x06\x12\x18\n\x14\x43OLUMN_TYPE_OBJECT3D\x10\x07\x12\x18\n\x14\x43OLUMN_TYPE_MOLECULE\x10\x08*]\n\x0b\x43olumnClass\x12\x1c\n\x18\x43OLUMN_CLASS_UNSPECIFIED\x10\x00\x12\x17\n\x13\x43OLUMN_CLASS_CUSTOM\x10\x01\x12\x17\n\x13\x43OLUMN_CLASS_SYSTEM\x10\x02*\x88\x02\n\tChartType\x12\x1a\n\x16\x43HART_TYPE_UNSPECIFIED\x10\x00\x12\x13\n\x0f\x43HART_TYPE_LINE\x10\x01\x12\x12\n\x0e\x43HART_TYPE_BAR\x10\x02\x12\x15\n\x11\x43HART_TYPE_SCALAR\x10\x03\x12\x14\n\x10\x43HART_TYPE_IMAGE\x10\x04\x12\x14\n\x10\x43HART_TYPE_AUDIO\x10\x05\x12\x13\n\x0f\x43HART_TYPE_TEXT\x10\x06\x12\x14\n\x10\x43HART_TYPE_VIDEO\x10\x07\x12\x16\n\x12\x43HART_TYPE_ECHARTS\x10\x08\x12\x17\n\x13\x43HART_TYPE_OBJECT3D\x10\t\x12\x17\n\x13\x43HART_TYPE_MOLECULE\x10\n*\x8f\x01\n\x0bSectionType\x12\x1c\n\x18SECTION_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13SECTION_TYPE_PINNED\x10\x01\x12\x17\n\x13SECTION_TYPE_HIDDEN\x10\x02\x12\x17\n\x13SECTION_TYPE_PUBLIC\x10\x03\x12\x17\n\x13SECTION_TYPE_SYSTEM\x10\x04\x42JZHgithub.com/swanhubx/swanlab/core/proto/swanlab/metric/column/v1;columnv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,14 +32,16 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'swanlab.metric.column.v1.co
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'ZHgithub.com/swanhubx/swanlab/core/proto/swanlab/metric/column/v1;columnv1'
-  _globals['_COLUMNTYPE']._serialized_start=501
-  _globals['_COLUMNTYPE']._serialized_end=681
-  _globals['_COLUMNCLASS']._serialized_start=683
-  _globals['_COLUMNCLASS']._serialized_end=751
-  _globals['_SECTIONTYPE']._serialized_start=754
-  _globals['_SECTIONTYPE']._serialized_end=897
+  _globals['_COLUMNTYPE']._serialized_start=558
+  _globals['_COLUMNTYPE']._serialized_end=791
+  _globals['_COLUMNCLASS']._serialized_start=793
+  _globals['_COLUMNCLASS']._serialized_end=886
+  _globals['_CHARTTYPE']._serialized_start=889
+  _globals['_CHARTTYPE']._serialized_end=1153
+  _globals['_SECTIONTYPE']._serialized_start=1156
+  _globals['_SECTIONTYPE']._serialized_end=1299
   _globals['_YRANGE']._serialized_start=67
   _globals['_YRANGE']._serialized_end=101
   _globals['_COLUMNRECORD']._serialized_start=104
-  _globals['_COLUMNRECORD']._serialized_end=498
+  _globals['_COLUMNRECORD']._serialized_end=555
 # @@protoc_insertion_point(module_scope)

--- a/swanlab/proto/swanlab/metric/column/v1/column_pb2.pyi
+++ b/swanlab/proto/swanlab/metric/column/v1/column_pb2.pyi
@@ -10,17 +10,34 @@ DESCRIPTOR: _descriptor.FileDescriptor
 class ColumnType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
     COLUMN_TYPE_UNSPECIFIED: _ClassVar[ColumnType]
-    COLUMN_TYPE_FLOAT: _ClassVar[ColumnType]
+    COLUMN_TYPE_SCALAR: _ClassVar[ColumnType]
     COLUMN_TYPE_IMAGE: _ClassVar[ColumnType]
     COLUMN_TYPE_AUDIO: _ClassVar[ColumnType]
     COLUMN_TYPE_TEXT: _ClassVar[ColumnType]
     COLUMN_TYPE_VIDEO: _ClassVar[ColumnType]
     COLUMN_TYPE_ECHARTS: _ClassVar[ColumnType]
+    COLUMN_TYPE_OBJECT3D: _ClassVar[ColumnType]
+    COLUMN_TYPE_MOLECULE: _ClassVar[ColumnType]
 
 class ColumnClass(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
     COLUMN_CLASS_UNSPECIFIED: _ClassVar[ColumnClass]
     COLUMN_CLASS_CUSTOM: _ClassVar[ColumnClass]
+    COLUMN_CLASS_SYSTEM: _ClassVar[ColumnClass]
+
+class ChartType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    CHART_TYPE_UNSPECIFIED: _ClassVar[ChartType]
+    CHART_TYPE_LINE: _ClassVar[ChartType]
+    CHART_TYPE_BAR: _ClassVar[ChartType]
+    CHART_TYPE_SCALAR: _ClassVar[ChartType]
+    CHART_TYPE_IMAGE: _ClassVar[ChartType]
+    CHART_TYPE_AUDIO: _ClassVar[ChartType]
+    CHART_TYPE_TEXT: _ClassVar[ChartType]
+    CHART_TYPE_VIDEO: _ClassVar[ChartType]
+    CHART_TYPE_ECHARTS: _ClassVar[ChartType]
+    CHART_TYPE_OBJECT3D: _ClassVar[ChartType]
+    CHART_TYPE_MOLECULE: _ClassVar[ChartType]
 
 class SectionType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     __slots__ = ()
@@ -30,14 +47,28 @@ class SectionType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     SECTION_TYPE_PUBLIC: _ClassVar[SectionType]
     SECTION_TYPE_SYSTEM: _ClassVar[SectionType]
 COLUMN_TYPE_UNSPECIFIED: ColumnType
-COLUMN_TYPE_FLOAT: ColumnType
+COLUMN_TYPE_SCALAR: ColumnType
 COLUMN_TYPE_IMAGE: ColumnType
 COLUMN_TYPE_AUDIO: ColumnType
 COLUMN_TYPE_TEXT: ColumnType
 COLUMN_TYPE_VIDEO: ColumnType
 COLUMN_TYPE_ECHARTS: ColumnType
+COLUMN_TYPE_OBJECT3D: ColumnType
+COLUMN_TYPE_MOLECULE: ColumnType
 COLUMN_CLASS_UNSPECIFIED: ColumnClass
 COLUMN_CLASS_CUSTOM: ColumnClass
+COLUMN_CLASS_SYSTEM: ColumnClass
+CHART_TYPE_UNSPECIFIED: ChartType
+CHART_TYPE_LINE: ChartType
+CHART_TYPE_BAR: ChartType
+CHART_TYPE_SCALAR: ChartType
+CHART_TYPE_IMAGE: ChartType
+CHART_TYPE_AUDIO: ChartType
+CHART_TYPE_TEXT: ChartType
+CHART_TYPE_VIDEO: ChartType
+CHART_TYPE_ECHARTS: ChartType
+CHART_TYPE_OBJECT3D: ChartType
+CHART_TYPE_MOLECULE: ChartType
 SECTION_TYPE_UNSPECIFIED: SectionType
 SECTION_TYPE_PINNED: SectionType
 SECTION_TYPE_HIDDEN: SectionType
@@ -53,7 +84,7 @@ class YRange(_message.Message):
     def __init__(self, min: _Optional[float] = ..., max: _Optional[float] = ...) -> None: ...
 
 class ColumnRecord(_message.Message):
-    __slots__ = ("column_class", "column_type", "column_key", "column_name", "section_name", "section_type", "y_range", "chart_index", "chart_name", "metric_name", "metric_colors")
+    __slots__ = ("column_class", "column_type", "column_key", "column_name", "section_name", "section_type", "y_range", "chart_index", "chart_name", "chart_type", "metric_name", "metric_colors")
     COLUMN_CLASS_FIELD_NUMBER: _ClassVar[int]
     COLUMN_TYPE_FIELD_NUMBER: _ClassVar[int]
     COLUMN_KEY_FIELD_NUMBER: _ClassVar[int]
@@ -63,6 +94,7 @@ class ColumnRecord(_message.Message):
     Y_RANGE_FIELD_NUMBER: _ClassVar[int]
     CHART_INDEX_FIELD_NUMBER: _ClassVar[int]
     CHART_NAME_FIELD_NUMBER: _ClassVar[int]
+    CHART_TYPE_FIELD_NUMBER: _ClassVar[int]
     METRIC_NAME_FIELD_NUMBER: _ClassVar[int]
     METRIC_COLORS_FIELD_NUMBER: _ClassVar[int]
     column_class: ColumnClass
@@ -74,6 +106,7 @@ class ColumnRecord(_message.Message):
     y_range: YRange
     chart_index: str
     chart_name: str
+    chart_type: ChartType
     metric_name: str
     metric_colors: _containers.RepeatedScalarFieldContainer[str]
-    def __init__(self, column_class: _Optional[_Union[ColumnClass, str]] = ..., column_type: _Optional[_Union[ColumnType, str]] = ..., column_key: _Optional[str] = ..., column_name: _Optional[str] = ..., section_name: _Optional[str] = ..., section_type: _Optional[_Union[SectionType, str]] = ..., y_range: _Optional[_Union[YRange, _Mapping]] = ..., chart_index: _Optional[str] = ..., chart_name: _Optional[str] = ..., metric_name: _Optional[str] = ..., metric_colors: _Optional[_Iterable[str]] = ...) -> None: ...
+    def __init__(self, column_class: _Optional[_Union[ColumnClass, str]] = ..., column_type: _Optional[_Union[ColumnType, str]] = ..., column_key: _Optional[str] = ..., column_name: _Optional[str] = ..., section_name: _Optional[str] = ..., section_type: _Optional[_Union[SectionType, str]] = ..., y_range: _Optional[_Union[YRange, _Mapping]] = ..., chart_index: _Optional[str] = ..., chart_name: _Optional[str] = ..., chart_type: _Optional[_Union[ChartType, str]] = ..., metric_name: _Optional[str] = ..., metric_colors: _Optional[_Iterable[str]] = ...) -> None: ...

--- a/swanlab/sdk/internal/core_python/api/upload.py
+++ b/swanlab/sdk/internal/core_python/api/upload.py
@@ -8,8 +8,7 @@
 from typing import Dict
 
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.internal.pkg import helper
-from swanlab.sdk.typings.core_python.api.upload import ConsoleMetrics
+from swanlab.sdk.typings.core_python.api.upload import MetricPayload, UploadLogMetrics
 
 
 def upload_conda(username: str, project: str, experiment_id: str, *, content: str) -> None:
@@ -21,10 +20,7 @@ def upload_conda(username: str, project: str, experiment_id: str, *, content: st
     :param experiment_id: 实验唯一标识符
     :param content: conda.yaml 的原始文本内容
     """
-    client.put(
-        f"/project/{username}/{project}/runs/{experiment_id}/profile",
-        helper.strip_none({"conda": content}),
-    )
+    client.put(f"/project/{username}/{project}/runs/{experiment_id}/profile", {"conda": content})
 
 
 def upload_requirements(username: str, project: str, experiment_id: str, *, content: str) -> None:
@@ -36,10 +32,7 @@ def upload_requirements(username: str, project: str, experiment_id: str, *, cont
     :param experiment_id: 实验唯一标识符
     :param content: requirements.txt 的原始文本内容
     """
-    client.put(
-        f"/project/{username}/{project}/runs/{experiment_id}/profile",
-        helper.strip_none({"requirements": content}),
-    )
+    client.put(f"/project/{username}/{project}/runs/{experiment_id}/profile", {"requirements": content})
 
 
 def upload_metadata(username: str, project: str, experiment_id: str, *, content: Dict) -> None:
@@ -51,10 +44,7 @@ def upload_metadata(username: str, project: str, experiment_id: str, *, content:
     :param experiment_id: 实验唯一标识符
     :param content: 元数据字典
     """
-    client.put(
-        f"/project/{username}/{project}/runs/{experiment_id}/profile",
-        helper.strip_none({"metadata": content}),
-    )
+    client.put(f"/project/{username}/{project}/runs/{experiment_id}/profile", {"metadata": content})
 
 
 def upload_config(username: str, project: str, experiment_id: str, *, content: Dict) -> None:
@@ -66,13 +56,10 @@ def upload_config(username: str, project: str, experiment_id: str, *, content: D
     :param experiment_id: 实验唯一标识符
     :param content: 配置字典，格式为 {key: {value, sort, desc}}
     """
-    client.put(
-        f"/project/{username}/{project}/runs/{experiment_id}/profile",
-        helper.strip_none({"config": content}),
-    )
+    client.put(f"/project/{username}/{project}/runs/{experiment_id}/profile", {"config": content})
 
 
-def upload_console(project_id: str, experiment_id: str, *, metrics: ConsoleMetrics) -> None:
+def upload_console(project_id: str, experiment_id: str, *, metrics: UploadLogMetrics) -> None:
     """
     上传控制台日志信息。
 
@@ -84,7 +71,7 @@ def upload_console(project_id: str, experiment_id: str, *, metrics: ConsoleMetri
     """
     if not metrics:
         return
-    data = {
+    data: MetricPayload = {
         "projectId": project_id,
         "experimentId": experiment_id,
         "type": "log",

--- a/swanlab/sdk/internal/core_python/api/upload.py
+++ b/swanlab/sdk/internal/core_python/api/upload.py
@@ -8,7 +8,7 @@
 from typing import Dict
 
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.typings.core_python.api.upload import MetricPayload, UploadLogMetrics
+from swanlab.sdk.typings.core_python.api.upload import UploadLogMetrics, UploadMetricPayload
 
 
 def upload_conda(username: str, project: str, experiment_id: str, *, content: str) -> None:
@@ -71,7 +71,7 @@ def upload_console(project_id: str, experiment_id: str, *, metrics: UploadLogMet
     """
     if not metrics:
         return
-    data: MetricPayload = {
+    data: UploadMetricPayload = {
         "projectId": project_id,
         "experimentId": experiment_id,
         "type": "log",

--- a/swanlab/sdk/internal/core_python/client/__init__.py
+++ b/swanlab/sdk/internal/core_python/client/__init__.py
@@ -5,9 +5,10 @@
 @description: SwanLab 运行时客户端，用于与 SwanLab API 进行交互
 """
 
-from typing import Optional, Union
+from typing import Optional
 
 from swanlab.sdk.internal.pkg import client, console
+from swanlab.sdk.typings.pkg.client import JSONBody, JSONDict
 
 __all__ = ["exists", "reset", "new", "get", "post", "put", "patch", "delete"]
 
@@ -50,19 +51,19 @@ def _get_client() -> client.Client:
     return _default_client
 
 
-def get(url: str, params: Optional[dict] = None, retries: Optional[int] = None):
+def get(url: str, params: Optional[JSONDict] = None, retries: Optional[int] = None):
     return _get_client().get(url, params=params, retries=retries)
 
 
-def post(url: str, data: Optional[Union[dict, list]] = None, retries: Optional[int] = None):
+def post(url: str, data: JSONBody = None, retries: Optional[int] = None):
     return _get_client().post(url, data=data, retries=retries)
 
 
-def put(url: str, data: Optional[dict] = None, retries: Optional[int] = None):
+def put(url: str, data: JSONBody = None, retries: Optional[int] = None):
     return _get_client().put(url, data=data, retries=retries)
 
 
-def patch(url: str, data: Optional[dict] = None, retries: Optional[int] = None):
+def patch(url: str, data: JSONBody = None, retries: Optional[int] = None):
     return _get_client().patch(url, data=data, retries=retries)
 
 

--- a/swanlab/sdk/internal/core_python/pkg/column/__init__.py
+++ b/swanlab/sdk/internal/core_python/pkg/column/__init__.py
@@ -1,0 +1,26 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2026/4/25 16:17
+@description: 列处理模块
+"""
+
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord
+from swanlab.sdk.internal.pkg import safe
+from swanlab.sdk.typings.core_python.api.upload import UploadColumn
+
+
+@safe.block(message="Failed to encode column record")
+def encode(record: ColumnRecord) -> UploadColumn:
+    """
+    将列记录编码为后端所需的格式（DTO）
+    """
+    ...
+
+
+@safe.block(message="Failed to decode column record")
+def decode(data: bytes):
+    """
+    将后端返回的数据解码为列记录
+    """
+    raise NotImplementedError("Waiting for resume feature")

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -22,7 +22,7 @@ from swanlab.sdk.internal.core_python.api.upload import (
     upload_requirements,
 )
 from swanlab.sdk.internal.pkg import adapter, console, safe
-from swanlab.sdk.typings.core_python.api.upload import ConsoleMetric, ConsoleMetrics
+from swanlab.sdk.typings.core_python.api.upload import UploadLog, UploadLogMetrics
 
 
 class HttpRecordSender:
@@ -76,11 +76,11 @@ class HttpRecordSender:
         if not console_records:
             return
         with safe.block(message="Failed to upload console logs, skipping"):
-            metrics: ConsoleMetrics = []
+            metrics: UploadLogMetrics = []
             for console_record in console_records:
                 if console_record.HasField("timestamp"):
                     create_time = console_record.timestamp.ToJsonString()
-                    metric: ConsoleMetric = {
+                    metric: UploadLog = {
                         "level": adapter.level[console_record.stream],
                         "epoch": self._console_epoch,
                         "message": console_record.line,

--- a/swanlab/sdk/internal/pkg/adapter/__init__.py
+++ b/swanlab/sdk/internal/pkg/adapter/__init__.py
@@ -34,6 +34,22 @@ state = BiMap(
 )
 """RunState 枚举适配器"""
 
+
+column = BiMap(
+    {
+        "FLOAT": ColumnType.COLUMN_TYPE_SCALAR,
+        "IMAGE": ColumnType.COLUMN_TYPE_IMAGE,
+        "AUDIO": ColumnType.COLUMN_TYPE_AUDIO,
+        "VIDEO": ColumnType.COLUMN_TYPE_VIDEO,
+        "TEXT": ColumnType.COLUMN_TYPE_TEXT,
+        "ECHARTS": ColumnType.COLUMN_TYPE_ECHARTS,
+        "OBJECT3D": ColumnType.COLUMN_TYPE_OBJECT3D,
+        "MOLECULE": ColumnType.COLUMN_TYPE_MOLECULE,
+    }
+)
+"""ColumnType 枚举适配器，映射本地proto枚举与云端类型枚举"""
+
+
 medium = BiMap(
     {
         "text": ColumnType.COLUMN_TYPE_TEXT,

--- a/swanlab/sdk/internal/pkg/client/__init__.py
+++ b/swanlab/sdk/internal/pkg/client/__init__.py
@@ -7,11 +7,12 @@
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import requests
 
 from swanlab.exceptions import AuthenticationError
+from swanlab.sdk.typings.pkg.client import JSONBody, JSONDict
 from swanlab.sdk.typings.pkg.client.bootstrap import LoginResponse
 
 from .. import console, helper, nrc, scope
@@ -95,16 +96,16 @@ class Client:
         resp = self._session.request(method, full_url, **kwargs)
         return ApiResponse(data=decode_response(resp), raw=resp)
 
-    def get(self, url: str, params: Optional[dict] = None, retries: Optional[int] = None):
+    def get(self, url: str, params: Optional[JSONDict] = None, retries: Optional[int] = None):
         return self.request("GET", url, params=params, retries=retries)
 
-    def post(self, url: str, data: Optional[Union[dict, list]] = None, retries: Optional[int] = None):
+    def post(self, url: str, data: JSONBody = None, retries: Optional[int] = None):
         return self.request("POST", url, json=data, retries=retries)
 
-    def put(self, url: str, data: Optional[dict] = None, retries: Optional[int] = None):
+    def put(self, url: str, data: JSONBody = None, retries: Optional[int] = None):
         return self.request("PUT", url, json=data, retries=retries)
 
-    def patch(self, url: str, data: Optional[dict] = None, retries: Optional[int] = None):
+    def patch(self, url: str, data: JSONBody = None, retries: Optional[int] = None):
         return self.request("PATCH", url, json=data, retries=retries)
 
     def delete(self, url: str, retries: Optional[int] = None):

--- a/swanlab/sdk/internal/run/components/builder/__init__.py
+++ b/swanlab/sdk/internal/run/components/builder/__init__.py
@@ -83,7 +83,7 @@ class RecordBuilder:
         section_type = SectionType.SECTION_TYPE_SYSTEM if event.system else SectionType.SECTION_TYPE_PUBLIC
         col = ColumnRecord(
             column_key=event.key,
-            column_type=ColumnType.COLUMN_TYPE_FLOAT,
+            column_type=ColumnType.COLUMN_TYPE_SCALAR,
             column_class=ColumnClass.COLUMN_CLASS_CUSTOM,
             section_name=event.chart_name or "",
             section_type=section_type,

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -190,7 +190,7 @@ class BackgroundConsumer(ConsumerProtocol):
                     self._media_batch.append(data_record)
 
     def _handle_scalar_define(self, event: ScalarDefineEvent) -> None:
-        defined = self._metrics.ensure_defined_as(event.key, ColumnType.COLUMN_TYPE_FLOAT)
+        defined = self._metrics.ensure_defined_as(event.key, ColumnType.COLUMN_TYPE_SCALAR)
         if defined:
             console.warning(f"Scalar Column '{event.key}' has already been defined, skip redefine.")
             return

--- a/swanlab/sdk/internal/run/transforms/scalar/__init__.py
+++ b/swanlab/sdk/internal/run/transforms/scalar/__init__.py
@@ -24,7 +24,7 @@ class Scalar(TransformData):
 
     @classmethod
     def column_type(cls) -> ColumnType:
-        return ColumnType.COLUMN_TYPE_FLOAT
+        return ColumnType.COLUMN_TYPE_SCALAR
 
     @classmethod
     def build_data_record(cls, *, key: str, step: int, timestamp: Timestamp, data: ScalarValue) -> ScalarRecord:

--- a/swanlab/sdk/typings/core_python/api/upload.py
+++ b/swanlab/sdk/typings/core_python/api/upload.py
@@ -5,17 +5,116 @@
 @description: 上传相关API
 """
 
-from typing import List, Literal, TypedDict
+import sys
+from typing import Any, Dict, List, Literal, TypedDict, Union
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, Required
+else:
+    from typing_extensions import NotRequired, Required
+
+# ============================================================
+# Column 列 DTO
+# ============================================================
 
 
-class ConsoleMetric(TypedDict):
+UploadColumn = TypedDict(
+    "UploadColumn",
+    {
+        # ---- 必填 ----
+        "class": Required[str],
+        "type": Required[str],
+        "key": Required[str],
+        # ---- 可选 ----
+        "name": NotRequired[str],
+        "error": NotRequired[Dict[str, Any]],
+        "sectionName": NotRequired[str],
+        "sectionType": NotRequired[str],
+        "yRange": NotRequired[Dict[str, Any]],
+        "chartName": NotRequired[str],
+        "chartIndex": NotRequired[int],
+        "metricName": NotRequired[str],
+        "metricColors": NotRequired[List[str]],
+    },
+)
+
+
+UploadColumns = List[UploadColumn]
+"""
+列指标
+"""
+
+
+# ============================================================
+# Console 日志 DTO
+# ============================================================
+
+
+class UploadLog(TypedDict):
     level: Literal["INFO", "ERROR"]
     epoch: int
     message: str
     create_time: str
 
 
-ConsoleMetrics = List[ConsoleMetric]
+UploadLogMetrics = List[UploadLog]
 """
 Console 日志指标
 """
+
+
+# ============================================================
+# Scalar 标量 DTO
+# ============================================================
+
+
+class UploadScalar(TypedDict):
+    """标量指标 DTO，对应 POST /house/metrics type="scalar" 的单条 metric"""
+
+    key: str
+    epoch: int
+    index: int
+    data: float
+    create_time: NotRequired[str]
+
+
+UploadScalarMetrics = List[UploadScalar]
+"""
+标量指标
+"""
+
+
+# ============================================================
+# Media 媒体 DTO
+# ============================================================
+
+
+class UploadMedia(TypedDict):
+    """媒体指标 DTO，对应 POST /house/metrics type="media" 的单条 metric"""
+
+    key: str
+    epoch: int
+    index: int
+    data: Union[str, List[str]]
+    more: NotRequired[Union[str, List[str]]]
+    create_time: NotRequired[str]
+
+
+UploadMediaMetrics = List[UploadMedia]
+"""
+媒体指标
+"""
+
+
+# ============================================================
+# /house/metrics 信封
+# ============================================================
+
+
+class MetricPayload(TypedDict):
+    """POST /house/metrics 请求体"""
+
+    projectId: str
+    experimentId: str
+    type: str
+    metrics: Union[UploadScalarMetrics, UploadMediaMetrics, UploadLogMetrics]

--- a/swanlab/sdk/typings/core_python/api/upload.py
+++ b/swanlab/sdk/typings/core_python/api/upload.py
@@ -78,7 +78,7 @@ class UploadScalar(TypedDict):
     create_time: NotRequired[str]
 
 
-UploadScalarMetrics = List[UploadScalar]
+UploadScalarBatch = List[UploadScalar]
 """
 标量指标
 """
@@ -100,7 +100,7 @@ class UploadMedia(TypedDict):
     create_time: NotRequired[str]
 
 
-UploadMediaMetrics = List[UploadMedia]
+UploadMediaBatch = List[UploadMedia]
 """
 媒体指标
 """
@@ -111,10 +111,10 @@ UploadMediaMetrics = List[UploadMedia]
 # ============================================================
 
 
-class MetricPayload(TypedDict):
+class UploadMetricPayload(TypedDict):
     """POST /house/metrics 请求体"""
 
     projectId: str
     experimentId: str
     type: str
-    metrics: Union[UploadScalarMetrics, UploadMediaMetrics, UploadLogMetrics]
+    metrics: Union[UploadScalarBatch, UploadMediaBatch, UploadLogMetrics]

--- a/swanlab/sdk/typings/core_python/api/upload.py
+++ b/swanlab/sdk/typings/core_python/api/upload.py
@@ -32,7 +32,7 @@ UploadColumn = TypedDict(
         "sectionType": NotRequired[str],
         "yRange": NotRequired[Dict[str, Any]],
         "chartName": NotRequired[str],
-        "chartIndex": NotRequired[int],
+        "chartIndex": NotRequired[str],
         "metricName": NotRequired[str],
         "metricColors": NotRequired[List[str]],
     },

--- a/swanlab/sdk/typings/pkg/client/__init__.py
+++ b/swanlab/sdk/typings/pkg/client/__init__.py
@@ -5,7 +5,14 @@
 @description: SwanLab 客户端模块的类型提示定义
 """
 
+import sys
 from collections.abc import Mapping, Sequence
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
 from typing import Any, TypeAlias, Union
 
 from .bootstrap import LoginResponse

--- a/swanlab/sdk/typings/pkg/client/__init__.py
+++ b/swanlab/sdk/typings/pkg/client/__init__.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-from typing import Any, TypeAlias, Union
+from typing import Any, Union
 
 from .bootstrap import LoginResponse
 

--- a/swanlab/sdk/typings/pkg/client/__init__.py
+++ b/swanlab/sdk/typings/pkg/client/__init__.py
@@ -4,3 +4,15 @@
 @time: 2026/4/14 00:48
 @description: SwanLab 客户端模块的类型提示定义
 """
+
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias, Union
+
+from .bootstrap import LoginResponse
+
+JSONDict: TypeAlias = Mapping[str, Any]
+JSONList: TypeAlias = Sequence[Any]
+JSONBody: TypeAlias = Union[JSONDict, JSONList, None]
+
+
+__all__ = ["JSONBody", "JSONDict", "JSONList", "LoginResponse"]

--- a/tests/unit/sdk/internal/core_python/transport/conftest.py
+++ b/tests/unit/sdk/internal/core_python/transport/conftest.py
@@ -19,7 +19,7 @@ def make_scalar_record():
                 key="train/loss",
                 step=step,
                 timestamp=timestamp,
-                type=ColumnType.COLUMN_TYPE_FLOAT,
+                type=ColumnType.COLUMN_TYPE_SCALAR,
                 value=ScalarValue(number=0.125),
             )
         )


### PR DESCRIPTION
## Summary

- 将 `ColumnType.COLUMN_TYPE_FLOAT` 重命名为 `COLUMN_TYPE_SCALAR`，语义更准确
- Proto 新增 `ChartType` 枚举（LINE/BAR/SCALAR/IMAGE/AUDIO/TEXT/VIDEO/ECHARTS/OBJECT3D/MOLECULE）
- Proto 新增 `ColumnClass.COLUMN_CLASS_SYSTEM`、`ColumnType.COLUMN_TYPE_OBJECT3D`/`MOLECULE`
- `ColumnRecord` 新增 `chart_type` 字段，`metric_name`/`metric_colors` 字段编号调整
- 新增上传 DTO 类型定义（`UploadScalar`、`UploadMedia`、`UploadColumn`、`MetricPayload`）
- 新增 `client` 模块类型定义（`ApiResponse`）
- 新增 `adapter.medium` / `adapter.level` 双向映射
- 新增 `core_python/pkg/column` 列处理模块 stub
- 更新 `upload_console` 对齐接口文档字段名（`message`/`create_time`）

## Test plan

- [x] `make unit` 全部通过
- [x] 验证 cloud 模式 init/finish 流程正常
- [ ] 验证 console 日志上传格式正确