### PR TITLE
Feat/cli-helper

### DIFF
--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -17,9 +17,9 @@ from .column import Column, Columns
 from .experiment import Experiment, Experiments
 from .project import Project, Projects
 from .selfhosted import SelfHosted
-from .typings.common import ApiColumnClassLiteral, ApiColumnDataTypeLiteral, PaginatedQuery
+from .typings.common import ApiColumnClassLiteral, ApiColumnDataTypeLiteral, ApiVisibilityLiteral, PaginatedQuery
 from .user import User
-from .utils import validate_api_path, validate_non_empty_string
+from .utils import validate_api_path, validate_non_empty_string, validate_project_name, validate_visibility
 from .workspace import Workspace, Workspaces
 
 
@@ -170,6 +170,28 @@ class Api(BaseEntity):
         validate_api_path(path, segments=1, label="workspace")
         query = PaginatedQuery(page=page, size=size, search=search, sort=sort, all=all)
         return Projects(self._ctx, path=path, query=query, detail=detail)
+
+    def create_project(
+        self,
+        username: Optional[str] = None,
+        name: str = "",
+        *,
+        visibility: ApiVisibilityLiteral = "PRIVATE",
+        description: Optional[str] = None,
+    ) -> Optional[Project]:
+        """
+        在指定工作空间下创建项目。
+
+        :param username: 工作空间用户名，为 None 时使用当前登录用户
+        :param name: 项目名称 (1-100 字符，仅支持 0-9a-zA-Z-_.+)
+        :param visibility: 可见性，PUBLIC 或 PRIVATE，默认 PRIVATE
+        :param description: 项目描述
+        """
+        if username is None:
+            username = self._ctx.username
+        validate_api_path(username, segments=1, label="workspace")
+        ws = Workspace(self._ctx, username=username)
+        return ws.create_project(name, visibility=visibility, description=description)
 
     def run(self, path: str) -> Experiment:
         """

--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -82,6 +82,11 @@ class Api(BaseEntity):
         """Api 非数据实体，返回空字典。"""
         return {}
 
+    @property
+    def username(self) -> str:
+        """当前认证用户的 username。"""
+        return self._ctx.username
+
     @staticmethod
     def _resolve_credentials(
         api_key: Optional[str],

--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -47,13 +47,12 @@ class Api(BaseEntity):
         self,
         api_key: Optional[str] = None,
         host: Optional[str] = None,
-        web_host: Optional[str] = None,
     ) -> None:
         """
         初始化 Api 实例。
 
         认证优先级：
-        1. 显式参数 (api_key / host / web_host)
+        1. 显式参数 (api_key / host)
         2. scope 登录态（进程内已调用 swanlab.login 时可用）
         3. Settings（含 .netrc / 环境变量）
 
@@ -61,11 +60,10 @@ class Api(BaseEntity):
 
         :param api_key: API 密钥，为 None 时从 Settings / .netrc / 环境变量读取
         :param host: API 主机地址，为 None 时从 Settings 读取
-        :param web_host: Web 面板地址，为 None 时从 Settings 读取
         """
         # 优先从 scope 获取已有登录态（如进程内已调用 swanlab.login），直接复用凭证
         login_resp = scope.get_context("login_resp")
-        api_key, api_host, web_host = self._resolve_credentials(api_key, host, web_host)
+        api_key, api_host, web_host = self._resolve_credentials(api_key, host)
         _client = Client(api_key=str(api_key), base_url=api_host)
 
         if login_resp is None:
@@ -91,7 +89,6 @@ class Api(BaseEntity):
     def _resolve_credentials(
         api_key: Optional[str],
         host: Optional[str],
-        web_host: Optional[str],
     ) -> tuple[str, str, str]:
         """
         按优先级解析凭证：显式参数 > scope 登录态 > Settings（含 .netrc / 环境变量）。
@@ -103,10 +100,14 @@ class Api(BaseEntity):
             raise AuthenticationError("No API key found. Please login with `swanlab login` or pass api_key parameter.")
         api_key = api_key.strip()
 
-        api_host: str = nrc.fmt(host) if host is not None else global_settings.api_host
-        resolved_web_host: str = nrc.fmt(web_host) if web_host is not None else global_settings.web_host
+        if host is not None:
+            api_host: str = nrc.fmt(host)
+            web_host: str = api_host
+        else:
+            api_host = global_settings.api_host
+            web_host = global_settings.web_host
 
-        return api_key, api_host, resolved_web_host
+        return api_key, api_host, web_host
 
     # ------------------------------------------------------------------
     #  实体工厂方法

--- a/swanlab/api/column.py
+++ b/swanlab/api/column.py
@@ -53,6 +53,8 @@ class Column(BaseEntity):
         project_id: Optional[str] = None,
         run_id: Optional[str] = None,
         project_id_getter: Optional[Callable[[], str]] = None,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
     ) -> None:
         super().__init__(ctx)
         self._proj_path, self._run_slug = resolve_run_path(path=path)
@@ -63,6 +65,8 @@ class Column(BaseEntity):
         self._project_id = project_id or (data or {}).get("project_id", "") or None
         self._run_id = run_id or (data or {}).get("run_id", "") or ""
         self._project_id_getter = project_id_getter
+        self._root_pro_id = root_pro_id
+        self._root_exp_id = root_exp_id
 
     def _ensure_data(self) -> ApiColumnType:
         if self._data is None:
@@ -170,6 +174,8 @@ class Column(BaseEntity):
             metric_type=metric_type,
             ignore_timestamp=ignore_timestamp,
             media_step=media_step,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
         )
         return metric.json()
 
@@ -186,6 +192,8 @@ class Column(BaseEntity):
             run_id=self.run_id,
             key=self.key,
             metric_type=metric_type,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
         )
         return metric.export_csv()
 
@@ -223,6 +231,8 @@ class Columns(BaseEntity):
         project_id: Optional[str] = None,
         run_id: Optional[str] = None,
         project_id_getter: Optional[Callable[[], str]] = None,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
     ) -> None:
         super().__init__(ctx)
         self._run_path = path
@@ -231,6 +241,8 @@ class Columns(BaseEntity):
         self._project_id = project_id
         self._project_id_getter = project_id_getter
         self._query = query
+        self._root_pro_id = root_pro_id
+        self._root_exp_id = root_exp_id
         # 校验 column_type 和 column_class 的合法性
         validate_column_params(column_type=column_type, column_class=column_class)
         self._column_class = column_class
@@ -281,6 +293,8 @@ class Columns(BaseEntity):
                 data=cast(ApiColumnType, data),
                 run_id=run_id,
                 project_id_getter=self._ensure_project_id,
+                root_pro_id=self._root_pro_id,
+                root_exp_id=self._root_exp_id,
             )
 
     @property

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -47,7 +47,7 @@ class Experiment(BaseEntity):
     ) -> None:
         super().__init__(ctx)
         self._proj_path, self._run_slug = resolve_run_path(path=path)
-        self._cuid: str = (data or {}).get("cuid", "") or self._run_slug
+        self._cuid: str = (data or {}).get("cuid", "")
         self._data: Optional[ApiExperimentType] = data
         self._project_id = ""
 
@@ -57,7 +57,7 @@ class Experiment(BaseEntity):
 
     def _ensure_data(self) -> ApiExperimentType:
         if self._data is None:
-            resp = self._get(f"/project/{self._proj_path}/runs/{self._cuid}")
+            resp = self._get(f"/project/{self._proj_path}/runs/{self._run_slug}")
             self._data = resp.data if resp.ok and resp.data else cast(ApiExperimentType, {})
         self._refresh_cuid()
         assert self._data is not None
@@ -184,12 +184,14 @@ class Experiment(BaseEntity):
         ignore_timestamp: bool = True,
         all: bool = False,
     ) -> Dict[str, Any]:
+        run_id = self.run_id
+        project_id = self.project_id
         from swanlab.api.metric import Metrics
 
         return Metrics(
             ctx=self._ctx,
-            project_id=self.project_id,
-            run_id=self.run_id,
+            project_id=project_id,
+            run_id=run_id,
             keys=keys,
             sample=sample,
             metric_type="SCALAR",
@@ -203,12 +205,14 @@ class Experiment(BaseEntity):
         step: Optional[int] = 0,
         all: bool = False,
     ) -> Dict[str, Any]:
+        run_id = self.run_id
+        project_id = self.project_id
         from swanlab.api.metric import Metrics
 
         return Metrics(
             ctx=self._ctx,
-            project_id=self.project_id,
-            run_id=self.run_id,
+            project_id=project_id,
+            run_id=run_id,
             keys=keys,
             metric_type="MEDIA",
             media_step=step,
@@ -221,12 +225,14 @@ class Experiment(BaseEntity):
         level: ApiMetricLogLevelLiteral = "INFO",
         ignore_timestamp: bool = True,
     ) -> Dict[str, Any]:
