### PR TITLE
Rename 'cloud' mode to 'online' across codebase

### DIFF
--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -87,18 +87,18 @@ def init(
 
     :param reinit: If True, finish the current run before starting a new one. Defaults to False.
     :param logdir: Directory to store logs. Defaults to "./swanlog".
-    :param mode: Run mode. Options: "cloud" (sync to cloud), "local" (local only),
-        "offline" (save locally for later sync), "disabled" (no logging). Defaults to "cloud".
+    :param mode: Run mode. Options: "online" (sync to cloud), "local" (local only),
+        "offline" (save locally for later sync), "disabled" (no logging). Defaults to "online".
     :param workspace: Workspace or organization name. Defaults to current user.
     :param project: Project name. Defaults to current directory name.
-    :param public: Make project publicly visible (cloud mode only). Defaults to False.
+    :param public: Make project publicly visible (online mode only). Defaults to False.
     :param name: Experiment name. Auto-generated if not provided.
     :param color: Experiment color for visualization. Auto-generated if not provided.
     :param description: Experiment description.
     :param job_type: Job type label (e.g., "train", "eval").
     :param group: Group name for organizing related experiments.
     :param tags: List of tags for categorizing experiments.
-    :param id: Run ID for resuming a previous run (cloud mode only).
+    :param id: Run ID for resuming a previous run (online mode only).
     :param resume: Resume behavior. Options: "must" (must resume), "allow" (resume if exists),
         "never" (always create new). Defaults to "never".
     :param config: Experiment configuration dict or path to config file (JSON/YAML).
@@ -121,7 +121,7 @@ def init(
         >>> import swanlab
         >>> swanlab.login(api_key="your_key")
         >>> swanlab.init(
-        ...     mode="cloud",
+        ...     mode="online",
         ...     project="image_classification",
         ...     name="resnet50_experiment",
         ...     config={"lr": 0.001, "batch_size": 32}
@@ -193,7 +193,7 @@ def login(
 
         >>> import swanlab
         >>> swanlab.login(api_key="your_api_key_here")
-        >>> swanlab.init(mode="cloud")
+        >>> swanlab.init(mode="online")
 
         Force re-login and save credentials:
 

--- a/swanlab/cli/converter/__init__.py
+++ b/swanlab/cli/converter/__init__.py
@@ -33,8 +33,8 @@ import click
 )
 @click.option(
     "--mode",
-    default="cloud",
-    type=click.Choice(["cloud", "local", "offline", "disabled"]),
+    default="online",
+    type=click.Choice(["online", "local", "offline", "disabled"]),
     help="The mode of the swanlab run.",
 )
 @click.option(

--- a/swanlab/cli/mode/__init__.py
+++ b/swanlab/cli/mode/__init__.py
@@ -24,7 +24,7 @@ def local():
 
 @click.command()
 def online():
-    """Use cloud mode for SwanLab."""
+    """Use online mode for SwanLab."""
     # TODO: 接入重构后的 mode 设置逻辑
     pass
 

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -115,14 +115,14 @@ def init(
 
     :param logdir: Directory to store logs. Defaults to "./swanlog".
 
-    :param mode: Run mode. Options: "cloud" (sync to cloud), "local" (local only),
-        "offline" (save locally for later sync), "disabled" (no logging). Defaults to "cloud".
+    :param mode: Run mode. Options: "online" (sync to cloud), "local" (local only),
+        "offline" (save locally for later sync), "disabled" (no logging). Defaults to "online".
 
     :param workspace: Workspace or organization name. Defaults to current user.
 
     :param project: Project name. Defaults to current directory name.
 
-    :param public: Make project publicly visible (cloud mode only). Defaults to False.
+    :param public: Make project publicly visible (online mode only). Defaults to False.
 
     :param name: Experiment name. Auto-generated if not provided.
 
@@ -136,7 +136,7 @@ def init(
 
     :param tags: List of tags for categorizing experiments.
 
-    :param id: Run ID for resuming a previous run (cloud mode only).
+    :param id: Run ID for resuming a previous run (online mode only).
 
     :param resume: Resume behavior. Options: "must" (must resume), "allow" (resume if exists),
         "never" (always create new). Defaults to "never".
@@ -160,12 +160,12 @@ def init(
         >>> swanlab.log({"loss": 0.5})
         >>> swanlab.finish()
 
-        Cloud run with configuration:
+        Online run with configuration:
 
         >>> import swanlab
         >>> swanlab.login(api_key="your_key")
         >>> swanlab.init(
-        ...     mode="cloud",
+        ...     mode="online",
         ...     project="image_classification",
         ...     name="resnet50_experiment",
         ...     config={"lr": 0.001, "batch_size": 32}
@@ -177,7 +177,7 @@ def init(
 
         >>> import swanlab
         >>> swanlab.init(
-        ...     mode="cloud",
+        ...     mode="online",
         ...     project="my_project",
         ...     id="previous_run_id",
         ...     resume="must"
@@ -224,7 +224,7 @@ def init(
     mode = prompt_init_mode(run_settings)
     run_settings.merge_settings({"mode": mode})
     # 校验 run id 与 resume，仅在对两者存在性有要求的模式下校验
-    if run_settings.mode == "cloud":
+    if run_settings.mode == "online":
         if run_settings.run.resume == "must":
             assert run_settings.run.id is not None, "Run id must be provided when resume=must."
         elif run_settings.run.resume == "never":
@@ -234,7 +234,7 @@ def init(
     callbacker.merge_callbacks(callbacks or [])
     # 开始初始化
     generate_ctx = _init
-    if run_settings.mode == "cloud":
+    if run_settings.mode == "online":
         generate_ctx = utils.with_loading_animation()(_init)
     ctx, path = generate_ctx(run_settings)
     # 初始化run
@@ -296,10 +296,10 @@ def load_config(run_settings: Settings, config: Optional[ConfigLike]) -> Dict[st
 
 def prompt_init_mode(settings: Settings) -> ModeType:
     """
-    在 swanlab.init 阶段，针对 cloud 模式且未登录的用户进行交互式引导。
+    在 swanlab.init 阶段，针对 online 模式且未登录的用户进行交互式引导。
 
     规则：
-    1. 只有在 settings.interactive 为 True 且 settings.mode 为 'cloud' 时触发 。
+    1. 只有在 settings.interactive 为 True 且 settings.mode 为 'online' 时触发 。
     2. 如果 client 已存在（已登录），直接跳过 。
     3. 提供三个选项：(1) 使用已有的Key (2) 注册 (3) 切换为 offline 模式。
 
@@ -308,22 +308,24 @@ def prompt_init_mode(settings: Settings) -> ModeType:
     """
     # 如果不是云模式，或者已经登录，或者非交互环境，直接返回当前状态
     mode = settings.mode
-    if mode != "cloud" or client.exists():
+    if mode != "online" or client.exists():
         return mode
     login_func = partial(login_cli, save=True, host=settings.api_host)
-    if mode == "cloud":
+    if mode == "online":
         if settings.api_key is not None:
             # 不登录，交给后面处理，否则会出现闪烁动画，比较影响美感
             # login_func(api_key=settings.api_key)
-            return "cloud"
+            return "online"
 
         if not settings.interactive:
             raise RuntimeError(
-                "Failed to initialize SwanLab in cloud mode: no API key was provided, "
+                "Failed to initialize SwanLab in online mode: no API key was provided, "
                 "and interactive prompts are disabled."
             )
         if not helper.is_interactive():
-            raise RuntimeError("Failed to initialize SwanLab in cloud mode: no TTY is available for interactive login.")
+            raise RuntimeError(
+                "Failed to initialize SwanLab in online mode: no TTY is available for interactive login."
+            )
 
         console.info("Using SwanLab to track your experiments. To get started, choose one of the following options:")
         console.print(
@@ -339,12 +341,12 @@ def prompt_init_mode(settings: Settings) -> ModeType:
             if choice == "1":
                 console.info("Using an existing SwanLab API key.")
                 login_func()
-                return "cloud"
+                return "online"
 
             if choice == "2":
-                console.info(f"Create a SwanLab account here:{settings.web_host}/login")
+                console.info(f"Create a SwanLab account here: {settings.web_host}/login")
                 login_func()
-                return "cloud"
+                return "online"
 
             if choice == "3":
                 console.info("Continuing in Offline mode. Results will be saved locally.")
@@ -365,7 +367,7 @@ def send_webhook(ctx: RunContext) -> Tuple[bool, bool]:
       "value": "string",  // 即 SWANLAB_WEBHOOK_VALUE 的值
       "swanlab": {
         "version": "string",     // swanlab 版本号
-        "mode": "cloud" | "local", // swanlab 运行模式
+        "mode": "online" | "local", // swanlab 运行模式
         "run_dir": "string",  // 日志存储路径
         "exp_url": "string"       // 云端实验路径
       }
@@ -386,7 +388,7 @@ def send_webhook(ctx: RunContext) -> Tuple[bool, bool]:
     webhook_value = webhook.value
     webhook_timeout = webhook.timeout
     # 获取实验url
-    if settings.mode == "cloud":
+    if settings.mode == "online":
         exp_url = f"{settings.web_host}/@{settings.project.workspace}/{settings.project.name}/runs/{settings.run.id}"
     else:
         exp_url = None
@@ -469,9 +471,9 @@ def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
     # 3. 创建一个临时的上下文，避免出现任何问题导致上下文残留
     with use_context(RunContext(config=RunConfig(settings=run_settings, run_dir=run_dir))) as ctx:
         assert run_settings.project.name, "Project name is required."
-        # 1. cloud 模式前置：确保 client 已就绪
-        if mode == "cloud":
-            _ensure_cloud_client(run_settings)
+        # 1. online 模式前置：确保 client 已就绪
+        if mode == "online":
+            _ensure_online_client(run_settings)
         # 2. 确定默认 workspace 并生成本地 name/color，合并到 settings
         workspace = run_settings.project.workspace
         name = generate_name("beauty")
@@ -485,7 +487,7 @@ def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
         }.items():
             set_nested_value(args_dict, key, value)
         run_settings.merge_settings(args_dict)
-        # 3. 统一调用 deliver_run_start（core 内部按 mode 分发：cloud 走网络，其余本地处理）
+        # 3. 统一调用 deliver_run_start（core 内部按 mode 分发：online 走网络，其余本地处理）
         ts = Timestamp()
         ts.GetCurrentTime()
         resp = ctx.core.deliver_run_start(
@@ -507,9 +509,9 @@ def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
         if not resp.success:
             raise RuntimeError(resp.message)
         path = resp.path or path
-        if mode == "cloud":
-            assert path, "Initialization path failed when mode=cloud"
-        # 4. 从 core 响应同步配置（cloud 模式会覆盖为服务端分配的值）
+        if mode == "online":
+            assert path, "Initialization path failed when mode=online"
+        # 4. 从 core 响应同步配置（online 模式会覆盖为服务端分配的值）
         sync_args = {}
         merge_dict = helper.strip_none(
             {
@@ -529,9 +531,9 @@ def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
     return ctx, path
 
 
-def _ensure_cloud_client(run_settings: Settings):
+def _ensure_online_client(run_settings: Settings):
     """
-    确保 cloud 模式下 client 已就绪，未登录时自动执行登录。
+    确保 online 模式下 client 已就绪，未登录时自动执行登录。
     :param run_settings: 运行时配置
     """
     if not client.exists():

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -64,19 +64,19 @@ def login(
 
         >>> import swanlab
         >>> swanlab.login(api_key="your_api_key_here")
-        >>> swanlab.init(mode="cloud")
+        >>> swanlab.init(mode="online")
 
         Interactive login (prompts for API key):
 
         >>> import swanlab
         >>> swanlab.login()
-        >>> swanlab.init(mode="cloud")
+        >>> swanlab.init(mode="online")
 
         Force re-login and save credentials:
 
         >>> import swanlab
         >>> swanlab.login(api_key="new_api_key", relogin=True, save=True)
-        >>> swanlab.init(mode="cloud")
+        >>> swanlab.init(mode="online")
     """
     return login_raw(
         api_key=api_key,

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -82,26 +82,26 @@ class CorePython(CoreProtocol):
         record = builder.build_start_record(resp.run)
         self._store.write(record.SerializeToString())
 
-    def _start_without_cloud(self, start_record: StartRecord, message: str) -> StartResponse:
+    def _start_without_online(self, start_record: StartRecord, message: str) -> StartResponse:
         resp = StartResponse(success=True, message=message, run=start_record)
         self._start_store(resp)
         return resp
 
     def _start_when_local(self, start_record: StartRecord) -> StartResponse:
-        return self._start_without_cloud(start_record, "OK, but use local")
+        return self._start_without_online(start_record, "OK, but use local")
 
     def _start_when_offline(self, start_record: StartRecord) -> StartResponse:
-        return self._start_without_cloud(start_record, "OK, but use offline")
+        return self._start_without_online(start_record, "OK, but use offline")
 
-    def _start_when_cloud(self, start_record: StartRecord) -> StartResponse:
+    def _start_when_online(self, start_record: StartRecord) -> StartResponse:
         resp = self._report_run_start(start_record)
         self._start_store(resp)
-        # Transport initialization is part of startup in cloud mode.
+        # Transport initialization is part of startup in online mode.
         # Fail fast on error instead of degrading silently.
-        assert self._project, "project must be set when starting in cloud mode"
-        assert self._username, "username must be set when starting in cloud mode"
-        assert self._project_id, "project id must be set when starting in cloud mode"
-        assert self._experiment_id, "experiment id must be set when starting in cloud mode"
+        assert self._project, "project must be set when starting in online mode"
+        assert self._username, "username must be set when starting in online mode"
+        assert self._project_id, "project id must be set when starting in online mode"
+        assert self._experiment_id, "experiment id must be set when starting in online mode"
         sender = HttpRecordSender(
             run_dir=self._ctx.run_dir,
             username=self._username,
@@ -193,7 +193,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_column_record(self._counter, c) for c in columns]
         self._store_records(records)
 
-    def _upsert_columns_when_cloud(self, columns: List[ColumnRecord]) -> None:
+    def _upsert_columns_when_online(self, columns: List[ColumnRecord]) -> None:
         records = [builder.build_column_record(self._counter, c) for c in columns]
         self._store_records(records)
         self._transport_put(records)
@@ -208,7 +208,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_scalar_record(self._counter, d) for d in scalars]
         self._store_records(records)
 
-    def _upsert_scalars_when_cloud(self, scalars: List[ScalarRecord]) -> None:
+    def _upsert_scalars_when_online(self, scalars: List[ScalarRecord]) -> None:
         records = [builder.build_scalar_record(self._counter, d) for d in scalars]
         self._store_records(records)
         self._transport_put(records)
@@ -223,7 +223,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_media_record(self._counter, d) for d in media]
         self._store_records(records)
 
-    def _upsert_media_when_cloud(self, media: List[MediaRecord]) -> None:
+    def _upsert_media_when_online(self, media: List[MediaRecord]) -> None:
         records = [builder.build_media_record(self._counter, d) for d in media]
         self._store_records(records)
         self._transport_put(records)
@@ -238,7 +238,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_console_record(self._counter, c) for c in consoles]
         self._store_records(records)
 
-    def _upsert_consoles_when_cloud(self, consoles: List[ConsoleRecord]) -> None:
+    def _upsert_consoles_when_online(self, consoles: List[ConsoleRecord]) -> None:
         records = [builder.build_console_record(self._counter, c) for c in consoles]
         self._store_records(records)
         self._transport_put(records)
@@ -253,7 +253,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_config_record(c) for c in configs]
         self._store_records(records)
 
-    def _upsert_configs_when_cloud(self, configs: List[ConfigRecord]) -> None:
+    def _upsert_configs_when_online(self, configs: List[ConfigRecord]) -> None:
         records = [builder.build_config_record(c) for c in configs]
         self._store_records(records)
         self._transport_put(records)
@@ -268,7 +268,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_requirements_record(r.timestamp) for r in requirements]
         self._store_records(records)
 
-    def _upsert_requirements_when_cloud(self, requirements: List[RequirementsRecord]) -> None:
+    def _upsert_requirements_when_online(self, requirements: List[RequirementsRecord]) -> None:
         records = [builder.build_requirements_record(r.timestamp) for r in requirements]
         self._store_records(records)
         self._transport_put(records)
@@ -283,7 +283,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_conda_record(c.timestamp) for c in conda]
         self._store_records(records)
 
-    def _upsert_conda_when_cloud(self, conda: List[CondaRecord]) -> None:
+    def _upsert_conda_when_online(self, conda: List[CondaRecord]) -> None:
         records = [builder.build_conda_record(c.timestamp) for c in conda]
         self._store_records(records)
         self._transport_put(records)
@@ -298,7 +298,7 @@ class CorePython(CoreProtocol):
         records = [builder.build_metadata_record(m.timestamp) for m in metadata]
         self._store_records(records)
 
-    def _upsert_metadata_when_cloud(self, metadata: List[MetadataRecord]) -> None:
+    def _upsert_metadata_when_online(self, metadata: List[MetadataRecord]) -> None:
         records = [builder.build_metadata_record(m.timestamp) for m in metadata]
         self._store_records(records)
         self._transport_put(records)
@@ -353,7 +353,7 @@ class CorePython(CoreProtocol):
         self._finish_store(record)
         return FinishResponse(success=True, message="OK, but use offline")
 
-    def _finish_when_cloud(self, finish_record: FinishRecord) -> FinishResponse:
+    def _finish_when_online(self, finish_record: FinishRecord) -> FinishResponse:
         record, console_record = self._build_finish_record(finish_record)
         self._finish_store(record)
         assert self._transport is not None, "transport must be initialized before finishing"

--- a/swanlab/sdk/internal/probe_python/__init__.py
+++ b/swanlab/sdk/internal/probe_python/__init__.py
@@ -101,7 +101,7 @@ class ProbePython(ProbeProtocol):
     def _start_when_offline(self) -> None:
         self._start()
 
-    def _start_when_cloud(self) -> None:
+    def _start_when_online(self) -> None:
         self._start()
 
     def _finish(self):
@@ -115,6 +115,6 @@ class ProbePython(ProbeProtocol):
         if self._monitor is not None:
             self._monitor.stop()
 
-    def _finish_when_cloud(self) -> None:
+    def _finish_when_online(self) -> None:
         if self._monitor is not None:
             self._monitor.stop()

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -82,7 +82,7 @@ class Run:
 
         dir: Local directory where run data is stored.
 
-        url: Cloud URL for this run (None in local/offline/disabled mode).
+        url: Online URL for this run (None in local/offline/disabled mode).
 
     Examples:
 
@@ -245,21 +245,21 @@ class Run:
         """
         if not self._path:
             raise ValueError(
-                "Run path is unavailable because the current run is not using SwanLab cloud mode. "
-                "Please initialize SwanLab with cloud mode to access the run path."
+                "Run path is unavailable because the current run is not using SwanLab online mode. "
+                "Please initialize SwanLab with online mode to access the run path."
             )
         return self._path
 
     @cached_property
     def url(self) -> str:
         """
-        Current run URL if in cloud mode, otherwise None.
+        Current run URL if in online mode, otherwise None.
         :return: Run URL or None
         """
         if not self._path:
             raise ValueError(
-                "Run url is unavailable because the current run is not using SwanLab cloud mode. "
-                "Please initialize SwanLab with cloud mode to access the run path."
+                "Run url is unavailable because the current run is not using SwanLab online mode. "
+                "Please initialize SwanLab with online mode to access the run path."
             )
         settings = self._ctx.config.settings
         return f"{settings.web_host}{helper.fmt_run_path(self._path)}"

--- a/swanlab/sdk/internal/run/greeting.py
+++ b/swanlab/sdk/internal/run/greeting.py
@@ -28,7 +28,7 @@ def _print_save_dir(ctx: RunContext):
     console.info("Run data will be saved locally in", Text(str(ctx.config.run_dir), "magenta bold"))
 
 
-def _print_cloud_tip(run: "Run"):
+def _print_online_tip(run: "Run"):
     project_url = run.url.split("/runs/")[0]
     console.info(f"🏠 View project at {project_url}")
     console.info(f"🚀 View run at {run.url}")
@@ -54,7 +54,7 @@ def welcome(ctx: RunContext, run: "Run"):
     """
     实验开始欢迎语，根据不同模式选择不同的欢迎语
     0. Disabled: 直接返回
-    1. Cloud: 打印版本号、运行日志存储位置、实验名称、项目、实验的URL，并单独开启线程检查新版本
+    1. Online: 打印版本号、运行日志存储位置、实验名称、项目、实验的URL，并单独开启线程检查新版本
     2. Local: 打印版本号、运行日志存储位置、watch命令
     3. Offline: 答应版本号、运行日志存储位置、实验名称、sync命令
     """
@@ -62,13 +62,13 @@ def welcome(ctx: RunContext, run: "Run"):
     # 0. Disabled
     if mode == "disabled":
         return
-    # 1. Cloud
-    elif mode == "cloud":
+    # 1. Online
+    elif mode == "online":
         _print_version()
         _print_save_dir(ctx)
         if ctx.config.settings.experiment.name:
             console.info("Syncing run", Text(ctx.config.settings.experiment.name, "yellow"))
-        _print_cloud_tip(run)
+        _print_online_tip(run)
     # 2. Local
     elif mode == "local":
         _print_version()
@@ -86,9 +86,9 @@ def goodbye(ctx: RunContext, run: "Run"):
     # 0. Disabled
     if mode == "disabled":
         return
-    # 1. Cloud
-    elif mode == "cloud":
-        _print_cloud_tip(run)
+    # 1. Online
+    elif mode == "online":
+        _print_online_tip(run)
     # 2. Local
     elif mode == "local":
         _print_local_tip(ctx)

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -84,7 +84,7 @@ class Settings(BaseSettings):
 
         >>> from swanlab import Settings
         >>> settings = Settings(
-        ...     mode="cloud",
+        ...     mode="online",
         ...     monitor=Settings.Monitor(enable=False)
         ... )
         >>> import swanlab
@@ -106,13 +106,13 @@ class Settings(BaseSettings):
     Useful for CI/CD environments or background batch jobs.
     """
 
-    mode: ModeType = "cloud"
+    mode: ModeType = "online"
     """
     SwanLab Run mode.
-
-    * `local`: Run SwanLab locally.
-    * `cloud`: Run SwanLab on the cloud.
+    
     * `disabled`: Disable SwanLab.
+    * `local`: Run SwanLab locally.
+    * `online`: Run SwanLab syncing to cloud.
     * `offline`: Run SwanLab in offline mode.
     """
 
@@ -120,8 +120,8 @@ class Settings(BaseSettings):
     def validate_mode(cls, v: Any) -> ModeType:
         if v in list(get_args(ModeType)):
             return v
-        if v == "online":
-            return "cloud"
+        if v == "cloud":
+            return "online"
         raise ValueError(f"Invalid mode: {v}, allowed values are {list(get_args(ModeType))}")
 
     root: Path = Field(default_factory=root_factory)

--- a/swanlab/sdk/protocol/callbacker.py
+++ b/swanlab/sdk/protocol/callbacker.py
@@ -22,7 +22,7 @@ class Callback(ABC):
         Called immediately after `swanlab.init` has successfully executed.
 
         :param run_dir: The directory where the run is stored.
-        :param path: The run path, formatted as `/:username/:project/:run_id` in cloud mode,
+        :param path: The run path, formatted as `/:username/:project/:run_id` in online mode,
             or `/:project/:run_id` otherwise.
         """
         ...

--- a/swanlab/sdk/protocol/core.py
+++ b/swanlab/sdk/protocol/core.py
@@ -51,8 +51,8 @@ class CoreProtocol(ABC):
         约定应该在此处完成Core相关组件的初始化，在这里完成不同模式的初始化函数分发
         """
         with safe.block(message="run start error"):
-            if self._mode == "cloud":
-                return self._start_when_cloud(start_record)
+            if self._mode == "online":
+                return self._start_when_online(start_record)
             elif self._mode == "local":
                 return self._start_when_local(start_record)
             elif self._mode == "offline":
@@ -71,15 +71,15 @@ class CoreProtocol(ABC):
     def _start_when_offline(self, start_record: StartRecord) -> StartResponse: ...
 
     @abstractmethod
-    def _start_when_cloud(self, start_record: StartRecord) -> StartResponse: ...
+    def _start_when_online(self, start_record: StartRecord) -> StartResponse: ...
 
     # ---------------------------------- 指标定义 ----------------------------------
 
     def upsert_columns(self, columns: List[ColumnRecord]) -> None:
         """上报一组 ColumnRecord，定义指标列"""
         with safe.block(message="upsert columns error"):
-            if self._mode == "cloud":
-                return self._upsert_columns_when_cloud(columns)
+            if self._mode == "online":
+                return self._upsert_columns_when_online(columns)
             elif self._mode == "local":
                 return self._upsert_columns_when_local(columns)
             elif self._mode == "offline":
@@ -95,15 +95,15 @@ class CoreProtocol(ABC):
     def _upsert_columns_when_offline(self, columns: List[ColumnRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_columns_when_cloud(self, columns: List[ColumnRecord]) -> None: ...
+    def _upsert_columns_when_online(self, columns: List[ColumnRecord]) -> None: ...
 
     # ---------------------------------- 标量指标值 ----------------------------------
 
     def upsert_scalars(self, scalars: List[ScalarRecord]) -> None:
         """上报一组 ScalarRecord，记录标量指标值"""
         with safe.block(message="upsert data error"):
-            if self._mode == "cloud":
-                return self._upsert_scalars_when_cloud(scalars)
+            if self._mode == "online":
+                return self._upsert_scalars_when_online(scalars)
             elif self._mode == "local":
                 return self._upsert_scalars_when_local(scalars)
             elif self._mode == "offline":
@@ -119,15 +119,15 @@ class CoreProtocol(ABC):
     def _upsert_scalars_when_offline(self, scalars: List[ScalarRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_scalars_when_cloud(self, scalars: List[ScalarRecord]) -> None: ...
+    def _upsert_scalars_when_online(self, scalars: List[ScalarRecord]) -> None: ...
 
     # ---------------------------------- 媒体指标值 ----------------------------------
 
     def upsert_media(self, media: List[MediaRecord]) -> None:
         """上报一组 MediaRecord，记录媒体指标值"""
         with safe.block(message="upsert data error"):
-            if self._mode == "cloud":
-                return self._upsert_media_when_cloud(media)
+            if self._mode == "online":
+                return self._upsert_media_when_online(media)
             elif self._mode == "local":
                 return self._upsert_media_when_local(media)
             elif self._mode == "offline":
@@ -143,15 +143,15 @@ class CoreProtocol(ABC):
     def _upsert_media_when_offline(self, media: List[MediaRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_media_when_cloud(self, media: List[MediaRecord]) -> None: ...
+    def _upsert_media_when_online(self, media: List[MediaRecord]) -> None: ...
 
     # ---------------------------------- 用户配置 ----------------------------------
 
     def upsert_configs(self, configs: List[ConfigRecord]) -> None:
         """上报一组 ConfigRecord，记录用户对 config 的修改"""
         with safe.block(message="upsert configs error"):
-            if self._mode == "cloud":
-                return self._upsert_configs_when_cloud(configs)
+            if self._mode == "online":
+                return self._upsert_configs_when_online(configs)
             elif self._mode == "local":
                 return self._upsert_configs_when_local(configs)
             elif self._mode == "offline":
@@ -167,15 +167,15 @@ class CoreProtocol(ABC):
     def _upsert_configs_when_offline(self, configs: List[ConfigRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_configs_when_cloud(self, configs: List[ConfigRecord]) -> None: ...
+    def _upsert_configs_when_online(self, configs: List[ConfigRecord]) -> None: ...
 
     # ---------------------------------- 终端输出 ----------------------------------
 
     def upsert_consoles(self, consoles: List[ConsoleRecord]) -> None:
         """上报一组 ConsoleRecord，记录用户终端输出"""
         with safe.block(message="upsert consoles error"):
-            if self._mode == "cloud":
-                return self._upsert_consoles_when_cloud(consoles)
+            if self._mode == "online":
+                return self._upsert_consoles_when_online(consoles)
             elif self._mode == "local":
                 return self._upsert_consoles_when_local(consoles)
             elif self._mode == "offline":
@@ -191,15 +191,15 @@ class CoreProtocol(ABC):
     def _upsert_consoles_when_offline(self, consoles: List[ConsoleRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_consoles_when_cloud(self, consoles: List[ConsoleRecord]) -> None: ...
+    def _upsert_consoles_when_online(self, consoles: List[ConsoleRecord]) -> None: ...
 
     # ---------------------------------- 依赖信息 ----------------------------------
 
     def upsert_requirements(self, requirements: List[RequirementsRecord]) -> None:
         """上报一组 RequirementsRecord，记录对 requirements 的修改"""
         with safe.block(message="upsert requirements error"):
-            if self._mode == "cloud":
-                return self._upsert_requirements_when_cloud(requirements)
+            if self._mode == "online":
+                return self._upsert_requirements_when_online(requirements)
             elif self._mode == "local":
                 return self._upsert_requirements_when_local(requirements)
             elif self._mode == "offline":
@@ -215,15 +215,15 @@ class CoreProtocol(ABC):
     def _upsert_requirements_when_offline(self, requirements: List[RequirementsRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_requirements_when_cloud(self, requirements: List[RequirementsRecord]) -> None: ...
+    def _upsert_requirements_when_online(self, requirements: List[RequirementsRecord]) -> None: ...
 
     # ---------------------------------- conda信息 ----------------------------------
 
     def upsert_conda(self, conda: List[CondaRecord]) -> None:
         """上报一组 CondaRecord，记录对 conda 的修改"""
         with safe.block(message="upsert conda error"):
-            if self._mode == "cloud":
-                return self._upsert_conda_when_cloud(conda)
+            if self._mode == "online":
+                return self._upsert_conda_when_online(conda)
             elif self._mode == "local":
                 return self._upsert_conda_when_local(conda)
             elif self._mode == "offline":
@@ -239,15 +239,15 @@ class CoreProtocol(ABC):
     def _upsert_conda_when_offline(self, conda: List[CondaRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_conda_when_cloud(self, conda: List[CondaRecord]) -> None: ...
+    def _upsert_conda_when_online(self, conda: List[CondaRecord]) -> None: ...
 
     # ---------------------------------- 系统元信息 ----------------------------------
 
     def upsert_metadata(self, metadata: List[MetadataRecord]) -> None:
         """上报一组 MetadataRecord，记录对 metadata 的修改"""
         with safe.block(message="upsert metadata error"):
-            if self._mode == "cloud":
-                return self._upsert_metadata_when_cloud(metadata)
+            if self._mode == "online":
+                return self._upsert_metadata_when_online(metadata)
             elif self._mode == "local":
                 return self._upsert_metadata_when_local(metadata)
             elif self._mode == "offline":
@@ -263,7 +263,7 @@ class CoreProtocol(ABC):
     def _upsert_metadata_when_offline(self, metadata: List[MetadataRecord]) -> None: ...
 
     @abstractmethod
-    def _upsert_metadata_when_cloud(self, metadata: List[MetadataRecord]) -> None: ...
+    def _upsert_metadata_when_online(self, metadata: List[MetadataRecord]) -> None: ...
 
     # ---------------------------------- 运行结束 ----------------------------------
 
@@ -273,8 +273,8 @@ class CoreProtocol(ABC):
         约定应该在此处完成Core相关组件的清理，在这里完成不同模式的结束函数分发
         """
         with safe.block(message="run finish error"):
-            if self._mode == "cloud":
-                return self._finish_when_cloud(finish_record)
+            if self._mode == "online":
+                return self._finish_when_online(finish_record)
             elif self._mode == "local":
                 return self._finish_when_local(finish_record)
             elif self._mode == "offline":
@@ -293,7 +293,7 @@ class CoreProtocol(ABC):
     def _finish_when_offline(self, finish_record: FinishRecord) -> FinishResponse: ...
 
     @abstractmethod
-    def _finish_when_cloud(self, finish_record: FinishRecord) -> FinishResponse: ...
+    def _finish_when_online(self, finish_record: FinishRecord) -> FinishResponse: ...
 
     # ---------------------------------- 进程fork ----------------------------------
 

--- a/swanlab/sdk/protocol/probe.py
+++ b/swanlab/sdk/protocol/probe.py
@@ -41,8 +41,8 @@ class ProbeProtocol(ABC):
             return self._start_when_disabled()
         assert self._ctx.files_dir.is_dir(), "files_dir must be set before starting probe"
         with safe.block(message="probe start error"):
-            if self._mode == "cloud":
-                return self._start_when_cloud()
+            if self._mode == "online":
+                return self._start_when_online()
             elif self._mode == "local":
                 return self._start_when_local()
             return self._start_when_offline()
@@ -56,15 +56,15 @@ class ProbeProtocol(ABC):
     def _start_when_offline(self) -> None: ...
 
     @abstractmethod
-    def _start_when_cloud(self) -> None: ...
+    def _start_when_online(self) -> None: ...
 
     def finish(self):
         """
         停止 probe 服务
         """
         with safe.block(message="probe finish error"):
-            if self._mode == "cloud":
-                return self._finish_when_cloud()
+            if self._mode == "online":
+                return self._finish_when_online()
             elif self._mode == "local":
                 return self._finish_when_local()
             elif self._mode == "offline":
@@ -80,4 +80,4 @@ class ProbeProtocol(ABC):
     def _finish_when_offline(self) -> None: ...
 
     @abstractmethod
-    def _finish_when_cloud(self) -> None: ...
+    def _finish_when_online(self) -> None: ...

--- a/swanlab/sdk/typings/run/__init__.py
+++ b/swanlab/sdk/typings/run/__init__.py
@@ -12,7 +12,7 @@ ResumeType = Literal["must", "allow", "never"]
 Run 恢复策略
 """
 
-ModeType = Literal["disabled", "cloud", "local", "offline"]
+ModeType = Literal["disabled", "online", "local", "offline"]
 """
 Run 运行策略
 """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,7 +19,7 @@ def isolate_sdk_environment(tmp_path, monkeypatch):
       2. 重置 Settings 单例字段
 
     Teardown（测试后，无论成功或失败均执行）：
-      1. 清理 Run —— 需在 client 之前，cloud 模式的 finish() 依赖 client
+      1. 清理 Run —— 需在 client 之前，online 模式的 finish() 依赖 client
       2. 清理 Client 单例
       3. 清理 logger
       4. 清理 callbacker
@@ -46,7 +46,7 @@ def isolate_sdk_environment(tmp_path, monkeypatch):
     object.__setattr__(settings, "__pydantic_extra__", None)
 
     # 3. 清理 Run 单例
-    # 必须在 client 重置之前执行：cloud 模式的 run.finish() 可能需要 client 发送最后请求
+    # 必须在 client 重置之前执行：online 模式的 run.finish() 可能需要 client 发送最后请求
     # 若 finish() 本身出错（如后台线程异常），直接强制清除引用，防止污染下一个用例
     if (run := swanlab.run) is not None:
         # noinspection PyBroadException

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -11,7 +11,7 @@
   - TestInitReinit           : reinit 参数行为（跳过/重建）
   - TestInitSettingsPriority : 配置优先级（全局 < 自定义 < 传参）
   - TestInitResumeValidation : resume/id 校验逻辑
-  - TestInitCloudMode        : cloud 模式，依赖本文件内的 HTTP mock fixtures
+  - TestInitOnlineMode       : online 模式，依赖本文件内的 HTTP mock fixtures
   - TestInitFactoryDispatch  : 验证 factory 模式按模式分派组件类型
 """
 
@@ -34,7 +34,7 @@ from swanlab.sdk.internal.settings import Settings, settings
 from swanlab.sdk.typings.run import ModeType
 
 # ============================================================
-# Cloud 模式测试常量
+# Online 模式测试常量
 # ============================================================
 API_HOST = "https://api.fake.swanlab.cn"
 WEB_HOST = "https://test.swanlab.cn"
@@ -45,7 +45,7 @@ API_KEY = "test-api-key"
 
 
 # ============================================================
-# Cloud 模式响应体数据工厂
+# Online 模式响应体数据工厂
 # 返回与后端 schema 一致的 dict，支持 **overrides 局部定制
 # ============================================================
 
@@ -114,17 +114,17 @@ def make_presigned_put_resp(**overrides) -> dict:
 
 
 # ============================================================
-# Cloud 模式 HTTP Mock Fixtures
+# Online 模式 HTTP Mock Fixtures
 #
 # 分层设计：
 #   层 1 - rsps：激活 responses.RequestsMock，所有 endpoint fixture 共享同一实例
 #   层 2 - 单一 Endpoint Fixture：每个 fixture 只注册一个 API 端点
-#   层 3 - 组合 Fixture：mock_cloud_init_apis 一次性装配 init() cloud 流程所需端点
+#   层 3 - 组合 Fixture：mock_online_init_apis 一次性装配 init() online 流程所需端点
 #
-# 未来 _init_cloud 新增 API 调用时，只需：
+# 未来 _init_online 新增 API 调用时，只需：
 #   1. 新增 make_*_resp() 工厂函数
 #   2. 新增对应 endpoint fixture
-#   3. 将其追加为 mock_cloud_init_apis 的参数
+#   3. 将其追加为 mock_online_init_apis 的参数
 # ============================================================
 
 
@@ -251,14 +251,14 @@ def mock_resource_upload_api(rsps):
 
 
 @pytest.fixture
-def mock_cloud_settings():
+def mock_online_settings():
     """将全局 settings 的 api_host/web_host 指向测试 HOST，避免意外触发生产环境"""
     merge_settings({"api_host": API_HOST, "web_host": WEB_HOST})
 
 
 @pytest.fixture
-def mock_cloud_init_apis(
-    mock_cloud_settings,
+def mock_online_init_apis(
+    mock_online_settings,
     mock_login_api,
     mock_project_create_api,
     mock_project_get_api,
@@ -271,14 +271,14 @@ def mock_cloud_init_apis(
     mock_resource_upload_api,
 ):
     """
-    组合 fixture：一次性注册 init(mode='cloud') 当前所需的全部 HTTP 端点。
+    组合 fixture：一次性注册 init(mode='online') 当前所需的全部 HTTP 端点。
     所有子 fixture 通过 pytest 的 fixture 缓存机制共享同一个 rsps 实例。
     """
     pass
 
 
 @pytest.fixture
-def logged_in_client(mock_login_api, mock_cloud_settings):
+def logged_in_client(mock_login_api, mock_online_settings):
     """
     调用 login_raw() 完成登录流程，确保全局 client 已创建。
     依赖 mock_login_api，故登录请求不会触及真实网络。
@@ -463,33 +463,33 @@ class TestInitSettingsPriority:
 
 class TestInitResumeValidation:
     def test_resume_must_without_id_raises(self, monkeypatch):
-        """cloud 模式 resume='must' 但未提供 id → AssertionError"""
-        monkeypatch.setattr("swanlab.sdk.cmd.init.prompt_init_mode", lambda _: "cloud")
+        """online 模式 resume='must' 但未提供 id → AssertionError"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.prompt_init_mode", lambda _: "online")
 
         with pytest.raises(AssertionError, match="Run id must be provided"):
-            init(mode="cloud", resume="must")
+            init(mode="online", resume="must")
 
     def test_resume_never_with_id_raises(self, monkeypatch):
-        """cloud 模式 resume='never' 但同时提供了 id → AssertionError"""
-        monkeypatch.setattr("swanlab.sdk.cmd.init.prompt_init_mode", lambda _: "cloud")
+        """online 模式 resume='never' 但同时提供了 id → AssertionError"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.prompt_init_mode", lambda _: "online")
 
         with pytest.raises(AssertionError, match="Run id should not be provided"):
-            init(mode="cloud", resume="never", id="some-run-id")
+            init(mode="online", resume="never", id="some-run-id")
 
-    def test_resume_validation_skipped_for_non_cloud_mode(self):
-        """非 cloud 模式下，resume/id 校验不触发（即使传了也不报错）"""
+    def test_resume_validation_skipped_for_non_online_mode(self):
+        """非 online 模式下，resume/id 校验不触发（即使传了也不报错）"""
         run = init(mode="offline", resume="must")
 
         assert isinstance(run, Run)
 
 
 # ============================================================
-# TestInitCloudMode
+# TestInitOnlineMode
 # ============================================================
 
 
-class TestInitCloudMode:
-    def test_init_cloud_success(
+class TestInitOnlineMode:
+    def test_init_online_success(
         self,
         logged_in_client,
         mock_project_create_api,
@@ -498,13 +498,13 @@ class TestInitCloudMode:
         mock_experiment_stop_api,
         mock_profile_api,
     ):
-        """cloud 模式完整 init 流程：返回 Run，has_run() 为 True"""
-        run = init(mode="cloud", project=PROJECT)
+        """online 模式完整 init 流程：返回 Run，has_run() 为 True"""
+        run = init(mode="online", project=PROJECT)
 
         assert isinstance(run, Run)
         assert has_run()
 
-    def test_init_cloud_sets_project_and_workspace(
+    def test_init_online_sets_project_and_workspace(
         self,
         logged_in_client,
         mock_project_create_api,
@@ -513,14 +513,14 @@ class TestInitCloudMode:
         mock_experiment_stop_api,
         mock_profile_api,
     ):
-        """cloud 模式下，workspace 和 project.name 应与后端响应同步"""
-        run = init(mode="cloud", project=PROJECT)
+        """online 模式下，workspace 和 project.name 应与后端响应同步"""
+        run = init(mode="online", project=PROJECT)
         s = run._ctx.config.settings
 
         assert s.project.workspace == USERNAME
         assert s.project.name == PROJECT
 
-    def test_init_cloud_project_already_exists(
+    def test_init_online_project_already_exists(
         self,
         logged_in_client,
         rsps,
@@ -532,12 +532,12 @@ class TestInitCloudMode:
         """POST /project 返回 409（项目已存在）时，应优雅降级为获取项目，继续初始化"""
         rsps.add(responses_lib.POST, f"{API_HOST}/api/project", json=make_init_project_resp(), status=409)
 
-        run = init(mode="cloud", project=PROJECT)
+        run = init(mode="online", project=PROJECT)
 
         assert isinstance(run, Run)
         assert run._ctx.config.settings.project.workspace == USERNAME
 
-    def test_init_cloud_uses_all_expected_endpoints(
+    def test_init_online_uses_all_expected_endpoints(
         self,
         logged_in_client,
         mock_project_create_api,
@@ -547,8 +547,8 @@ class TestInitCloudMode:
         mock_profile_api,
         rsps,
     ):
-        """验证 cloud init 确实调用了 project 和 experiment 端点"""
-        init(mode="cloud", project=PROJECT)
+        """验证 online init 确实调用了 project 和 experiment 端点"""
+        init(mode="online", project=PROJECT)
 
         non_login_calls = [c.request.url for c in rsps.calls if "login" not in c.request.url]
 

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -21,7 +21,7 @@ def mock_settings():
     """构造一个轻量级的 Settings Mock 对象"""
     settings = MagicMock()
     settings.run.config = None
-    settings.mode = "cloud"
+    settings.mode = "online"
     settings.interactive = True
     settings.web_host = "https://swanlab.cn"
     return settings
@@ -62,16 +62,16 @@ def test_load_config_exceptions(mock_settings):
 # Tests for `prompt_init_mode`
 # ==========================================
 def test_prompt_fast_exits(mock_settings, monkeypatch):
-    """测试快速跳过的条件：非 cloud 模式、非交互模式、已登录"""
+    """测试快速跳过的条件：非 online 模式、非交互模式、已登录"""
     # 1. 模拟已登录 (client.exists 返回 True)
     monkeypatch.setattr("swanlab.sdk.cmd.init.client.exists", lambda: True)
-    assert prompt_init_mode(mock_settings) == "cloud"
+    assert prompt_init_mode(mock_settings) == "online"
 
     monkeypatch.setattr("swanlab.sdk.cmd.init.client.exists", lambda: False)
 
     # 2. 模拟非交互模式
     mock_settings.interactive = False
-    assert prompt_init_mode(mock_settings) == "cloud"
+    assert prompt_init_mode(mock_settings) == "online"
 
     # 3. 模拟非云端模式
     mock_settings.interactive = True
@@ -80,7 +80,7 @@ def test_prompt_fast_exits(mock_settings, monkeypatch):
 
 
 def test_prompt_auto_login(mock_settings, monkeypatch):
-    """测试本地已存在 apikey 时直接返回 cloud 模式"""
+    """测试本地已存在 apikey 时直接返回 online 模式"""
     monkeypatch.setattr("swanlab.sdk.cmd.init.client.exists", lambda: False)
     # 设置 api_key 模拟已存在凭证
     mock_settings.api_key = "fake-key"
@@ -88,7 +88,7 @@ def test_prompt_auto_login(mock_settings, monkeypatch):
     mock_login_raw = MagicMock(return_value=True)
     monkeypatch.setattr("swanlab.sdk.cmd.init.login_raw", mock_login_raw)
 
-    assert prompt_init_mode(mock_settings) == "cloud"
+    assert prompt_init_mode(mock_settings) == "online"
     # 有 api_key 时不再调用 login_raw，登录推迟到后续流程
 
 
@@ -98,9 +98,9 @@ def test_prompt_auto_login(mock_settings, monkeypatch):
         # 直接选 3 -> 切换离线模式
         (["3"], False, "offline"),
         # 直接选 1 -> 触发交互登录并返回成功
-        (["1"], True, "cloud"),
+        (["1"], True, "online"),
         # 直接选 2 -> 触发交互登录并返回失败
-        (["2"], False, "cloud"),
+        (["2"], False, "online"),
         # 乱输一通后选 3 -> 循环容错测试
         (["invalid", "wrong", "3"], False, "offline"),
     ],

--- a/tests/unit/sdk/cmd/init/test_init_webhook.py
+++ b/tests/unit/sdk/cmd/init/test_init_webhook.py
@@ -66,10 +66,10 @@ def test_send_webhook_no_url(mock_ctx, setup_mocks):
 
 
 @responses.activate
-def test_send_webhook_cloud_mode(mock_ctx, setup_mocks):
-    """测试 cloud 模式下的正常请求，验证云端 exp_url 拼接和 JSON 载荷"""
+def test_send_webhook_online_mode(mock_ctx, setup_mocks):
+    """测试 online 模式下的正常请求，验证云端 exp_url 拼接和 JSON 载荷"""
     settings = mock_ctx.config.settings
-    settings.mode = "cloud"
+    settings.mode = "online"
     settings.web_host = "https://swanlab.cn"
     settings.project.workspace = "test_user"
     settings.project.name = "test_project"
@@ -93,7 +93,7 @@ def test_send_webhook_cloud_mode(mock_ctx, setup_mocks):
         "value": "test_webhook_value",
         "swanlab": {
             "version": "1.0.0",
-            "mode": "cloud",
+            "mode": "online",
             "run_dir": "/path/to/run_dir",
             "exp_url": "https://swanlab.cn/@test_user/test_project/runs/run_12345",
         },

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -39,7 +39,7 @@ def make_start_record() -> StartRecord:
 
 class TestCorePythonStart:
     @pytest.mark.parametrize("mode", ["disabled", "local", "offline"])
-    def test_non_cloud_modes(self, tmp_path, mode):
+    def test_non_online_modes(self, tmp_path, mode):
         ctx = make_ctx(tmp_path, mode)
         core = CorePython(ctx)
         resp = core.deliver_run_start(make_start_record())
@@ -51,14 +51,14 @@ class TestCorePythonStart:
         else:
             assert core._store is not None
 
-    def test_cloud_mode(self, tmp_path, monkeypatch):
-        ctx = make_ctx(tmp_path, "cloud")
+    def test_online_mode(self, tmp_path, monkeypatch):
+        ctx = make_ctx(tmp_path, "online")
         core = CorePython(ctx)
         record = make_start_record()
         mock_deliver = MagicMock(return_value=StartResponse(success=True, message="OK", run=record))
 
         def _report_run_start_and_set_attrs(rec):
-            """mock _report_run_start，同时设置 cloud 模式所需的属性。"""
+            """mock _report_run_start，同时设置 online 模式所需的属性。"""
             core._username = "test-user"
             core._project = "test-project"
             core._project_id = "test-project-id"
@@ -82,7 +82,7 @@ class TestCorePythonStart:
 
 class TestCorePythonFinish:
     @pytest.mark.parametrize("mode", ["disabled", "local", "offline"])
-    def test_non_cloud_modes(self, tmp_path, mode):
+    def test_non_online_modes(self, tmp_path, mode):
         ctx = make_ctx(tmp_path, mode)
         core = CorePython(ctx)
         core.deliver_run_start(make_start_record())
@@ -92,14 +92,14 @@ class TestCorePythonFinish:
         assert resp.success is True
         assert core._store is None
 
-    def test_cloud_closes_store_and_transport(self, tmp_path, monkeypatch):
-        ctx = make_ctx(tmp_path, "cloud")
+    def test_online_closes_store_and_transport(self, tmp_path, monkeypatch):
+        ctx = make_ctx(tmp_path, "online")
         core = CorePython(ctx)
 
         mock_start = MagicMock(return_value=StartResponse(success=True, message="OK", run=make_start_record()))
 
         def _report_run_start_and_set_attrs(rec):
-            """mock _report_run_start，同时设置 cloud 模式所需的属性。"""
+            """mock _report_run_start，同时设置 online 模式所需的属性。"""
             core._username = "test-user"
             core._project = "test-project"
             core._project_id = "test-project-id"

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -101,10 +101,13 @@ def test_secrets_loading(tmp_path):
 def test_mode_validation():
     """测试 mode 字段的校验与转换"""
     s_default = Settings()
-    assert s_default.mode == "cloud"
+    assert s_default.mode == "online"
 
-    s_online = Settings(mode="online")  # type: ignore
-    assert s_online.mode == "cloud"
+    s_online = Settings(mode="online")
+    assert s_online.mode == "online"
+
+    s_cloud_compat = Settings(mode="cloud")  # type: ignore
+    assert s_cloud_compat.mode == "online"
 
     with pytest.raises(ValueError, match="Invalid mode: invalid, allowed values are"):
         Settings(mode="invalid")  # type: ignore
@@ -267,7 +270,7 @@ class TestNetrcFallback:
         # 验证 netrc 读取进来的属性没有因为 merge (exclude_unset=True) 而丢失
         assert settings.api_key == "sync_token"
         assert settings.api_host == "https://api.sync.com"
-        assert settings.mode == "cloud"
+        assert settings.mode == "online"
 
 
 def test_directory_validators(tmp_path):


### PR DESCRIPTION
明确 swanlab mode 为：

* `disabled`: Disable SwanLab.
* `local`: Run SwanLab locally.
* `online`: Run SwanLab syncing to cloud.
* `offline`: Run SwanLab in offline mode.

mode=cloud不再受代码提示支持，但是依旧可用