### PR TITLE
feat: add run greeting/farewell, run path & URL

### DIFF
--- a/core/proto/swanlab/run/v1/run.pb.go
+++ b/core/proto/swanlab/run/v1/run.pb.go
@@ -262,6 +262,7 @@ type StartResponse struct {
 	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"` // 请求是否成功
 	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`  // 请求失败的响应
 	Run           *StartRecord           `protobuf:"bytes,3,opt,name=run,proto3" json:"run,omitempty"`          // 最终创建的 Run 记录
+	Path          string                 `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`        // 对应的实验路径，格式为 /@:username/:project_name/runs/:slug(run_id)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -315,6 +316,13 @@ func (x *StartResponse) GetRun() *StartRecord {
 		return x.Run
 	}
 	return nil
+}
+
+func (x *StartResponse) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
 }
 
 // Run 结束记录，对应 swanlab.finish() 或进程退出，由sdk前端生成并同步交给后端
@@ -451,11 +459,12 @@ const file_swanlab_run_v1_run_proto_rawDesc = "" +
 	" \x01(\tR\x02id\x122\n" +
 	"\x06resume\x18\v \x01(\x0e2\x1a.swanlab.run.v1.ResumeModeR\x06resume\x129\n" +
 	"\n" +
-	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\"r\n" +
+	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\"\x86\x01\n" +
 	"\rStartResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12-\n" +
-	"\x03run\x18\x03 \x01(\v2\x1b.swanlab.run.v1.StartRecordR\x03run\"\x91\x01\n" +
+	"\x03run\x18\x03 \x01(\v2\x1b.swanlab.run.v1.StartRecordR\x03run\x12\x12\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\"\x91\x01\n" +
 	"\fFinishRecord\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.swanlab.run.v1.RunStateR\x05state\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12;\n" +

--- a/protos/swanlab/run/v1/run.proto
+++ b/protos/swanlab/run/v1/run.proto
@@ -27,6 +27,7 @@ message StartResponse {
   bool success    = 1;  // 请求是否成功
   string message  = 2;  // 请求失败的响应
   StartRecord run = 3;  // 最终创建的 Run 记录
+  string path     = 4;  // 对应的实验路径，格式为 /:username/:project_name/:slug(run_id)
 }
 
 

--- a/swanlab/proto/swanlab/run/v1/run_pb2.py
+++ b/swanlab/proto/swanlab/run/v1/run_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18swanlab/run/v1/run.proto\x12\x0eswanlab.run.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x02\n\x0bStartRecord\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tworkspace\x18\x02 \x01(\t\x12\x0e\n\x06public\x18\x03 \x01(\x08\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12\x0c\n\x04tags\x18\x06 \x03(\t\x12\r\n\x05group\x18\x07 \x01(\t\x12\x10\n\x08job_type\x18\x08 \x01(\t\x12\r\n\x05\x63olor\x18\t \x01(\t\x12\n\n\x02id\x18\n \x01(\t\x12*\n\x06resume\x18\x0b \x01(\x0e\x32\x1a.swanlab.run.v1.ResumeMode\x12.\n\nstarted_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"[\n\rStartResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x03run\x18\x03 \x01(\x0b\x32\x1b.swanlab.run.v1.StartRecord\"w\n\x0c\x46inishRecord\x12\'\n\x05state\x18\x01 \x01(\x0e\x32\x18.swanlab.run.v1.RunState\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12/\n\x0b\x66inished_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"2\n\x0e\x46inishResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*g\n\x08RunState\x12\x15\n\x11RUN_STATE_RUNNING\x10\x00\x12\x16\n\x12RUN_STATE_FINISHED\x10\x01\x12\x15\n\x11RUN_STATE_CRASHED\x10\x02\x12\x15\n\x11RUN_STATE_ABORTED\x10\x03*P\n\nResumeMode\x12\x15\n\x11RESUME_MODE_NEVER\x10\x00\x12\x15\n\x11RESUME_MODE_ALLOW\x10\x01\x12\x14\n\x10RESUME_MODE_MUST\x10\x02\x42=Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18swanlab/run/v1/run.proto\x12\x0eswanlab.run.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x02\n\x0bStartRecord\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tworkspace\x18\x02 \x01(\t\x12\x0e\n\x06public\x18\x03 \x01(\x08\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12\x0c\n\x04tags\x18\x06 \x03(\t\x12\r\n\x05group\x18\x07 \x01(\t\x12\x10\n\x08job_type\x18\x08 \x01(\t\x12\r\n\x05\x63olor\x18\t \x01(\t\x12\n\n\x02id\x18\n \x01(\t\x12*\n\x06resume\x18\x0b \x01(\x0e\x32\x1a.swanlab.run.v1.ResumeMode\x12.\n\nstarted_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"i\n\rStartResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x03run\x18\x03 \x01(\x0b\x32\x1b.swanlab.run.v1.StartRecord\x12\x0c\n\x04path\x18\x04 \x01(\t\"w\n\x0c\x46inishRecord\x12\'\n\x05state\x18\x01 \x01(\x0e\x32\x18.swanlab.run.v1.RunState\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12/\n\x0b\x66inished_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"2\n\x0e\x46inishResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*g\n\x08RunState\x12\x15\n\x11RUN_STATE_RUNNING\x10\x00\x12\x16\n\x12RUN_STATE_FINISHED\x10\x01\x12\x15\n\x11RUN_STATE_CRASHED\x10\x02\x12\x15\n\x11RUN_STATE_ABORTED\x10\x03*P\n\nResumeMode\x12\x15\n\x11RESUME_MODE_NEVER\x10\x00\x12\x15\n\x11RESUME_MODE_ALLOW\x10\x01\x12\x14\n\x10RESUME_MODE_MUST\x10\x02\x42=Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,16 +33,16 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'swanlab.run.v1.run_pb2', _g
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1'
-  _globals['_RUNSTATE']._serialized_start=612
-  _globals['_RUNSTATE']._serialized_end=715
-  _globals['_RESUMEMODE']._serialized_start=717
-  _globals['_RESUMEMODE']._serialized_end=797
+  _globals['_RUNSTATE']._serialized_start=626
+  _globals['_RUNSTATE']._serialized_end=729
+  _globals['_RESUMEMODE']._serialized_start=731
+  _globals['_RESUMEMODE']._serialized_end=811
   _globals['_STARTRECORD']._serialized_start=78
   _globals['_STARTRECORD']._serialized_end=344
   _globals['_STARTRESPONSE']._serialized_start=346
-  _globals['_STARTRESPONSE']._serialized_end=437
-  _globals['_FINISHRECORD']._serialized_start=439
-  _globals['_FINISHRECORD']._serialized_end=558
-  _globals['_FINISHRESPONSE']._serialized_start=560
-  _globals['_FINISHRESPONSE']._serialized_end=610
+  _globals['_STARTRESPONSE']._serialized_end=451
+  _globals['_FINISHRECORD']._serialized_start=453
+  _globals['_FINISHRECORD']._serialized_end=572
+  _globals['_FINISHRESPONSE']._serialized_start=574
+  _globals['_FINISHRESPONSE']._serialized_end=624
 # @@protoc_insertion_point(module_scope)

--- a/swanlab/proto/swanlab/run/v1/run_pb2.pyi
+++ b/swanlab/proto/swanlab/run/v1/run_pb2.pyi
@@ -59,14 +59,16 @@ class StartRecord(_message.Message):
     def __init__(self, project: _Optional[str] = ..., workspace: _Optional[str] = ..., public: bool = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., tags: _Optional[_Iterable[str]] = ..., group: _Optional[str] = ..., job_type: _Optional[str] = ..., color: _Optional[str] = ..., id: _Optional[str] = ..., resume: _Optional[_Union[ResumeMode, str]] = ..., started_at: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
 
 class StartResponse(_message.Message):
-    __slots__ = ("success", "message", "run")
+    __slots__ = ("success", "message", "run", "path")
     SUCCESS_FIELD_NUMBER: _ClassVar[int]
     MESSAGE_FIELD_NUMBER: _ClassVar[int]
     RUN_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
     success: bool
     message: str
     run: StartRecord
-    def __init__(self, success: bool = ..., message: _Optional[str] = ..., run: _Optional[_Union[StartRecord, _Mapping]] = ...) -> None: ...
+    path: str
+    def __init__(self, success: bool = ..., message: _Optional[str] = ..., run: _Optional[_Union[StartRecord, _Mapping]] = ..., path: _Optional[str] = ...) -> None: ...
 
 class FinishRecord(_message.Message):
     __slots__ = ("state", "error", "finished_at")

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -236,9 +236,9 @@ def init(
     generate_ctx = _init
     if run_settings.mode == "cloud":
         generate_ctx = utils.with_loading_animation()(_init)
-    ctx = generate_ctx(run_settings)
+    ctx, path = generate_ctx(run_settings)
     # 初始化run
-    run = Run(ctx)
+    run = Run(ctx, path)
     # 发送webhook回调，在除了disabled模式外，都会触发
     success = send_webhook(ctx)
     if not success:
@@ -443,12 +443,14 @@ def _generate_run_dir_name(run_id: str) -> str:
     return "run-" + datetime.now().strftime("%Y%m%d_%H%M%S") + "-" + run_id
 
 
-def _init(run_settings: Settings) -> RunContext:
+def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
     """
     初始化运行时配置，在这之前，所有引导式交互都已经完成
     上下文生命周期通过 `Run` 管理，而非全局 `ContextVar`
     """
     mode = run_settings.mode
+    # 实验路径，/:username/:project_name/:slug(run_id)，与open api命名一致
+    path = None
     # 1. 生成run_id
     if not run_settings.run.id:
         run_settings.merge_settings({"run": {"id": generate_id()}})
@@ -504,6 +506,9 @@ def _init(run_settings: Settings) -> RunContext:
         )
         if not resp.success:
             raise RuntimeError(resp.message)
+        path = resp.path or path
+        if mode == "cloud":
+            assert path, "Initialization path failed when mode=cloud"
         # 4. 从 core 响应同步配置（cloud 模式会覆盖为服务端分配的值）
         sync_args = {}
         merge_dict = helper.strip_none(
@@ -521,7 +526,7 @@ def _init(run_settings: Settings) -> RunContext:
     # 4. 创建运行目录
     if mode != "disabled":
         fs.safe_mkdirs(ctx.media_dir, ctx.files_dir, ctx.debug_dir)
-    return ctx
+    return ctx, path
 
 
 def _ensure_cloud_client(run_settings: Settings):
@@ -532,11 +537,5 @@ def _ensure_cloud_client(run_settings: Settings):
     if not client.exists():
         assert run_settings.api_key, "API key is required."
         assert run_settings.api_host, "API host is required."
-        login_raw(
-            api_key=run_settings.api_key,
-            host=run_settings.api_host,
-            save=False,
-            animation=False,
-            wellcome_on_success=False,
-        )
+        login_raw(api_key=run_settings.api_key, host=run_settings.api_host, save=False, animation=False)
     assert client.exists(), "No client found, please login first."

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -93,7 +93,6 @@ def login_raw(
     host: Optional[str] = None,
     save: LoginType = False,
     timeout: int = 10,
-    wellcome_on_success: bool = True,
     animation: bool = True,
 ) -> bool:
     # 1. 判断是否允许重新登录
@@ -132,8 +131,7 @@ def login_raw(
         f = utils.with_loading_animation("Waiting for response...")(create_client) if animation else create_client
         f(api_key=api_key, api_host=api_host, timeout=timeout)
         login_resp: Optional[LoginResponse] = s.get("login_resp", None)
-        if wellcome_on_success:
-            wellcome(login_resp)
+        wellcome(api_host, login_resp)
         if save:
             nrc_path = nrc.path(Path.cwd() / ROOT_FOLDER) if save == "local" else nrc.path(global_settings.root)
             nrc.write(nrc_path, api_host=api_host, web_host=login_settings.web_host, api_key=api_key)
@@ -189,7 +187,7 @@ def login_cli(
             with scope.Scope() as s:
                 client.new(api_key, base_url, timeout=timeout)
                 login_resp: Optional[LoginResponse] = s.get("login_resp", None)
-            wellcome(login_resp)
+            wellcome(base_url, login_resp)
             write_gitignore = save == "local" and not nrc_path.exists()
             if write_gitignore:
                 if not nrc_path.parent.exists():
@@ -269,12 +267,22 @@ def prompt_api_key(
             sys.exit(0)
 
 
-def wellcome(login_resp: Optional[LoginResponse]):
+def wellcome(base_url: str, login_resp: Optional[LoginResponse]):
     """
     登录成功后打印欢迎信息
+    :param base_url: 登录地址
     :param login_resp: 登录响应对象，包含用户信息等数据
     :return:
     """
     assert login_resp is not None, "Login response is missing"
-    username = login_resp.get("userInfo", {}).get("username", "unknown")
-    console.info("Login successfully. Hi", Text(f"{username}!", "bold"), sep=" ")
+    username = login_resp.get("userInfo", {}).get("username", "")
+    nickname = login_resp.get("userInfo", {}).get("name", "")
+    name = nickname or username
+    if name:
+        console.info(
+            "Currently logged in as:",
+            Text(name, "yellow"),
+            f"to {base_url}. Use",
+            Text("`swanlab login --relogin`", "bold"),
+            "to force relogin",
+        )

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -286,5 +286,3 @@ def wellcome(base_url: str, login_resp: Optional[LoginResponse]):
             Text("`swanlab login --relogin`", "bold"),
             "to force relogin",
         )
-    else:
-        raise ValueError("Failed to get user info from login response: ", login_resp)

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -286,3 +286,5 @@ def wellcome(base_url: str, login_resp: Optional[LoginResponse]):
             Text("`swanlab login --relogin`", "bold"),
             "to force relogin",
         )
+    else:
+        raise ValueError("Failed to get user info from login response: ", login_resp)

--- a/swanlab/sdk/internal/context/__init__.py
+++ b/swanlab/sdk/internal/context/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
 
 
 # 运行配置，包含当前运行上下文的必要状态
-@dataclass(frozen=True)
+@dataclass(frozen=False)
 class RunConfig:
     run_dir: Path
     settings: Settings
@@ -92,7 +92,7 @@ class RunContext:
         return self.config.run_dir / f"run-{run_id}.swanlab"
 
 
-# ContextVar 现在只存这个轻量级的数据宿主
+# 运行上下文
 _current_ctx: ContextVar[Optional[RunContext]] = ContextVar("swanlab_run_ctx", default=None)
 
 

--- a/swanlab/sdk/internal/context/__init__.py
+++ b/swanlab/sdk/internal/context/__init__.py
@@ -36,7 +36,7 @@ __all__ = [
 
 
 # 运行配置，包含当前运行上下文的必要状态
-@dataclass(frozen=False)
+@dataclass(frozen=True)
 class RunConfig:
     run_dir: Path
     settings: Settings

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -163,7 +163,12 @@ class CorePython(CoreProtocol):
         start_record.resume = record.resume
         start_record.project = project
         start_record.workspace = username
-        return StartResponse(success=True, message="OK", run=start_record)
+        # 5. 获取path，/:username/:project_name/:run_id
+        run_id = experiment.get("slug", "") or experiment["cuid"]
+        # /:username/:project_name
+        project_path = project_info["path"]
+        path = f"{project_path}/{run_id}"
+        return StartResponse(success=True, message="OK", run=start_record, path=path)
 
     # ---------------------------------- 数据上报 ----------------------------------
 

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -80,13 +80,6 @@ class Transport:
     def finish(self) -> None:
         """
         通知线程停止，等待最终排空，由线程自行关闭 sender。
-
-        设计要点：
-        - _loop 的 finally 块负责 _close_sender()，保证线程退出前 sender 可用。
-        - finish() 仅设置 _finished flag 并 join，不在 join 后关闭 sender，
-          避免线程仍在 dispatch 时 sender 被 use-after-close。
-        - join timeout 设为 30s 以覆盖弱网下多 chunk 重试场景；
-          超时后线程仍为 daemon 线程会随进程退出，不会泄漏。
         """
         if self._finished:
             return

--- a/swanlab/sdk/internal/pkg/console/__init__.py
+++ b/swanlab/sdk/internal/pkg/console/__init__.py
@@ -20,7 +20,7 @@ from . import log
 
 __all__ = ["debug", "info", "warning", "error", "trace", "c", "init", "reset"]
 
-c = Console()
+c = Console(highlighter=None)
 _name = "swanlab"
 _this_file = os.path.abspath(__file__)
 

--- a/swanlab/sdk/internal/pkg/helper/__init__.py
+++ b/swanlab/sdk/internal/pkg/helper/__init__.py
@@ -53,7 +53,8 @@ def fmt_run_path(run_path: str) -> str:
     parts = PurePosixPath(run_path).parts
 
     # 去掉根路径 "/"
-    parts = tuple(p for p in parts if p != "/")
+    parts = parts[1:] if parts and parts[0] == "/" else parts
+
     if len(parts) < 3:
         raise ValueError(f"Invalid run path: {run_path!r}")
 

--- a/swanlab/sdk/internal/pkg/helper/__init__.py
+++ b/swanlab/sdk/internal/pkg/helper/__init__.py
@@ -5,6 +5,8 @@
 @description: SwanLab SDK 辅助函数
 """
 
+from pathlib import PurePosixPath
+
 from .env import DEBUG, is_interactive, is_jupyter
 from .version import get_swanlab_latest_version, get_swanlab_version
 
@@ -13,6 +15,7 @@ __all__ = [
     "is_jupyter",
     "is_interactive",
     "strip_none",
+    "fmt_run_path",
     "get_swanlab_version",
     "get_swanlab_latest_version",
 ]
@@ -39,3 +42,24 @@ def strip_none(data: dict, strip_empty_dict: bool = True, strip_empty_str: bool 
             clean_data[k] = v
 
     return clean_data
+
+
+def fmt_run_path(run_path: str) -> str:
+    """
+    格式化运行路径为 /@:username/:project_name/runs/:run_id，适配前端路由设计
+    传入路径格式为 /:username/:project_name/:run_id
+    后端返回可能是：/cunyue/demo/abc123，cunyue/demo/abc123，/@cunyue/demo/abc123，@cunyue/demo/abc123
+    """
+    parts = PurePosixPath(run_path).parts
+
+    # 去掉根路径 "/"
+    parts = tuple(p for p in parts if p != "/")
+    if len(parts) < 3:
+        raise ValueError(f"Invalid run path: {run_path!r}")
+
+    username, project_name, run_id = parts[0], parts[1], parts[2]
+
+    if not username.startswith("@"):
+        username = f"@{username}"
+
+    return PurePosixPath("/", username, project_name, "runs", run_id).as_posix()

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -22,7 +22,7 @@ from typing import Any, Callable, Literal, Mapping, Optional, Type, Union, cast,
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from swanlab.proto.swanlab.run.v1.run_pb2 import FinishRecord
-from swanlab.sdk.internal.bus import MetricLogEvent, ScalarDefineEvent
+from swanlab.sdk.internal.bus import MetricLogEvent
 from swanlab.sdk.internal.context import RunContext
 from swanlab.sdk.internal.pkg import adapter, console, fork, helper, safe
 from swanlab.sdk.internal.run import greeting
@@ -132,7 +132,14 @@ class Run:
         signal.signal(signal.SIGINT, self._handle_sigint)
 
         # 3. 启动组件 + 初始化日志
-        self._callbacker.on_run_initialized(self._ctx.run_dir, path)
+        # 回调的path在path为空的时候自动生成一个/:project_name/:run_id，否则使用path
+        run_settings = ctx.config.settings
+        assert run_settings.project.name, "project name is required when init run"
+        assert run_settings.run.id, "run id is required when init run"
+        self._callbacker.on_run_initialized(
+            self._ctx.run_dir, path or f"{run_settings.project.name}/{run_settings.run.id}"
+        )
+        # 启动组件
         self._components.start()
         self._probe.start()
         console.init(bind_to=self._ctx.debug_dir if self.mode != "disabled" else None)
@@ -534,37 +541,37 @@ class Run:
         raise NotImplementedError("run.define_scalar() is not available yet. Support is planned for a future release.")
 
         # TODO: 实现 glob 匹配逻辑
-        if not (this_key := fmt.safe_validate_key(key)):
-            return console.error(
-                f"Invalid key for define scalar: {key}, please use valid characters (alphanumeric, '.', '-', '/') and avoid special characters."
-            )
-
-        original_name = name
-        if name and not (name := fmt.safe_validate_name(name)):
-            return console.error(f"Invalid name for define scalar: {original_name}, must be a string.")
-
-        original_color = color
-        if color and not (color := fmt.safe_validate_color(color)):
-            return console.error(f"Invalid color for define scalar: {original_color}, must be a hex color code.")
-
-        if (this_x_axis := fmt.safe_validate_x_axis(x_axis)) is None:
-            return console.error(f"Invalid x_axis for define scalar: {x_axis}, must be a valid ScalarXAxisType.")
-
-        original_chart_name = chart_name
-        if chart_name and not (chart_name := fmt.safe_validate_chart_name(chart_name)):
-            return console.error(f"Invalid chart_name for define scalar: {original_chart_name}, must be a string.")
-
-        self._components.emitter.emit(
-            ScalarDefineEvent(
-                key=this_key,
-                name=name,
-                color=color,
-                system=False,
-                x_axis=this_x_axis,
-                chart_name=chart_name,
-                chart=None,
-            )
-        )
+        # if not (this_key := fmt.safe_validate_key(key)):
+        #     return console.error(
+        #         f"Invalid key for define scalar: {key}, please use valid characters (alphanumeric, '.', '-', '/') and avoid special characters."
+        #     )
+        #
+        # original_name = name
+        # if name and not (name := fmt.safe_validate_name(name)):
+        #     return console.error(f"Invalid name for define scalar: {original_name}, must be a string.")
+        #
+        # original_color = color
+        # if color and not (color := fmt.safe_validate_color(color)):
+        #     return console.error(f"Invalid color for define scalar: {original_color}, must be a hex color code.")
+        #
+        # if (this_x_axis := fmt.safe_validate_x_axis(x_axis)) is None:
+        #     return console.error(f"Invalid x_axis for define scalar: {x_axis}, must be a valid ScalarXAxisType.")
+        #
+        # original_chart_name = chart_name
+        # if chart_name and not (chart_name := fmt.safe_validate_chart_name(chart_name)):
+        #     return console.error(f"Invalid chart_name for define scalar: {original_chart_name}, must be a string.")
+        #
+        # self._components.emitter.emit(
+        #     ScalarDefineEvent(
+        #         key=this_key,
+        #         name=name,
+        #         color=color,
+        #         system=False,
+        #         x_axis=this_x_axis,
+        #         chart_name=chart_name,
+        #         chart=None,
+        #     )
+        # )
 
     @with_api("run.finish()", must_alive=False)
     def finish(

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -24,7 +24,8 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from swanlab.proto.swanlab.run.v1.run_pb2 import FinishRecord
 from swanlab.sdk.internal.bus import MetricLogEvent, ScalarDefineEvent
 from swanlab.sdk.internal.context import RunContext
-from swanlab.sdk.internal.pkg import adapter, console, fork, safe
+from swanlab.sdk.internal.pkg import adapter, console, fork, helper, safe
+from swanlab.sdk.internal.run import greeting
 from swanlab.sdk.internal.run.components import Components
 from swanlab.sdk.internal.run.components.config import Config
 from swanlab.sdk.internal.run.transforms import Audio, Image, Text, Video, normalize_media_input
@@ -101,9 +102,11 @@ class Run:
         >>> swanlab.finish()
     """
 
-    def __init__(self, ctx: RunContext):
+    def __init__(self, ctx: RunContext, path: Optional[str] = None):
         # 1. 基础状态、组件准备
         self._ctx = ctx
+        # 运行实验路径，/:username/:project_name/:run_id
+        self._path = path
         self._state: Union[FinishType, Literal["running"]] = "running"
         self._init_pid = fork.current_pid()
         # 外部API锁，防止并发调用
@@ -133,6 +136,7 @@ class Run:
         self._components.start()
         self._probe.start()
         console.init(bind_to=self._ctx.debug_dir if self.mode != "disabled" else None)
+        greeting.welcome(self._ctx, self)
 
     # ----------------------------------
     # 私有钩子
@@ -228,23 +232,30 @@ class Run:
     @cached_property
     def path(self) -> str:
         """
-        Current run path in the format of /:project/:run_id.
+        Current run path in the format of /:username/:project_name/:run_id.
 
         :return: Run path
         """
-        settings = self._ctx.config.settings
-        return f"/{settings.project.name}/runs/{settings.run.id}"
+        if not self._path:
+            raise ValueError(
+                "Run path is unavailable because the current run is not using SwanLab cloud mode. "
+                "Please initialize SwanLab with cloud mode to access the run path."
+            )
+        return self._path
 
     @cached_property
-    def url(self) -> Optional[str]:
+    def url(self) -> str:
         """
         Current run URL if in cloud mode, otherwise None.
         :return: Run URL or None
         """
+        if not self._path:
+            raise ValueError(
+                "Run url is unavailable because the current run is not using SwanLab cloud mode. "
+                "Please initialize SwanLab with cloud mode to access the run path."
+            )
         settings = self._ctx.config.settings
-        if settings.mode != "cloud":
-            return None
-        return f"{settings.web_host}/@{settings.project.workspace}{self.path}"
+        return f"{settings.web_host}{helper.fmt_run_path(self._path)}"
 
     @cached_property
     def config(self) -> Config:
@@ -577,6 +588,7 @@ class Run:
         if state == "crashed" and error is None:
             console.warning("Crashed reason has been set to 'unknown' due to missing error message.")
             error = "unknown"
+        greeting.goodbye(self._ctx, self)
         # 2. 运行结束，清理组件
         self._state = this_state
         # 停止所有内部组件（async_log → terminal → config → consumer）

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -137,7 +137,7 @@ class Run:
         assert run_settings.project.name, "project name is required when init run"
         assert run_settings.run.id, "run id is required when init run"
         self._callbacker.on_run_initialized(
-            self._ctx.run_dir, path or f"{run_settings.project.name}/{run_settings.run.id}"
+            self._ctx.run_dir, path or f"/{run_settings.project.name}/{run_settings.run.id}"
         )
         # 启动组件
         self._components.start()

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -132,7 +132,7 @@ class Run:
         signal.signal(signal.SIGINT, self._handle_sigint)
 
         # 3. 启动组件 + 初始化日志
-        self._callbacker.on_run_initialized(self._ctx.run_dir, self.path)
+        self._callbacker.on_run_initialized(self._ctx.run_dir, path)
         self._components.start()
         self._probe.start()
         console.init(bind_to=self._ctx.debug_dir if self.mode != "disabled" else None)

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -531,6 +531,8 @@ class Run:
         :param x_axis: Optional x-axis type for the column.
         :param chart_name: Optional chart name to group the column into.
         """
+        raise NotImplementedError("run.define_scalar() is not available yet. Support is planned for a future release.")
+
         # TODO: 实现 glob 匹配逻辑
         if not (this_key := fmt.safe_validate_key(key)):
             return console.error(

--- a/swanlab/sdk/internal/run/greeting.py
+++ b/swanlab/sdk/internal/run/greeting.py
@@ -1,0 +1,97 @@
+"""
+@author: cunyue
+@file: greeting.py
+@time: 2026/4/28 13:36
+@description: 用于在终端打印run运行开始、结束的提示信息
+"""
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+
+from swanlab.sdk.internal.context import RunContext
+from swanlab.sdk.internal.pkg import console
+from swanlab.sdk.internal.pkg.helper.version import get_swanlab_version
+
+if TYPE_CHECKING:
+    from swanlab.sdk.internal.run import Run
+
+__all__ = ["welcome", "goodbye"]
+
+
+def _print_version():
+    version = get_swanlab_version()
+    console.info("Tracking run with swanlab version", version)
+
+
+def _print_save_dir(ctx: RunContext):
+    console.info("Run data will be saved locally in", Text(str(ctx.config.run_dir), "magenta bold"))
+
+
+def _print_cloud_tip(run: "Run"):
+    project_url = run.url.split("/runs/")[0]
+    console.info(f"🏠 View project at {project_url}")
+    console.info(f"🚀 View run at {run.url}")
+
+
+def _print_local_tip(ctx: RunContext):
+    console.info(
+        "🌟 Run ",
+        Text(f"`swanlab watch {str(ctx.config.settings.log_dir)}`", "bold"),
+        "to view SwanLab Experiment Dashboard",
+    )
+
+
+def _print_offline_tip(ctx: RunContext):
+    console.info(
+        "☁️ Run ",
+        Text(f"`swanlab sync {str(ctx.config.run_dir)}`", "bold"),
+        "to sync this run",
+    )
+
+
+def welcome(ctx: RunContext, run: "Run"):
+    """
+    实验开始欢迎语，根据不同模式选择不同的欢迎语
+    0. Disabled: 直接返回
+    1. Cloud: 打印版本号、运行日志存储位置、实验名称、项目、实验的URL，并单独开启线程检查新版本
+    2. Local: 打印版本号、运行日志存储位置、watch命令
+    3. Offline: 答应版本号、运行日志存储位置、实验名称、sync命令
+    """
+    mode = ctx.config.settings.mode
+    # 0. Disabled
+    if mode == "disabled":
+        return
+    # 1. Cloud
+    elif mode == "cloud":
+        _print_version()
+        _print_save_dir(ctx)
+        if ctx.config.settings.experiment.name:
+            console.info("Syncing run", Text(ctx.config.settings.experiment.name, "yellow"))
+        _print_cloud_tip(run)
+    # 2. Local
+    elif mode == "local":
+        _print_version()
+        _print_save_dir(ctx)
+        _print_local_tip(ctx)
+    # 3. Offline
+    elif mode == "offline":
+        _print_version()
+        _print_save_dir(ctx)
+        _print_offline_tip(ctx)
+
+
+def goodbye(ctx: RunContext, run: "Run"):
+    mode = ctx.config.settings.mode
+    # 0. Disabled
+    if mode == "disabled":
+        return
+    # 1. Cloud
+    elif mode == "cloud":
+        _print_cloud_tip(run)
+    # 2. Local
+    elif mode == "local":
+        _print_local_tip(ctx)
+    # 3. Offline
+    elif mode == "offline":
+        _print_offline_tip(ctx)

--- a/swanlab/sdk/protocol/callbacker.py
+++ b/swanlab/sdk/protocol/callbacker.py
@@ -17,12 +17,12 @@ class Callback(ABC):
     at various stages of an experiment.
     """
 
-    def on_run_initialized(self, run_dir: Path, path: str) -> None:
+    def on_run_initialized(self, run_dir: Path, path: Optional[str]) -> None:
         """
         Called immediately after `swanlab.init` has successfully executed.
 
         :param run_dir: The directory path where the run is stored.
-        :param path: The cloud routing path of the experiment, formatted as `/:project/:run_id`.
+        :param path: The cloud routing path of the experiment, formatted as `/:username/:project/:run_id`.
         """
         ...
 

--- a/swanlab/sdk/protocol/callbacker.py
+++ b/swanlab/sdk/protocol/callbacker.py
@@ -17,12 +17,13 @@ class Callback(ABC):
     at various stages of an experiment.
     """
 
-    def on_run_initialized(self, run_dir: Path, path: Optional[str]) -> None:
+    def on_run_initialized(self, run_dir: Path, path: str) -> None:
         """
         Called immediately after `swanlab.init` has successfully executed.
 
-        :param run_dir: The directory path where the run is stored.
-        :param path: The cloud routing path of the experiment, formatted as `/:username/:project/:run_id`.
+        :param run_dir: The directory where the run is stored.
+        :param path: The run path, formatted as `/:username/:project/:run_id` in cloud mode,
+            or `/:project/:run_id` otherwise.
         """
         ...
 

--- a/swanlab/sdk/typings/core_python/api/experiment.py
+++ b/swanlab/sdk/typings/core_python/api/experiment.py
@@ -5,9 +5,11 @@
 @description: SwanLab 运行时实验API类型
 """
 
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 
 class InitExperimentType(TypedDict):
     # 实验cuid
     cuid: str
+    # 实验slug(run id)
+    slug: Optional[str]

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -843,6 +843,9 @@ class TestInitFactoryDispatch:
     def test_non_disabled_run_emitter_enqueues_events(self):
         """RunEmitter.emit() 将事件放入队列"""
         run = init(mode="local")
+        # 排空 greeting 产生的 ConsoleEvent
+        while not run._components.emitter.queue.empty():
+            run._components.emitter.queue.get_nowait()
         run._components.emitter.emit("test-event")  # type: ignore
         assert not run._components.emitter.queue.empty()
         assert run._components.emitter.queue.get_nowait() == "test-event"

--- a/tests/unit/sdk/internal/pkg/helper/test_pkg_helper.py
+++ b/tests/unit/sdk/internal/pkg/helper/test_pkg_helper.py
@@ -5,7 +5,9 @@
 @description: SwanLab SDK 辅助函数
 """
 
-from swanlab.sdk.internal.pkg.helper import strip_none
+import pytest
+
+from swanlab.sdk.internal.pkg.helper import fmt_run_path, strip_none
 
 
 class TestStripNone:
@@ -60,3 +62,24 @@ class TestStripNone:
         """测试 strip_empty_dict=False 时，即使嵌套字典变空也保留"""
         data = {"outer": {"a": None}, "c": 1}
         assert strip_none(data, strip_empty_dict=False) == {"outer": {}, "c": 1}
+
+
+class TestFmtRunPath:
+    """测试 fmt_run_path 函数"""
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("/cunyue/demo/run1", "/@cunyue/demo/runs/run1"),
+            ("cunyue/demo/run1", "/@cunyue/demo/runs/run1"),
+            ("/@cunyue/demo/run1", "/@cunyue/demo/runs/run1"),
+            ("@cunyue/demo/run1", "/@cunyue/demo/runs/run1"),
+        ],
+    )
+    def test_normalizes_to_at_username(self, path, expected):
+        assert fmt_run_path(path) == expected
+
+    @pytest.mark.parametrize("path", ["only-one-part", "two-parts", "", "/", "/cunyue"])
+    def test_invalid_path_raises(self, path):
+        with pytest.raises(ValueError, match="Invalid run path"):
+            fmt_run_path(path)


### PR DESCRIPTION
## Summary

### 破坏性调整

- 暂时注释 define_scalar 接口，后端还未准备好，设计上预留

### 新增功能
- **greeting/farewell**：`init()` 成功后打印欢迎信息（含实验 URL），`finish()` 后打印告别信息
- **`Run.path`**：从后端响应获取实验路径 `/:username/:project_name/:run_id`，cloud 模式必填
- **`Run.url`**：基于 `path` + `web_host` + `fmt_run_path` 生成前端可访问 URL，cloud 模式必填
- **`fmt_run_path`**：新增辅助函数，将后端路径归一化为 `/@:username/:project_name/runs/:run_id`
- **`StartResponse.path`**：proto 新增 `path` 字段，`CorePython._report_run_start` 中拼接返回

### 改进
- **登录欢迎语**：显示昵称/用户名、登录地址、relogin 提示，Rich Text 样式修复
- **`Console` 默认关闭 highlighter**：避免 f-string 中 URL/数字被意外高亮
- **`login_raw` 移除 `wellcome_on_success` 参数**：统一由调用方控制

### 测试
- 新增 `TestFmtRunPath`：覆盖 4 种路径格式归一化 + 非法路径校验