+        run_id = self.run_id
+        project_id = self.project_id
         from swanlab.api.metric import Metric
 
         logs = Metric(
             ctx=self._ctx,
-            project_id=self.project_id,
-            run_id=self.run_id,
+            project_id=project_id,
+            run_id=run_id,
             key="LOG",
             log_offset=offset,
             log_level=level,
@@ -254,6 +260,7 @@ class Experiment(BaseEntity):
         :param column_class: 列的分类，CUSTOM 或 SYSTEM
         :param all: 是否获取全部数据，默认 False
         """
+        self._ensure_data()
         from swanlab.api.column import Columns
 
         query = PaginatedQuery(page=page, size=size, search=search, all=all)

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -127,6 +127,14 @@ class Experiment(BaseEntity):
         return self._ensure_data().get("job", "")
 
     @property
+    def root_pro_id(self) -> str:
+        return self._ensure_data().get("rootProId", "")
+
+    @property
+    def root_exp_id(self) -> str:
+        return self._ensure_data().get("rootExpId", "")
+
+    @property
     def user(self) -> ApiUserType:
         user_data = self._ensure_data().get("user", {})
         return cast(ApiUserType, user_data)
@@ -175,6 +183,8 @@ class Experiment(BaseEntity):
             column_type=column_type,
             run_id=run_id,
             project_id_getter=lambda: self.project_id,
+            root_pro_id=self.root_pro_id,
+            root_exp_id=self.root_exp_id,
         )
 
     def metrics(
@@ -197,6 +207,8 @@ class Experiment(BaseEntity):
             metric_type="SCALAR",
             ignore_timestamp=ignore_timestamp,
             all=all,
+            root_pro_id=self.root_pro_id,
+            root_exp_id=self.root_exp_id,
         ).json()
 
     def medias(
@@ -217,6 +229,8 @@ class Experiment(BaseEntity):
             metric_type="MEDIA",
             media_step=step,
             all=all,
+            root_pro_id=self.root_pro_id,
+            root_exp_id=self.root_exp_id,
         ).json()
 
     def logs(
@@ -238,6 +252,8 @@ class Experiment(BaseEntity):
             log_level=level,
             metric_type="LOG",
             ignore_timestamp=ignore_timestamp,
+            root_pro_id=self.root_pro_id,
+            root_exp_id=self.root_exp_id,
         )
         return logs.json()
 
@@ -273,6 +289,8 @@ class Experiment(BaseEntity):
             column_class=column_class,
             run_id=run_id,
             project_id_getter=lambda: self.project_id,
+            root_pro_id=self.root_pro_id,
+            root_exp_id=self.root_exp_id,
         )
 
     def delete(self) -> bool:

--- a/swanlab/api/metric.py
+++ b/swanlab/api/metric.py
@@ -55,6 +55,8 @@ class Metric(BaseEntity):
         ignore_timestamp: bool = False,
         media_step: Optional[int] = None,
         all: bool = False,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
     ) -> None:
         super().__init__(ctx)
         validate_metric_type(metric_type, key)
@@ -73,6 +75,8 @@ class Metric(BaseEntity):
         self._log_level = log_level
         self._media_step = media_step
         self._all = all
+        self._root_pro_id = root_pro_id
+        self._root_exp_id = root_exp_id
 
     # 类型 → 加载方法 的分发表，新增类型只需在此注册
     _FETCH_DISPATCH = {
@@ -140,35 +144,66 @@ class Metric(BaseEntity):
         return None
 
     @staticmethod
-    def _build_scalar_payload(project_id: str, run_id: str, keys: List[str], sample: int = 1500) -> Dict[str, Any]:
+    def _build_column_ref(
+        experiment_id: str,
+        key: str,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
+    ) -> Dict[str, str]:
+        ref: Dict[str, str] = {"experimentId": experiment_id, "key": key}
+        if root_pro_id:
+            ref["rootProId"] = root_pro_id
+        if root_exp_id:
+            ref["rootExpId"] = root_exp_id
+        return ref
+
+    @staticmethod
+    def _build_scalar_payload(
+        project_id: str,
+        run_id: str,
+        keys: List[str],
+        sample: int = 1500,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
+    ) -> Dict[str, Any]:
         return {
             "projectId": project_id,
             "xType": "step",
             "range": [0, 0],
-            "columns": [{"experimentId": run_id, "key": key} for key in keys],
+            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id) for key in keys],
             "num": sample if sample <= 1500 else 1500,
         }
 
     @staticmethod
     def _build_media_payload(
-        project_id: str, run_id: str, keys: List[str], step: Optional[int] = None
+        project_id: str,
+        run_id: str,
+        keys: List[str],
+        step: Optional[int] = None,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "projectId": project_id,
-            "columns": [{"experimentId": run_id, "key": key} for key in keys],
+            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id) for key in keys],
         }
         if step is not None:
             payload["step"] = step
         return payload
 
     def _build_log_params(self) -> Dict[str, Any]:
-        return {
+        params: Dict[str, Any] = {
             "projectId": self.project_id,
             "experimentId": self.run_id,
-            "size": 1000,  # 硬编码为 1000
+            "size": 1000,
             "epoch": self._offset,
             "level": self._log_level,
         }
+        if self._root_pro_id:
+            params["rootProId"] = self._root_pro_id
+        if self._root_exp_id:
+            params["rootExpId"] = self._root_exp_id
+        return params
 
     # ------------------------------------------------------------------
     # 类型专属加载
@@ -176,7 +211,18 @@ class Metric(BaseEntity):
 
     def _fetch_scalar(self) -> ApiScalarSeriesType:
         res = ApiScalarSeriesType(projectId=self.project_id, experimentId=self.run_id, key=self.key)
-        payload = self._build_scalar_payload(self.project_id, self.run_id, [self.key], self._sample)
+        if self._root_pro_id:
+            res["rootProId"] = self._root_pro_id
+        if self._root_exp_id:
+            res["rootExpId"] = self._root_exp_id
+        payload = self._build_scalar_payload(
+            self.project_id,
+            self.run_id,
+            [self.key],
+            self._sample,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
 
         # 1. 获取折线数据
         raw_data = self._extract_first(self._post("/house/metrics/scalar", data=payload))
@@ -223,7 +269,14 @@ class Metric(BaseEntity):
 
     def _fetch_media(self) -> ApiMediaSeriesType:
         res = ApiMediaSeriesType(projectId=self.project_id, experimentId=self.run_id, key=self.key)
-        payload = self._build_media_payload(self.project_id, self.run_id, [self.key], step=self._media_step)
+        payload = self._build_media_payload(
+            self.project_id,
+            self.run_id,
+            [self.key],
+            step=self._media_step,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
         raw_resp = self._post("/house/metrics/media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
             return res
@@ -254,7 +307,13 @@ class Metric(BaseEntity):
 
     def _fetch_media_all(self) -> ApiMediaSeriesType:
         res = ApiMediaSeriesType(projectId=self.project_id, experimentId=self.run_id, key=self.key)
-        payload = self._build_media_payload(self.project_id, self.run_id, [self.key])
+        payload = self._build_media_payload(
+            self.project_id,
+            self.run_id,
+            [self.key],
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
         raw_resp = self._post("/house/metrics/f_media", data=payload)
         raw_data = self._extract_first(raw_resp)
         if raw_data is None:
@@ -359,6 +418,8 @@ class Metrics(BaseEntity):
         ignore_timestamp: bool = False,
         media_step: Optional[int] = None,
         all: bool = False,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
     ) -> None:
         super().__init__(ctx)
         validate_metric_keys(keys)
@@ -373,6 +434,8 @@ class Metrics(BaseEntity):
         self._ignore_timestamp = ignore_timestamp
         self._media_step = media_step
         self._all = all
+        self._root_pro_id = root_pro_id
+        self._root_exp_id = root_exp_id
         self._page_info: Dict[str, Any] = {
             "keys": keys,
             "metricType": metric_type,
@@ -409,10 +472,19 @@ class Metrics(BaseEntity):
             media_step=self._media_step,
             data=data,
             all=self._all,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
         )
 
     def _fetch_scalars(self) -> Iterator[Metric]:
-        payload = Metric._build_scalar_payload(self._project_id, self._run_id, self._keys, self._sample)
+        payload = Metric._build_scalar_payload(
+            self._project_id,
+            self._run_id,
+            self._keys,
+            self._sample,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
 
         # 1. 获取折线数据
         scalar_resp = self._post("/house/metrics/scalar", data=payload)
@@ -447,7 +519,14 @@ class Metrics(BaseEntity):
             if resp.ok and resp.data:
                 urls[key] = _extract_csv_url(resp.data)
 
-        payload = Metric._build_scalar_payload(self._project_id, self._run_id, self._keys, self._sample)
+        payload = Metric._build_scalar_payload(
+            self._project_id,
+            self._run_id,
+            self._keys,
+            self._sample,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
         value_resp = self._post("/house/metrics/scalar/value", data=payload)
         value_list: List[Dict[str, Any]] = value_resp.ok and isinstance(value_resp.data, list) and value_resp.data or []
 
@@ -466,7 +545,14 @@ class Metrics(BaseEntity):
             yield self._build_metric(key, data)
 
     def _fetch_medias(self) -> Iterator[Metric]:
-        payload = Metric._build_media_payload(self._project_id, self._run_id, self._keys, step=self._media_step)
+        payload = Metric._build_media_payload(
+            self._project_id,
+            self._run_id,
+            self._keys,
+            step=self._media_step,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
         raw_resp = self._post("/house/metrics/media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
             return
@@ -503,7 +589,13 @@ class Metrics(BaseEntity):
             yield self._build_metric(key, data)
 
     def _fetch_medias_all(self) -> Iterator[Metric]:
-        payload = Metric._build_media_payload(self._project_id, self._run_id, self._keys)
+        payload = Metric._build_media_payload(
+            self._project_id,
+            self._run_id,
+            self._keys,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
         raw_resp = self._post("/house/metrics/f_media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
             return

--- a/swanlab/api/selfhosted.py
+++ b/swanlab/api/selfhosted.py
@@ -5,7 +5,7 @@
 @description: SelfHosted 实体类 — 私有化部署实例的查询与管理
 """
 
-from typing import Any, Dict, Iterator, Optional, cast
+from typing import Any, Dict, Optional, cast
 
 from swanlab.api.base import ApiClientContext, BaseEntity
 from swanlab.api.typings.common import ApiResponseType, PaginatedQuery
@@ -81,13 +81,16 @@ class SelfHosted(BaseEntity):
         :param username: 待创建用户名
         :param password: 待创建用户密码
         """
-        SelfHosted.validate_root(self._ensure_data())
-        validate_non_empty_string(username, label="username")
-        validate_non_empty_string(password, label="password")
+        try:
+            SelfHosted.validate_root(self._ensure_data())
+            validate_non_empty_string(username, label="username")
+            validate_non_empty_string(password, label="password")
+        except ValueError as e:
+            return ApiResponseType(ok=False, errmsg=str(e))
         data = {"users": [{"username": username, "password": password}]}
         return self._post("/self_hosted/users", data=data)
 
-    def get_users(self, page: int = 1, size: int = 20, all: bool = False) -> Iterator[dict]:
+    def get_users(self, page: int = 1, size: int = 20, all: bool = False) -> ApiResponseType:
         """
         分页获取用户（管理员限定）。
 
@@ -95,10 +98,14 @@ class SelfHosted(BaseEntity):
         :param size: 每页大小，默认 20
         :param all: 是否获取全部数据，默认 False
         """
-        SelfHosted.validate_root(self._ensure_data())
+        try:
+            SelfHosted.validate_root(self._ensure_data())
+        except ValueError as e:
+            return ApiResponseType(ok=False, errmsg=str(e))
         query = PaginatedQuery(page=page, size=size, all=all)
         page_info: Dict[str, Any] = {"total": 0, "pages": 0}
-        yield from self._paginate("/self_hosted/users", query, page_info=page_info)
+        users = list(self._paginate("/self_hosted/users", query, page_info=page_info))
+        return ApiResponseType(ok=True, data={"list": users, **page_info})
 
     def json(self) -> Dict[str, Any]:
         return get_properties(self)

--- a/swanlab/api/selfhosted.py
+++ b/swanlab/api/selfhosted.py
@@ -5,7 +5,7 @@
 @description: SelfHosted 实体类 — 私有化部署实例的查询与管理
 """
 
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Iterator, Optional, cast
 
 from swanlab.api.base import ApiClientContext, BaseEntity
 from swanlab.api.typings.common import ApiResponseType, PaginatedQuery
@@ -81,16 +81,13 @@ class SelfHosted(BaseEntity):
         :param username: 待创建用户名
         :param password: 待创建用户密码
         """
-        try:
-            SelfHosted.validate_root(self._ensure_data())
-            validate_non_empty_string(username, label="username")
-            validate_non_empty_string(password, label="password")
-        except ValueError as e:
-            return ApiResponseType(ok=False, errmsg=str(e))
+        SelfHosted.validate_root(self._ensure_data())
+        validate_non_empty_string(username, label="username")
+        validate_non_empty_string(password, label="password")
         data = {"users": [{"username": username, "password": password}]}
         return self._post("/self_hosted/users", data=data)
 
-    def get_users(self, page: int = 1, size: int = 20, all: bool = False) -> ApiResponseType:
+    def get_users(self, page: int = 1, size: int = 20, all: bool = False) -> Iterator[dict]:
         """
         分页获取用户（管理员限定）。
 
@@ -98,14 +95,10 @@ class SelfHosted(BaseEntity):
         :param size: 每页大小，默认 20
         :param all: 是否获取全部数据，默认 False
         """
-        try:
-            SelfHosted.validate_root(self._ensure_data())
-        except ValueError as e:
-            return ApiResponseType(ok=False, errmsg=str(e))
+        SelfHosted.validate_root(self._ensure_data())
         query = PaginatedQuery(page=page, size=size, all=all)
         page_info: Dict[str, Any] = {"total": 0, "pages": 0}
-        users = list(self._paginate("/self_hosted/users", query, page_info=page_info))
-        return ApiResponseType(ok=True, data={"list": users, **page_info})
+        yield from self._paginate("/self_hosted/users", query, page_info=page_info)
 
     def json(self) -> Dict[str, Any]:
         return get_properties(self)

--- a/swanlab/api/typings/experiment.py
+++ b/swanlab/api/typings/experiment.py
@@ -93,3 +93,5 @@ class ApiExperimentType(TypedDict, total=False):
     cluster: str
     job: str
     user: ApiUserType
+    rootProId: str
+    rootExpId: str

--- a/swanlab/api/workspace.py
+++ b/swanlab/api/workspace.py
@@ -12,7 +12,6 @@ from swanlab.api.typings.common import ApiVisibilityLiteral, PaginatedQuery
 from swanlab.api.typings.project import ApiProjectType
 from swanlab.api.typings.workspace import ApiWorkspaceLiteral, ApiWorkspaceProfileType, ApiWorkspaceType
 from swanlab.api.utils import get_properties, strip_dict, validate_project_name, validate_visibility
-from swanlab.sdk.internal.pkg import safe
 
 if TYPE_CHECKING:
     from swanlab.api.project import Project
@@ -99,20 +98,18 @@ class Workspace(BaseEntity):
         """
         from swanlab.api.project import Project
 
-        with safe.block(message=None):
-            validate_project_name(name)
-            validate_visibility(visibility)
+        validate_project_name(name)
+        validate_visibility(visibility)
 
-            body: Dict[str, Any] = {"name": name, "visibility": visibility, "username": self.username}
-            if description:
-                body["description"] = description
-            resp = self._post("/project", data=body)
-            if not resp.ok:
-                return None
-            data = resp.data
-            path = data.get("path", "")
-            return Project(self._ctx, path=path, data=cast(ApiProjectType, data))
-        return None
+        body: Dict[str, Any] = {"name": name, "visibility": visibility, "username": self.username}
+        if description is not None:
+            body["description"] = description
+        resp = self._post("/project", data=body)
+        if not resp.ok:
+            return None
+        data = resp.data
+        path = data.get("path", "")
+        return Project(self._ctx, path=path, data=cast(ApiProjectType, data))
 
     def json(self) -> Dict[str, Any]:
         return get_properties(self)

--- a/swanlab/cli/api/__init__.py
+++ b/swanlab/cli/api/__init__.py
@@ -7,7 +7,7 @@
 
 import click
 
-from .experiment import experiment_cli
+from .experiment import run_cli
 from .project import project_cli
 from .selfhosted import selfhosted_cli
 from .workspace import workspace_cli
@@ -20,7 +20,7 @@ def api_cli():
 
 
 api_cli.add_command(project_cli)
-api_cli.add_command(experiment_cli)
+api_cli.add_command(run_cli)
 api_cli.add_command(workspace_cli)
 api_cli.add_command(selfhosted_cli)
 

--- a/swanlab/cli/api/__init__.py
+++ b/swanlab/cli/api/__init__.py
@@ -10,6 +10,7 @@ import click
 from .experiment import run_cli
 from .project import project_cli
 from .selfhosted import selfhosted_cli
+from .user import user_cli
 from .workspace import workspace_cli
 
 
@@ -23,6 +24,7 @@ api_cli.add_command(project_cli)
 api_cli.add_command(run_cli)
 api_cli.add_command(workspace_cli)
 api_cli.add_command(selfhosted_cli)
+api_cli.add_command(user_cli)
 
 
 __all__ = ["api_cli"]

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -72,3 +72,72 @@ def list_experiments(page_num: int, page_size: int, project_path: str, fetch_all
     format_output(resp)
     if resp.ok and name is not None:
         save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+
+
+@experiment_cli.command("columns")
+@click.argument("path", required=True)
+@click.option(
+    "--page_num",
+    "--page-num",
+    "-n",
+    default=1,
+    type=int,
+    help="Page number.",
+)
+@click.option(
+    "--page_size",
+    "--page-size",
+    "-s",
+    default=20,
+    type=int,
+    help="Page size.",
+)
+@click.option(
+    "--class",
+    "column_class",
+    default="CUSTOM",
+    type=str,
+    help="Column class, such as CUSTOM or SYSTEM.",
+)
+@click.option(
+    "--type",
+    "column_type",
+    default=None,
+    type=str,
+    help="Column type, such as IMAGE, FLOAT, or STRING.",
+)
+@click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
+@click.option(
+    "--save",
+    "name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def list_experiment_columns(
+    path: str,
+    page_num: int,
+    page_size: int,
+    column_class: str,
+    column_type: str,
+    fetch_all: bool,
+    name,
+    api,
+):
+    """List columns under an experiment."""
+    resp = ApiResponseType(
+        ok=True,
+        data=api.columns(
+            path=path,
+            page=page_num,
+            size=page_size,
+            column_class=column_class,
+            column_type=column_type,
+            all=fetch_all,
+        ),
+    )
+    format_output(resp)
+    if resp.ok and name is not None:
+        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -41,7 +41,6 @@ def get_experiment(path: str, save_name: str, api: Api):
 @run_cli.command("list")
 @click.option(
     "--page_num",
-    "--page-num",
     "-n",
     default=1,
     type=click.IntRange(min=1),
@@ -49,7 +48,6 @@ def get_experiment(path: str, save_name: str, api: Api):
 )
 @click.option(
     "--page_size",
-    "--page-size",
     "-s",
     default="20",
     type=PAGE_SIZE_TYPE,
@@ -57,7 +55,6 @@ def get_experiment(path: str, save_name: str, api: Api):
 )
 @click.option(
     "--project_path",
-    "--project-path",
     "-p",
     required=True,
     type=str,
@@ -87,7 +84,6 @@ def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all
 @click.argument("path", required=True)
 @click.option(
     "--page_num",
-    "--page-num",
     "-n",
     default=1,
     type=click.IntRange(min=1),
@@ -95,7 +91,6 @@ def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all
 )
 @click.option(
     "--page_size",
-    "--page-size",
     "-s",
     default="20",
     type=PAGE_SIZE_TYPE,

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -26,9 +26,9 @@ def experiment_cli():
 def get_experiment(path: str, name, api):
     """Get Experiment(Run) info by path (username/project/run_id)."""
     resp = api.run(path).wrapper()
-    format_output(resp)
-    if resp.ok and name is not None:
-        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+    payload = format_output(resp)
+    if payload["ok"] and name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
 
 
 @experiment_cli.command("list")
@@ -69,9 +69,9 @@ def get_experiment(path: str, name, api):
 def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all: bool, name, api):
     """List experiments under a project."""
     resp = ApiResponseType(ok=True, data=api.runs_get(path=project_path, page=page_num, size=int(page_size), all=fetch_all))
-    format_output(resp)
-    if resp.ok and name is not None:
-        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+    payload = format_output(resp)
+    if payload["ok"] and name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
 
 
 @experiment_cli.command("columns")
@@ -138,6 +138,6 @@ def list_experiment_columns(
             all=fetch_all,
         ),
     )
-    format_output(resp)
-    if resp.ok and name is not None:
-        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+    payload = format_output(resp)
+    if payload["ok"] and name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -33,7 +33,7 @@ def run_cli():
 )
 @with_custom_host
 def get_experiment(path: str, save_name: str, api: Api):
-    """Get Experiment(Run) info by path (username/project/run_id)."""
+    """Get Experiment(Run) info by path (e.g. username/project_name/run_id)."""
     resp = api.run(path).wrapper()
     payload = format_output(resp)
     if payload["ok"] and save_name is not None:
@@ -60,7 +60,7 @@ def get_experiment(path: str, save_name: str, api: Api):
     "-p",
     required=True,
     type=str,
-    help="Project path, like username/project_name.",
+    help="Project path (e.g. username/project_name).",
 )
 @click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
 @click.option(
@@ -73,7 +73,7 @@ def get_experiment(path: str, save_name: str, api: Api):
 )
 @with_custom_host
 def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all: bool, save_name: str, api: Api):
-    """List experiments under a project."""
+    """List experiments under a project by project path (e.g. username/project_name)."""
     resp = ApiResponseType(
         ok=True, data=api.runs_get(path=project_path, page=page_num, size=int(page_size), all=fetch_all)
     )
@@ -132,7 +132,7 @@ def list_experiment_columns(
     save_name: str,
     api: Api,
 ):
-    """List columns under an experiment."""
+    """List columns under an experiment by path (e.g. username/project_name/run_id)."""
     resp = ApiResponseType(
         ok=True,
         data=api.columns(
@@ -190,11 +190,63 @@ def get_experiment_metrics(
     save_name: str,
     api: Api,
 ):
-    """Get scalar metrics of an experiment by path (username/project/run_id)."""
+    """Get scalar metrics of an experiment by path (e.g. username/project_name/run_id)."""
     key_list = parse_keys(keys)
     experiment = api.run(path)
     data = experiment.metrics(keys=key_list, sample=sample, ignore_timestamp=ignore_timestamp, all=fetch_all)
     payload = format_output(ApiResponseType(ok=True, data=data))
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@run_cli.command("column")
+@click.argument("path", required=True)
+@click.option(
+    "--key",
+    required=True,
+    type=str,
+    help="Column key name.",
+)
+@click.option(
+    "--class",
+    "column_class",
+    default="CUSTOM",
+    type=COLUMN_CLASS_TYPE,
+    help="Column class, such as CUSTOM or SYSTEM.",
+)
+@click.option(
+    "--type",
+    "column_type",
+    default=None,
+    type=COLUMN_DATA_TYPE,
+    help="Column type, such as IMAGE, FLOAT, or STRING.",
+)
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def get_experiment_column(
+    path: str,
+    key: str,
+    column_class: str,
+    column_type: str,
+    save_name: str,
+    api: Api,
+):
+    """Get column info of an experiment by path (e.g. username/project_name/run_id)."""
+    col = api.column(
+        path=path,
+        key=key,
+        column_class=column_class.upper(),  # type: ignore
+        column_type=column_type.upper() if column_type else None,  # type: ignore
+    )
+    resp = col.wrapper()
+    payload = format_output(resp)
     if payload["ok"] and save_name is not None:
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
 
@@ -232,7 +284,7 @@ def get_experiment_medias(
     save_name: str,
     api: Api,
 ):
-    """Get media metrics of an experiment by path (username/project/run_id)."""
+    """Get media metrics of an experiment by path (e.g. username/project_name/run_id)."""
     key_list = parse_keys(keys)
     experiment = api.run(path)
     data = experiment.medias(keys=key_list, step=step, all=fetch_all)
@@ -281,7 +333,7 @@ def get_experiment_logs(
     save_name: str,
     api: Api,
 ):
-    """Get console logs of an experiment by path (username/project/run_id)."""
+    """Get console logs of an experiment by path (e.g. username/project_name/run_id)."""
     experiment = api.run(path)
     data = experiment.logs(offset=offset, level=level.upper(), ignore_timestamp=ignore_timestamp)  # type: ignore
     payload = format_output(ApiResponseType(ok=True, data=data))

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -23,8 +23,7 @@ def run_cli():
 @click.argument("path", required=True)
 @click.option(
     "--save",
-    "-s",
-    "name",
+    "save_name",
     is_flag=False,
     flag_value=".",
     default=None,
@@ -67,7 +66,7 @@ def get_experiment(path: str, save_name: str, api: Api):
 @click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
 @click.option(
     "--save",
-    "name",
+    "save_name",
     is_flag=False,
     flag_value=".",
     default=None,
@@ -119,7 +118,7 @@ def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all
 @click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
 @click.option(
     "--save",
-    "name",
+    "save_name",
     is_flag=False,
     flag_value=".",
     default=None,

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -12,13 +12,13 @@ from swanlab.cli.api.helper import (
 )
 
 
-@click.group("experiment")
-def experiment_cli():
+@click.group("run")
+def run_cli():
     """Experiment(Run) management commands."""
     pass
 
 
-@experiment_cli.command("info")
+@run_cli.command("info")
 @click.argument("path", required=True)
 @click.option(
     "--save",
@@ -38,7 +38,7 @@ def get_experiment(path: str, name, api):
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
 
 
-@experiment_cli.command("list")
+@run_cli.command("list")
 @click.option(
     "--page_num",
     "--page-num",
@@ -75,13 +75,15 @@ def get_experiment(path: str, name, api):
 @with_custom_host
 def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all: bool, name, api):
     """List experiments under a project."""
-    resp = ApiResponseType(ok=True, data=api.runs_get(path=project_path, page=page_num, size=int(page_size), all=fetch_all))
+    resp = ApiResponseType(
+        ok=True, data=api.runs_get(path=project_path, page=page_num, size=int(page_size), all=fetch_all)
+    )
     payload = format_output(resp)
     if payload["ok"] and name is not None:
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
 
 
-@experiment_cli.command("columns")
+@run_cli.command("columns")
 @click.argument("path", required=True)
 @click.option(
     "--page_num",

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -1,7 +1,8 @@
 import click
 import orjson
 
-from swanlab.cli.api.helper import format_output, save_output, with_custom_host
+from swanlab.api import Api
+from swanlab.cli.api.helper import format_output, save_output
 
 
 @click.group("run")
@@ -21,9 +22,9 @@ def experiment_cli():
     default=None,
     help="Save output as JSON to current directory.",
 )
-@with_custom_host
-def get_experiment(path: str, name, api):
+def get_experiment(path: str, name):
     """Get Experiment(Run) info by path (username/project/run_id)."""
+    api = Api()
     resp = api.run(path).wrapper()
     format_output(resp)
     if resp.ok and name is not None:

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -2,7 +2,14 @@ import click
 import orjson
 
 from swanlab.api.typings.common import ApiResponseType
-from swanlab.cli.api.helper import PAGE_SIZE_TYPE, format_output, save_output, with_custom_host
+from swanlab.cli.api.helper import (
+    COLUMN_CLASS_TYPE,
+    COLUMN_DATA_TYPE,
+    PAGE_SIZE_TYPE,
+    format_output,
+    save_output,
+    with_custom_host,
+)
 
 
 @click.group("experiment")
@@ -96,14 +103,14 @@ def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all
     "--class",
     "column_class",
     default="CUSTOM",
-    type=str,
+    type=COLUMN_CLASS_TYPE,
     help="Column class, such as CUSTOM or SYSTEM.",
 )
 @click.option(
     "--type",
     "column_type",
     default=None,
-    type=str,
+    type=COLUMN_DATA_TYPE,
     help="Column type, such as IMAGE, FLOAT, or STRING.",
 )
 @click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
@@ -133,8 +140,8 @@ def list_experiment_columns(
             path=path,
             page=page_num,
             size=int(page_size),
-            column_class=column_class,
-            column_type=column_type,
+            column_class=column_class.upper(),
+            column_type=column_type.upper() if column_type else None,
             all=fetch_all,
         ),
     )

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -1,8 +1,7 @@
 import click
 import orjson
 
-from swanlab.api import Api
-from swanlab.cli.api.helper import format_output, save_output
+from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
 @click.group("run")
@@ -22,9 +21,9 @@ def experiment_cli():
     default=None,
     help="Save output as JSON to current directory.",
 )
-def get_experiment(path: str, name):
+@with_custom_host
+def get_experiment(path: str, name, api):
     """Get Experiment(Run) info by path (username/project/run_id)."""
-    api = Api()
     resp = api.run(path).wrapper()
     format_output(resp)
     if resp.ok and name is not None:

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -6,8 +6,10 @@ from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import (
     COLUMN_CLASS_TYPE,
     COLUMN_DATA_TYPE,
+    METRIC_LOG_LEVEL_TYPE,
     PAGE_SIZE_TYPE,
     format_output,
+    parse_keys,
     save_output,
     with_custom_host,
 )
@@ -143,5 +145,145 @@ def list_experiment_columns(
         ),
     )
     payload = format_output(resp)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@run_cli.command("metrics")
+@click.argument("path", required=True)
+@click.option(
+    "--keys",
+    required=True,
+    type=str,
+    help="Comma-separated metric keys, e.g. 'loss,acc'.",
+)
+@click.option(
+    "--sample",
+    "-s",
+    default=1500,
+    type=click.IntRange(min=1),
+    help="Sample size for scalar metrics. Default 1500.",
+)
+@click.option(
+    "--ignore-timestamp",
+    "ignore_timestamp",
+    is_flag=True,
+    default=False,
+    help="Remove timestamp from metric data.",
+)
+@click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all data (CSV export for scalars).")
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def get_experiment_metrics(
+    path: str,
+    keys: str,
+    sample: int,
+    ignore_timestamp: bool,
+    fetch_all: bool,
+    save_name: str,
+    api: Api,
+):
+    """Get scalar metrics of an experiment by path (username/project/run_id)."""
+    key_list = parse_keys(keys)
+    experiment = api.run(path)
+    data = experiment.metrics(keys=key_list, sample=sample, ignore_timestamp=ignore_timestamp, all=fetch_all)
+    payload = format_output(ApiResponseType(ok=True, data=data))
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@run_cli.command("medias")
+@click.argument("path", required=True)
+@click.option(
+    "--keys",
+    required=True,
+    type=str,
+    help="Comma-separated media keys, e.g. 'image,audio'.",
+)
+@click.option(
+    "--step",
+    "-s",
+    default=0,
+    type=int,
+    help="Step number for media data. Default 0.",
+)
+@click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all media steps.")
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def get_experiment_medias(
+    path: str,
+    keys: str,
+    step: int,
+    fetch_all: bool,
+    save_name: str,
+    api: Api,
+):
+    """Get media metrics of an experiment by path (username/project/run_id)."""
+    key_list = parse_keys(keys)
+    experiment = api.run(path)
+    data = experiment.medias(keys=key_list, step=step, all=fetch_all)
+    payload = format_output(ApiResponseType(ok=True, data=data))
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@run_cli.command("logs")
+@click.argument("path", required=True)
+@click.option(
+    "--offset",
+    "-o",
+    default=0,
+    type=int,
+    help="Log offset (shard index). Default 0.",
+)
+@click.option(
+    "--level",
+    "-l",
+    default="INFO",
+    type=METRIC_LOG_LEVEL_TYPE,
+    help="Log level: DEBUG, INFO, WARN, ERROR. Default INFO.",
+)
+@click.option(
+    "--ignore-timestamp",
+    "ignore_timestamp",
+    is_flag=True,
+    default=False,
+    help="Remove timestamp from log data.",
+)
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def get_experiment_logs(
+    path: str,
+    offset: int,
+    level: str,
+    ignore_timestamp: bool,
+    save_name: str,
+    api: Api,
+):
+    """Get console logs of an experiment by path (username/project/run_id)."""
+    experiment = api.run(path)
+    data = experiment.logs(offset=offset, level=level.upper(), ignore_timestamp=ignore_timestamp)  # type: ignore
+    payload = format_output(ApiResponseType(ok=True, data=data))
     if payload["ok"] and save_name is not None:
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -2,7 +2,7 @@ import click
 import orjson
 
 from swanlab.api.typings.common import ApiResponseType
-from swanlab.cli.api.helper import format_output, save_output, with_custom_host
+from swanlab.cli.api.helper import PAGE_SIZE_TYPE, format_output, save_output, with_custom_host
 
 
 @click.group("experiment")
@@ -37,15 +37,15 @@ def get_experiment(path: str, name, api):
     "--page-num",
     "-n",
     default=1,
-    type=int,
+    type=click.IntRange(min=1),
     help="Page number.",
 )
 @click.option(
     "--page_size",
     "--page-size",
     "-s",
-    default=20,
-    type=int,
+    default="20",
+    type=PAGE_SIZE_TYPE,
     help="Page size.",
 )
 @click.option(
@@ -66,9 +66,9 @@ def get_experiment(path: str, name, api):
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def list_experiments(page_num: int, page_size: int, project_path: str, fetch_all: bool, name, api):
+def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all: bool, name, api):
     """List experiments under a project."""
-    resp = ApiResponseType(ok=True, data=api.runs_get(path=project_path, page=page_num, size=page_size, all=fetch_all))
+    resp = ApiResponseType(ok=True, data=api.runs_get(path=project_path, page=page_num, size=int(page_size), all=fetch_all))
     format_output(resp)
     if resp.ok and name is not None:
         save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
@@ -81,15 +81,15 @@ def list_experiments(page_num: int, page_size: int, project_path: str, fetch_all
     "--page-num",
     "-n",
     default=1,
-    type=int,
+    type=click.IntRange(min=1),
     help="Page number.",
 )
 @click.option(
     "--page_size",
     "--page-size",
     "-s",
-    default=20,
-    type=int,
+    default="20",
+    type=PAGE_SIZE_TYPE,
     help="Page size.",
 )
 @click.option(
@@ -119,7 +119,7 @@ def list_experiments(page_num: int, page_size: int, project_path: str, fetch_all
 def list_experiment_columns(
     path: str,
     page_num: int,
-    page_size: int,
+    page_size: str,
     column_class: str,
     column_type: str,
     fetch_all: bool,
@@ -132,7 +132,7 @@ def list_experiment_columns(
         data=api.columns(
             path=path,
             page=page_num,
-            size=page_size,
+            size=int(page_size),
             column_class=column_class,
             column_type=column_type,
             all=fetch_all,

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -1,10 +1,11 @@
 import click
 import orjson
 
+from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
-@click.group("run")
+@click.group("experiment")
 def experiment_cli():
     """Experiment(Run) management commands."""
     pass
@@ -25,6 +26,49 @@ def experiment_cli():
 def get_experiment(path: str, name, api):
     """Get Experiment(Run) info by path (username/project/run_id)."""
     resp = api.run(path).wrapper()
+    format_output(resp)
+    if resp.ok and name is not None:
+        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+
+
+@experiment_cli.command("list")
+@click.option(
+    "--page_num",
+    "--page-num",
+    "-n",
+    default=1,
+    type=int,
+    help="Page number.",
+)
+@click.option(
+    "--page_size",
+    "--page-size",
+    "-s",
+    default=20,
+    type=int,
+    help="Page size.",
+)
+@click.option(
+    "--project_path",
+    "--project-path",
+    "-p",
+    required=True,
+    type=str,
+    help="Project path, like username/project_name.",
+)
+@click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
+@click.option(
+    "--save",
+    "name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def list_experiments(page_num: int, page_size: int, project_path: str, fetch_all: bool, name, api):
+    """List experiments under a project."""
+    resp = ApiResponseType(ok=True, data=api.runs_get(path=project_path, page=page_num, size=page_size, all=fetch_all))
     format_output(resp)
     if resp.ok and name is not None:
         save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -1,6 +1,7 @@
 import click
 import orjson
 
+from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import (
     COLUMN_CLASS_TYPE,
@@ -30,12 +31,12 @@ def run_cli():
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def get_experiment(path: str, name, api):
+def get_experiment(path: str, save_name: str, api: Api):
     """Get Experiment(Run) info by path (username/project/run_id)."""
     resp = api.run(path).wrapper()
     payload = format_output(resp)
-    if payload["ok"] and name is not None:
-        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
 
 
 @run_cli.command("list")
@@ -73,14 +74,14 @@ def get_experiment(path: str, name, api):
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all: bool, name, api):
+def list_experiments(page_num: int, page_size: str, project_path: str, fetch_all: bool, save_name: str, api: Api):
     """List experiments under a project."""
     resp = ApiResponseType(
         ok=True, data=api.runs_get(path=project_path, page=page_num, size=int(page_size), all=fetch_all)
     )
     payload = format_output(resp)
-    if payload["ok"] and name is not None:
-        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
 
 
 @run_cli.command("columns")
@@ -132,8 +133,8 @@ def list_experiment_columns(
     column_class: str,
     column_type: str,
     fetch_all: bool,
-    name,
-    api,
+    save_name: str,
+    api: Api,
 ):
     """List columns under an experiment."""
     resp = ApiResponseType(
@@ -142,11 +143,11 @@ def list_experiment_columns(
             path=path,
             page=page_num,
             size=int(page_size),
-            column_class=column_class.upper(),
-            column_type=column_type.upper() if column_type else None,
+            column_class=column_class.upper(),  # type: ignore
+            column_type=column_type.upper() if column_type else None,  # type: ignore
             all=fetch_all,
         ),
     )
     payload = format_output(resp)
-    if payload["ok"] and name is not None:
-        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -1,16 +1,53 @@
 import enum
 from datetime import datetime
-from typing import Optional
+from functools import wraps
+from typing import Callable, Optional
 
 import click
 import nanoid
 import orjson
 
+from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
 
 
 class _SaveFormatEnum(enum.Enum):
     JSON = "json"
+
+
+def with_custom_host(func: Callable) -> Callable:
+    """
+    Add common SwanLab API host/auth options to a CLI command.
+
+    The wrapped command receives an `api` keyword argument. When no option is
+    provided, the default local login settings are used.
+    """
+
+    @click.option(
+        "--host",
+        "-h",
+        default=None,
+        type=str,
+        help="The host of the SwanLab server.",
+    )
+    @click.option(
+        "--api-key",
+        "--api_key",
+        "-k",
+        "api_key",
+        default=None,
+        type=str,
+        help="The API key to use for authentication.",
+    )
+    @wraps(func)
+    def wrapper(*args, host: Optional[str], api_key: Optional[str], **kwargs):
+        if host is None and api_key is None:
+            api = Api()
+        else:
+            api = Api(host=host, api_key=api_key)
+        return func(*args, api=api, **kwargs)
+
+    return wrapper
 
 
 def format_output(resp: ApiResponseType, fmt: _SaveFormatEnum = _SaveFormatEnum.JSON) -> None:

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -43,7 +43,7 @@ def with_custom_host(func: Callable) -> Callable:
         help="The API key to use for authentication.",
     )
     @wraps(func)
-    def wrapper(*args, host: Optional[str], api_key: Optional[str], **kwargs):
+    def wrapper(*args, host: Optional[str] = None, api_key: Optional[str] = None, **kwargs):
         if host is None and api_key is None:
             api = Api()
         else:

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -9,10 +9,10 @@ import orjson
 
 from swanlab.api import Api
 from swanlab.api.typings.common import (
+    _VALID_PAGE_SIZES,
     ApiColumnClassLiteral,
     ApiColumnDataTypeLiteral,
     ApiResponseType,
-    _VALID_PAGE_SIZES,
 )
 
 

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -15,6 +15,9 @@ class _SaveFormatEnum(enum.Enum):
     JSON = "json"
 
 
+PAGE_SIZE_TYPE = click.Choice(["10", "12", "15", "20", "24", "27", "50", "100"])
+
+
 def with_custom_host(func: Callable) -> Callable:
     """
     Add common SwanLab API host/auth options to a CLI command.

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -12,6 +12,7 @@ from swanlab.api.typings.common import (
     _VALID_PAGE_SIZES,
     ApiColumnClassLiteral,
     ApiColumnDataTypeLiteral,
+    ApiMetricLogLevelLiteral,
     ApiResponseType,
     ApiVisibilityLiteral,
 )
@@ -25,6 +26,7 @@ PAGE_SIZE_TYPE = click.Choice([str(s) for s in _VALID_PAGE_SIZES])
 COLUMN_CLASS_TYPE = click.Choice(list(get_args(ApiColumnClassLiteral)), case_sensitive=False)
 COLUMN_DATA_TYPE = click.Choice(list(get_args(ApiColumnDataTypeLiteral)), case_sensitive=False)
 VISIBILITY_TYPE = click.Choice(list(get_args(ApiVisibilityLiteral)), case_sensitive=False)
+METRIC_LOG_LEVEL_TYPE = click.Choice(list(get_args(ApiMetricLogLevelLiteral)), case_sensitive=False)
 
 
 def with_custom_host(func: Callable) -> Callable:
@@ -81,3 +83,11 @@ def save_output(content: bytes, name: Optional[str] = None, fmt: _SaveFormatEnum
     with open(filename, "wb") as f:
         f.write(content)
     click.echo(f"Saved to {filename}")
+
+
+def parse_keys(keys: str) -> list[str]:
+    """Parse comma-separated keys string into a list, raising click.BadParameter on empty result."""
+    key_list = [k.strip() for k in keys.split(",") if k.strip()]
+    if not key_list:
+        raise click.BadParameter("No valid keys provided. Expected comma-separated keys, e.g. 'loss,acc'.")
+    return key_list

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -1,53 +1,16 @@
 import enum
 from datetime import datetime
-from functools import wraps
-from typing import Callable, Optional
+from typing import Optional
 
 import click
 import nanoid
 import orjson
 
-from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
 
 
 class _SaveFormatEnum(enum.Enum):
     JSON = "json"
-
-
-def with_custom_host(func: Callable) -> Callable:
-    """
-    Add common SwanLab API host/auth options to a CLI command.
-
-    The wrapped command receives an `api` keyword argument. When no option is
-    provided, the default local login settings are used.
-    """
-
-    @click.option(
-        "--host",
-        "-h",
-        default=None,
-        type=str,
-        help="The host of the SwanLab server.",
-    )
-    @click.option(
-        "--api-key",
-        "--api_key",
-        "-k",
-        "api_key",
-        default=None,
-        type=str,
-        help="The API key to use for authentication.",
-    )
-    @wraps(func)
-    def wrapper(*args, host: Optional[str], api_key: Optional[str], **kwargs):
-        if host is None and api_key is None:
-            api = Api()
-        else:
-            api = Api(host=host, api_key=api_key)
-        return func(*args, api=api, **kwargs)
-
-    return wrapper
 
 
 def format_output(resp: ApiResponseType, fmt: _SaveFormatEnum = _SaveFormatEnum.JSON) -> None:

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -1,38 +1,28 @@
 import enum
 from datetime import datetime
 from functools import wraps
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, get_args
 
 import click
 import nanoid
 import orjson
 
 from swanlab.api import Api
-from swanlab.api.typings.common import ApiResponseType
+from swanlab.api.typings.common import (
+    ApiColumnClassLiteral,
+    ApiColumnDataTypeLiteral,
+    ApiResponseType,
+    _VALID_PAGE_SIZES,
+)
 
 
 class _SaveFormatEnum(enum.Enum):
     JSON = "json"
 
 
-PAGE_SIZE_TYPE = click.Choice(["10", "12", "15", "20", "24", "27", "50", "100"])
-COLUMN_CLASS_TYPE = click.Choice(["CUSTOM", "SYSTEM"], case_sensitive=False)
-COLUMN_DATA_TYPE = click.Choice(
-    [
-        "FLOAT",
-        "BOOLEAN",
-        "STRING",
-        "IMAGE",
-        "AUDIO",
-        "VIDEO",
-        "OBJECT3D",
-        "MOLECULE",
-        "ECHARTS",
-        "TABLE",
-        "TEXT",
-    ],
-    case_sensitive=False,
-)
+PAGE_SIZE_TYPE = click.Choice([str(s) for s in _VALID_PAGE_SIZES])
+COLUMN_CLASS_TYPE = click.Choice(list(get_args(ApiColumnClassLiteral)), case_sensitive=False)
+COLUMN_DATA_TYPE = click.Choice(list(get_args(ApiColumnDataTypeLiteral)), case_sensitive=False)
 
 
 def with_custom_host(func: Callable) -> Callable:

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -13,6 +13,7 @@ from swanlab.api.typings.common import (
     ApiColumnClassLiteral,
     ApiColumnDataTypeLiteral,
     ApiResponseType,
+    ApiVisibilityLiteral,
 )
 
 
@@ -23,6 +24,7 @@ class _SaveFormatEnum(enum.Enum):
 PAGE_SIZE_TYPE = click.Choice([str(s) for s in _VALID_PAGE_SIZES])
 COLUMN_CLASS_TYPE = click.Choice(list(get_args(ApiColumnClassLiteral)), case_sensitive=False)
 COLUMN_DATA_TYPE = click.Choice(list(get_args(ApiColumnDataTypeLiteral)), case_sensitive=False)
+VISIBILITY_TYPE = click.Choice(list(get_args(ApiVisibilityLiteral)), case_sensitive=False)
 
 
 def with_custom_host(func: Callable) -> Callable:

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -16,6 +16,23 @@ class _SaveFormatEnum(enum.Enum):
 
 
 PAGE_SIZE_TYPE = click.Choice(["10", "12", "15", "20", "24", "27", "50", "100"])
+COLUMN_CLASS_TYPE = click.Choice(["CUSTOM", "SYSTEM"], case_sensitive=False)
+COLUMN_DATA_TYPE = click.Choice(
+    [
+        "FLOAT",
+        "BOOLEAN",
+        "STRING",
+        "IMAGE",
+        "AUDIO",
+        "VIDEO",
+        "OBJECT3D",
+        "MOLECULE",
+        "ECHARTS",
+        "TABLE",
+        "TEXT",
+    ],
+    case_sensitive=False,
+)
 
 
 def with_custom_host(func: Callable) -> Callable:

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -1,7 +1,7 @@
 import enum
 from datetime import datetime
 from functools import wraps
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 import click
 import nanoid
@@ -53,9 +53,11 @@ def with_custom_host(func: Callable) -> Callable:
     return wrapper
 
 
-def format_output(resp: ApiResponseType, fmt: _SaveFormatEnum = _SaveFormatEnum.JSON) -> None:
+def format_output(resp: ApiResponseType, fmt: _SaveFormatEnum = _SaveFormatEnum.JSON) -> Dict[str, Any]:
+    payload = resp.json()
     if fmt == _SaveFormatEnum.JSON:
-        click.echo(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2).decode())
+        click.echo(orjson.dumps(payload, option=orjson.OPT_INDENT_2).decode())
+    return payload
 
 
 def save_output(content: bytes, name: Optional[str] = None, fmt: _SaveFormatEnum = _SaveFormatEnum.JSON) -> None:

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -1,6 +1,7 @@
 import click
 import orjson
 
+from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import PAGE_SIZE_TYPE, format_output, save_output, with_custom_host
 
@@ -23,7 +24,7 @@ def project_cli():
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def get_project(path: str, name, api):
+def get_project(path: str, name, api: Api):
     """Get project info by path (username/project)."""
     resp = api.project(path).wrapper()
     payload = format_output(resp)
@@ -57,19 +58,19 @@ def get_project(path: str, name, api):
 @click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
 @click.option(
     "--save",
-    "name",
+    "save_name",
     is_flag=False,
     flag_value=".",
     default=None,
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool, name, api):
+def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool, save_name: str, api: Api):
     """List projects under a workspace."""
     workspace = workspace or api.username
     resp = ApiResponseType(
         ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all)
     )
     payload = format_output(resp)
-    if payload["ok"] and name is not None:
-        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -3,7 +3,7 @@ import orjson
 
 from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
-from swanlab.cli.api.helper import PAGE_SIZE_TYPE, format_output, save_output, with_custom_host
+from swanlab.cli.api.helper import PAGE_SIZE_TYPE, VISIBILITY_TYPE, format_output, save_output, with_custom_host
 
 
 @click.group("project")
@@ -68,6 +68,56 @@ def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool
     resp = ApiResponseType(
         ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all)
     )
+    payload = format_output(resp)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@project_cli.command("create")
+@click.option(
+    "-n",
+    "--name",
+    required=True,
+    type=str,
+    help="Project name (1-100 chars, only 0-9a-zA-Z-_.+).",
+)
+@click.option(
+    "-v",
+    "--visibility",
+    default="PRIVATE",
+    type=VISIBILITY_TYPE,
+    help="Project visibility, PUBLIC or PRIVATE. Default PRIVATE.",
+)
+@click.option(
+    "-d",
+    "--description",
+    default=None,
+    type=str,
+    help="Project description.",
+)
+@click.option(
+    "-w",
+    "--workspace",
+    default=None,
+    type=str,
+    help="Workspace username. Defaults to the current logged-in workspace.",
+)
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def create_project(name: str, visibility: str, description: str, workspace: str, save_name: str, api: Api):
+    """Create a project in a workspace."""
+    project = api.create_project(username=workspace, name=name, visibility=visibility.upper(), description=description)  # type: ignore
+    if project is None:
+        format_output(ApiResponseType(ok=False, errmsg="Failed to create project"))
+        return
+    resp = project.wrapper()
     payload = format_output(resp)
     if payload["ok"] and save_name is not None:
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -1,7 +1,8 @@
 import click
 import orjson
 
-from swanlab.cli.api.helper import format_output, save_output, with_custom_host
+from swanlab.api import Api
+from swanlab.cli.api.helper import format_output, save_output
 
 
 @click.group("project")
@@ -21,9 +22,9 @@ def project_cli():
     default=None,
     help="Save output as JSON to current directory.",
 )
-@with_custom_host
-def get_project(path: str, name, api):
+def get_project(path: str, name):
     """Get project info by path (username/project)."""
+    api = Api()
     resp = api.project(path).wrapper()
     format_output(resp)
     if resp.ok and name is not None:

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -66,7 +66,7 @@ def get_project(path: str, name, api):
 @with_custom_host
 def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool, name, api):
     """List projects under a workspace."""
-    workspace = workspace or getattr(api, "_ctx").username
+    workspace = workspace or api.username
     resp = ApiResponseType(ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all))
     payload = format_output(resp)
     if payload["ok"] and name is not None:

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -16,26 +16,24 @@ def project_cli():
 @click.argument("path", required=True)
 @click.option(
     "--save",
-    "-s",
-    "name",
+    "save_name",
     is_flag=False,
     flag_value=".",
     default=None,
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def get_project(path: str, name, api: Api):
+def get_project(path: str, save_name: str, api: Api):
     """Get project info by path (username/project)."""
     resp = api.project(path).wrapper()
     payload = format_output(resp)
-    if payload["ok"] and name is not None:
-        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
 
 
 @project_cli.command("list")
 @click.option(
     "--page_num",
-    "--page-num",
     "-n",
     default=1,
     type=click.IntRange(min=1),
@@ -43,7 +41,6 @@ def get_project(path: str, name, api: Api):
 )
 @click.option(
     "--page_size",
-    "--page-size",
     "-s",
     default="20",
     type=PAGE_SIZE_TYPE,

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -1,8 +1,7 @@
 import click
 import orjson
 
-from swanlab.api import Api
-from swanlab.cli.api.helper import format_output, save_output
+from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
 @click.group("project")
@@ -22,9 +21,9 @@ def project_cli():
     default=None,
     help="Save output as JSON to current directory.",
 )
-def get_project(path: str, name):
+@with_custom_host
+def get_project(path: str, name, api):
     """Get project info by path (username/project)."""
-    api = Api()
     resp = api.project(path).wrapper()
     format_output(resp)
     if resp.ok and name is not None:

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -24,7 +24,7 @@ def project_cli():
 )
 @with_custom_host
 def get_project(path: str, save_name: str, api: Api):
-    """Get project info by path (username/project)."""
+    """Get project info by path (e.g. username/project_name)."""
     resp = api.project(path).wrapper()
     payload = format_output(resp)
     if payload["ok"] and save_name is not None:

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -67,7 +67,9 @@ def get_project(path: str, name, api):
 def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool, name, api):
     """List projects under a workspace."""
     workspace = workspace or api.username
-    resp = ApiResponseType(ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all))
+    resp = ApiResponseType(
+        ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all)
+    )
     payload = format_output(resp)
     if payload["ok"] and name is not None:
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -1,6 +1,7 @@
 import click
 import orjson
 
+from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
@@ -25,6 +26,48 @@ def project_cli():
 def get_project(path: str, name, api):
     """Get project info by path (username/project)."""
     resp = api.project(path).wrapper()
+    format_output(resp)
+    if resp.ok and name is not None:
+        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+
+
+@project_cli.command("list")
+@click.option(
+    "--page_num",
+    "--page-num",
+    "-n",
+    default=1,
+    type=int,
+    help="Page number.",
+)
+@click.option(
+    "--page_size",
+    "--page-size",
+    "-s",
+    default=20,
+    type=int,
+    help="Page size.",
+)
+@click.option(
+    "--workspace",
+    default=None,
+    type=str,
+    help="Workspace username. Defaults to the current logged-in workspace.",
+)
+@click.option("--all", "fetch_all", is_flag=True, default=False, help="Fetch all pages.")
+@click.option(
+    "--save",
+    "name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def list_projects(page_num: int, page_size: int, workspace: str, fetch_all: bool, name, api):
+    """List projects under a workspace."""
+    workspace = workspace or getattr(api, "_ctx").username
+    resp = ApiResponseType(ok=True, data=api.projects(path=workspace, page=page_num, size=page_size, all=fetch_all))
     format_output(resp)
     if resp.ok and name is not None:
         save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -2,7 +2,7 @@ import click
 import orjson
 
 from swanlab.api.typings.common import ApiResponseType
-from swanlab.cli.api.helper import format_output, save_output, with_custom_host
+from swanlab.cli.api.helper import PAGE_SIZE_TYPE, format_output, save_output, with_custom_host
 
 
 @click.group("project")
@@ -37,15 +37,15 @@ def get_project(path: str, name, api):
     "--page-num",
     "-n",
     default=1,
-    type=int,
+    type=click.IntRange(min=1),
     help="Page number.",
 )
 @click.option(
     "--page_size",
     "--page-size",
     "-s",
-    default=20,
-    type=int,
+    default="20",
+    type=PAGE_SIZE_TYPE,
     help="Page size.",
 )
 @click.option(
@@ -64,10 +64,10 @@ def get_project(path: str, name, api):
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def list_projects(page_num: int, page_size: int, workspace: str, fetch_all: bool, name, api):
+def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool, name, api):
     """List projects under a workspace."""
     workspace = workspace or getattr(api, "_ctx").username
-    resp = ApiResponseType(ok=True, data=api.projects(path=workspace, page=page_num, size=page_size, all=fetch_all))
+    resp = ApiResponseType(ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all))
     format_output(resp)
     if resp.ok and name is not None:
         save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/project.py
+++ b/swanlab/cli/api/project.py
@@ -26,9 +26,9 @@ def project_cli():
 def get_project(path: str, name, api):
     """Get project info by path (username/project)."""
     resp = api.project(path).wrapper()
-    format_output(resp)
-    if resp.ok and name is not None:
-        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+    payload = format_output(resp)
+    if payload["ok"] and name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
 
 
 @project_cli.command("list")
@@ -68,6 +68,6 @@ def list_projects(page_num: int, page_size: str, workspace: str, fetch_all: bool
     """List projects under a workspace."""
     workspace = workspace or getattr(api, "_ctx").username
     resp = ApiResponseType(ok=True, data=api.projects(path=workspace, page=page_num, size=int(page_size), all=fetch_all))
-    format_output(resp)
-    if resp.ok and name is not None:
-        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+    payload = format_output(resp)
+    if payload["ok"] and name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/selfhosted.py
+++ b/swanlab/cli/api/selfhosted.py
@@ -2,7 +2,9 @@ import click
 import orjson
 
 from swanlab.api import Api
+from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import format_output, save_output, with_custom_host
+from swanlab.sdk.internal.pkg.safe import block
 
 
 @click.group("selfhosted")
@@ -30,13 +32,16 @@ def get_info(save_name: str, api: Api):
 
 
 @selfhosted_cli.command("create-user")
-@click.argument("username")
-@click.argument("password")
+@click.option("--username", "-u", type=str, required=True, help="username to create")
+@click.option("--password", "-p", type=str, required=True, help="password to create")
 @with_custom_host
 def create_user(username: str, password: str, api: Api):
     """Create a new user in the self-hosted instance."""
-    resp = api.self_hosted().create_user(username, password)
-    format_output(resp)
+    err: list[str] = []
+    resp: ApiResponseType | None = None
+    with block(message=None, on_error=lambda e: err.append(str(e))):
+        resp = api.self_hosted().create_user(username, password)
+    format_output(resp if resp is not None else ApiResponseType(ok=False, errmsg=err[0]))
 
 
 @selfhosted_cli.command("list-users")
@@ -46,5 +51,11 @@ def create_user(username: str, password: str, api: Api):
 @with_custom_host
 def list_users(page_num: int, page_size: int, fetch_all: bool, api: Api):
     """List users in the self-hosted instance."""
-    resp = api.self_hosted().get_users(page=page_num, size=page_size, all=fetch_all)
-    format_output(resp)
+    err: list[str] = []
+    users: list | None = None
+    with block(message=None, on_error=lambda e: err.append(str(e))):
+        users = list(api.self_hosted().get_users(page=page_num, size=page_size, all=fetch_all))
+    if users is not None:
+        format_output(ApiResponseType(ok=True, data={"list": users}))
+    else:
+        format_output(ApiResponseType(ok=False, errmsg=err[0]))

--- a/swanlab/cli/api/selfhosted.py
+++ b/swanlab/cli/api/selfhosted.py
@@ -1,11 +1,50 @@
 import click
+import orjson
 
 from swanlab.api import Api
-from swanlab.api.typings.common import ApiResponseType
-from swanlab.cli.api.helper import format_output
+from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
 @click.group("selfhosted")
 def selfhosted_cli():
     """Self-hosted deployment management commands."""
     pass
+
+
+@selfhosted_cli.command("info")
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def get_info(save_name: str, api: Api):
+    """Show self-hosted instance info."""
+    resp = api.self_hosted().wrapper()
+    payload = format_output(resp)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@selfhosted_cli.command("create-user")
+@click.argument("username")
+@click.argument("password")
+@with_custom_host
+def create_user(username: str, password: str, api: Api):
+    """Create a new user in the self-hosted instance."""
+    resp = api.self_hosted().create_user(username, password)
+    format_output(resp)
+
+
+@selfhosted_cli.command("list-users")
+@click.option("--page_num", "-n", default=1, type=int, help="Page number, default 1.")
+@click.option("--page_size", "-s", default=20, type=int, help="Page size, default 20.")
+@click.option("--all", "fetch_all", is_flag=True, help="Fetch all users.")
+@with_custom_host
+def list_users(page_num: int, page_size: int, fetch_all: bool, api: Api):
+    """List users in the self-hosted instance."""
+    resp = api.self_hosted().get_users(page=page_num, size=page_size, all=fetch_all)
+    format_output(resp)

--- a/swanlab/cli/api/user.py
+++ b/swanlab/cli/api/user.py
@@ -1,5 +1,6 @@
 import click
 
+from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
 from swanlab.cli.api.helper import format_output
 

--- a/swanlab/cli/api/user.py
+++ b/swanlab/cli/api/user.py
@@ -1,11 +1,30 @@
 import click
+import orjson
 
 from swanlab.api import Api
 from swanlab.api.typings.common import ApiResponseType
-from swanlab.cli.api.helper import format_output
+from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
 @click.group("user")
 def user_cli():
     """User management commands."""
     pass
+
+
+@user_cli.command("info")
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    default=None,
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def get_user(save_name: str, api: Api):
+    """Get current User info"""
+    resp = api.user().wrapper()
+    payload = format_output(resp)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)

--- a/swanlab/cli/api/workspace.py
+++ b/swanlab/cli/api/workspace.py
@@ -25,6 +25,6 @@ def workspace_cli():
 def get_workspace(username: str, name, api):
     """Get Workspace info."""
     resp = api.workspace(username).wrapper()
-    format_output(resp)
-    if resp.ok and name is not None:
-        save_output(orjson.dumps(resp.json(), option=orjson.OPT_INDENT_2), name=name)
+    payload = format_output(resp)
+    if payload["ok"] and name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)

--- a/swanlab/cli/api/workspace.py
+++ b/swanlab/cli/api/workspace.py
@@ -1,7 +1,8 @@
 import click
 import orjson
 
-from swanlab.cli.api.helper import format_output, save_output, with_custom_host
+from swanlab.api import Api
+from swanlab.cli.api.helper import format_output, save_output
 
 
 @click.group("workspace")
@@ -21,9 +22,9 @@ def workspace_cli():
     default=None,
     help="Save output as JSON to current directory.",
 )
-@with_custom_host
-def get_workspace(username: str, name, api):
+def get_workspace(username: str, name):
     """Get Workspace info."""
+    api = Api()
     resp = api.workspace(username).wrapper()
     format_output(resp)
     if resp.ok and name is not None:

--- a/swanlab/cli/api/workspace.py
+++ b/swanlab/cli/api/workspace.py
@@ -1,6 +1,7 @@
 import click
 import orjson
 
+from swanlab.api import Api
 from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
@@ -15,16 +16,16 @@ def workspace_cli():
 @click.option(
     "--save",
     "-s",
-    "name",
+    "save_name",
     is_flag=False,
     flag_value=".",
     default=None,
     help="Save output as JSON to current directory.",
 )
 @with_custom_host
-def get_workspace(username: str, name, api):
+def get_workspace(username: str, save_name: str, api: Api):
     """Get Workspace info."""
     resp = api.workspace(username).wrapper()
     payload = format_output(resp)
-    if payload["ok"] and name is not None:
-        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=name)
+    if payload["ok"] and save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)

--- a/swanlab/cli/api/workspace.py
+++ b/swanlab/cli/api/workspace.py
@@ -1,8 +1,7 @@
 import click
 import orjson
 
-from swanlab.api import Api
-from swanlab.cli.api.helper import format_output, save_output
+from swanlab.cli.api.helper import format_output, save_output, with_custom_host
 
 
 @click.group("workspace")
@@ -22,9 +21,9 @@ def workspace_cli():
     default=None,
     help="Save output as JSON to current directory.",
 )
-def get_workspace(username: str, name):
+@with_custom_host
+def get_workspace(username: str, name, api):
     """Get Workspace info."""
-    api = Api()
     resp = api.workspace(username).wrapper()
     format_output(resp)
     if resp.ok and name is not None:

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -82,16 +82,16 @@ class TestApiEntryValidation:
         )
 
         with pytest.raises(AuthenticationError, match="No API key"):
-            Api._resolve_credentials(None, None, None)
+            Api._resolve_credentials(None, None)
 
     @pytest.mark.parametrize("api_key", ["", "   "])
     def test_blank_api_key_raises(self, api_key):
         with pytest.raises(AuthenticationError, match="No API key"):
-            Api._resolve_credentials(api_key, "https://api.swanlab.cn", "https://swanlab.cn")
+            Api._resolve_credentials(api_key, "https://api.swanlab.cn")
 
     def test_blank_host_raises(self):
         with pytest.raises(ValueError, match="Host cannot be empty"):
-            Api._resolve_credentials("test-key", "   ", "https://swanlab.cn")
+            Api._resolve_credentials("test-key", "   ")
 
     def test_projects_invalid_page_raises(self, api):
         with pytest.raises(ValueError, match="page must be >= 1"):

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -259,6 +259,72 @@ class TestExperimentRunIdResolution:
 
         assert column.run_id == "run-cuid"
 
+    def test_metrics_uses_run_cuid_for_metric_payload(self, ctx):
+        def get(path, **kwargs):
+            if path == "/project/user/proj/runs/run-slug":
+                return _api_response(
+                    {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"}
+                )
+            raise AssertionError(f"unexpected GET {path}")
+
+        ctx.client.get.side_effect = get
+        ctx.client.post.side_effect = [
+            _api_response([{"metrics": [{"step": 1, "value": 0.1}]}]),
+            _api_response([{"min": {"value": 0.1}}]),
+        ]
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.metrics(["loss"])
+
+        payload = ctx.client.post.call_args_list[0].kwargs["data"]
+        assert [call.args[0] for call in ctx.client.get.call_args_list] == ["/project/user/proj/runs/run-slug"]
+        assert payload["projectId"] == "project-cuid"
+        assert payload["columns"] == [{"experimentId": "run-cuid", "key": "loss"}]
+
+    def test_medias_uses_run_cuid_for_metric_payload(self, ctx):
+        def get(path, **kwargs):
+            if path == "/project/user/proj/runs/run-slug":
+                return _api_response(
+                    {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"}
+                )
+            raise AssertionError(f"unexpected GET {path}")
+
+        ctx.client.get.side_effect = get
+        ctx.client.post.return_value = _api_response(
+            {"steps": [1], "step": 1, "metrics": [{"key": "image", "data": [], "more": []}]}
+        )
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.medias(["image"], step=1)
+
+        payload = ctx.client.post.call_args_list[0].kwargs["data"]
+        assert [call.args[0] for call in ctx.client.get.call_args_list] == ["/project/user/proj/runs/run-slug"]
+        assert payload["projectId"] == "project-cuid"
+        assert payload["columns"] == [{"experimentId": "run-cuid", "key": "image"}]
+
+    def test_logs_uses_run_cuid_for_log_params(self, ctx):
+        def get(path, **kwargs):
+            if path == "/project/user/proj/runs/run-slug":
+                return _api_response(
+                    {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"}
+                )
+            if path == "/house/metrics/log":
+                return _api_response({"logs": [{"message": "ready"}], "count": 1})
+            raise AssertionError(f"unexpected GET {path}")
+
+        ctx.client.get.side_effect = get
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.logs()
+
+        _, kwargs = ctx.client.get.call_args_list[-1]
+        assert [call.args[0] for call in ctx.client.get.call_args_list] == [
+            "/project/user/proj/runs/run-slug",
+            "/house/metrics/log",
+        ]
+        assert kwargs["params"]["projectId"] == "project-cuid"
+        assert kwargs["params"]["experimentId"] == "run-cuid"
+
 
 # ---------------------------------------------------------------------------
 # Column / Columns — 校验 + 4xx
@@ -266,11 +332,11 @@ class TestExperimentRunIdResolution:
 class TestColumnValidation:
     def test_columns_invalid_type_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid column_type"):
-            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_type="INVALID")
+            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_type="INVALID")  # type: ignore
 
     def test_columns_invalid_class_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid column_class"):
-            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_class="INVALID")
+            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_class="INVALID")  # type: ignore
 
     def test_iterated_columns_resolve_run_cuid_once_for_local_fields(self, ctx):
         ctx.client.get.side_effect = [
@@ -335,7 +401,7 @@ class TestMetricValidation:
 
     def test_metric_invalid_log_level_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid metric log level"):
-            Metric(ctx, project_id="p1", run_id="r1", key="LOG", metric_type="LOG", log_level="VERBOSE")
+            Metric(ctx, project_id="p1", run_id="r1", key="LOG", metric_type="LOG", log_level="VERBOSE")  # type: ignore
 
     def test_metric_scalar_no_key_raises(self, ctx):
         with pytest.raises(ValueError, match="key is required"):

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -168,20 +168,20 @@ class TestSelfHostedPermission:
 # Workspace — create_project 错误
 # ---------------------------------------------------------------------------
 class TestWorkspaceCreateProject:
-    def test_invalid_name_returns_none(self, ctx):
+    def test_invalid_name_raises_value_error(self, ctx):
         ws = Workspace(ctx, username="testuser")
-        result = ws.create_project("bad name!")
-        assert result is None
+        with pytest.raises(ValueError):
+            ws.create_project("bad name!")
 
-    def test_empty_name_returns_none(self, ctx):
+    def test_empty_name_raises_value_error(self, ctx):
         ws = Workspace(ctx, username="testuser")
-        result = ws.create_project("")
-        assert result is None
+        with pytest.raises(ValueError):
+            ws.create_project("")
 
-    def test_invalid_visibility_returns_none(self, ctx):
+    def test_invalid_visibility_raises_value_error(self, ctx):
         ws = Workspace(ctx, username="testuser")
-        result = ws.create_project("valid-name", visibility=cast(Any, "SECRET"))
-        assert result is None
+        with pytest.raises(ValueError):
+            ws.create_project("valid-name", visibility=cast(Any, "SECRET"))
         ctx.client.post.assert_not_called()
 
     def test_api_error_returns_none(self, ctx):


### PR DESCRIPTION
## 总结

  - 在 `swanlab api` 命令中新增通用 `-h/--host` 和 `-k/--api-key/--api_key` 选项，并通过
  `with_custom_host` 装饰器统一注入 `Api` 实例。
  - 将自定义 host/API key 能力接入现有的 `project info`、`experiment info`、`workspace info` 命
  令。
  - 新增基于 OpenAPI 的 CLI 命令：
    - `swanlab api project list`
    - `swanlab api run list`
    - `swanlab api run columns`


  ## 验证

  - 使用 `py_compile` 进行 Python 语法检查。
  - 使用 `ruff check` 检查修改过的 CLI 文件。
  - 验证了新增命令和选项的 Click help 输出。