### PR TITLE
feat: return experiment name in StartResponse

### DIFF
--- a/core/proto/swanlab/run/v1/run.pb.go
+++ b/core/proto/swanlab/run/v1/run.pb.go
@@ -262,7 +262,8 @@ type StartResponse struct {
 	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"` // 请求是否成功
 	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`  // 请求失败的响应
 	Run           *StartRecord           `protobuf:"bytes,3,opt,name=run,proto3" json:"run,omitempty"`          // 最终创建的 Run 记录
-	Path          string                 `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`        // 对应的实验路径，格式为 /@:username/:project_name/runs/:slug(run_id)
+	Path          string                 `protobuf:"bytes,4,opt,name=path,proto3" json:"path,omitempty"`        // 对应的实验路径，格式为 /:username/:project_name/:slug(run_id)
+	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`        // 对应的实验名称
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -321,6 +322,13 @@ func (x *StartResponse) GetRun() *StartRecord {
 func (x *StartResponse) GetPath() string {
 	if x != nil {
 		return x.Path
+	}
+	return ""
+}
+
+func (x *StartResponse) GetName() string {
+	if x != nil {
+		return x.Name
 	}
 	return ""
 }
@@ -459,12 +467,13 @@ const file_swanlab_run_v1_run_proto_rawDesc = "" +
 	" \x01(\tR\x02id\x122\n" +
 	"\x06resume\x18\v \x01(\x0e2\x1a.swanlab.run.v1.ResumeModeR\x06resume\x129\n" +
 	"\n" +
-	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\"\x86\x01\n" +
+	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\"\x9a\x01\n" +
 	"\rStartResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12-\n" +
 	"\x03run\x18\x03 \x01(\v2\x1b.swanlab.run.v1.StartRecordR\x03run\x12\x12\n" +
-	"\x04path\x18\x04 \x01(\tR\x04path\"\x91\x01\n" +
+	"\x04path\x18\x04 \x01(\tR\x04path\x12\x12\n" +
+	"\x04name\x18\x05 \x01(\tR\x04name\"\x91\x01\n" +
 	"\fFinishRecord\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.swanlab.run.v1.RunStateR\x05state\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12;\n" +

--- a/protos/swanlab/run/v1/run.proto
+++ b/protos/swanlab/run/v1/run.proto
@@ -28,6 +28,7 @@ message StartResponse {
   string message  = 2;  // 请求失败的响应
   StartRecord run = 3;  // 最终创建的 Run 记录
   string path     = 4;  // 对应的实验路径，格式为 /:username/:project_name/:slug(run_id)
+  string name     = 5;  // 对应的实验名称
 }
 
 

--- a/swanlab/proto/swanlab/run/v1/run_pb2.py
+++ b/swanlab/proto/swanlab/run/v1/run_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18swanlab/run/v1/run.proto\x12\x0eswanlab.run.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x02\n\x0bStartRecord\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tworkspace\x18\x02 \x01(\t\x12\x0e\n\x06public\x18\x03 \x01(\x08\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12\x0c\n\x04tags\x18\x06 \x03(\t\x12\r\n\x05group\x18\x07 \x01(\t\x12\x10\n\x08job_type\x18\x08 \x01(\t\x12\r\n\x05\x63olor\x18\t \x01(\t\x12\n\n\x02id\x18\n \x01(\t\x12*\n\x06resume\x18\x0b \x01(\x0e\x32\x1a.swanlab.run.v1.ResumeMode\x12.\n\nstarted_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"i\n\rStartResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x03run\x18\x03 \x01(\x0b\x32\x1b.swanlab.run.v1.StartRecord\x12\x0c\n\x04path\x18\x04 \x01(\t\"w\n\x0c\x46inishRecord\x12\'\n\x05state\x18\x01 \x01(\x0e\x32\x18.swanlab.run.v1.RunState\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12/\n\x0b\x66inished_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"2\n\x0e\x46inishResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*g\n\x08RunState\x12\x15\n\x11RUN_STATE_RUNNING\x10\x00\x12\x16\n\x12RUN_STATE_FINISHED\x10\x01\x12\x15\n\x11RUN_STATE_CRASHED\x10\x02\x12\x15\n\x11RUN_STATE_ABORTED\x10\x03*P\n\nResumeMode\x12\x15\n\x11RESUME_MODE_NEVER\x10\x00\x12\x15\n\x11RESUME_MODE_ALLOW\x10\x01\x12\x14\n\x10RESUME_MODE_MUST\x10\x02\x42=Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18swanlab/run/v1/run.proto\x12\x0eswanlab.run.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x02\n\x0bStartRecord\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tworkspace\x18\x02 \x01(\t\x12\x0e\n\x06public\x18\x03 \x01(\x08\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12\x0c\n\x04tags\x18\x06 \x03(\t\x12\r\n\x05group\x18\x07 \x01(\t\x12\x10\n\x08job_type\x18\x08 \x01(\t\x12\r\n\x05\x63olor\x18\t \x01(\t\x12\n\n\x02id\x18\n \x01(\t\x12*\n\x06resume\x18\x0b \x01(\x0e\x32\x1a.swanlab.run.v1.ResumeMode\x12.\n\nstarted_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"w\n\rStartResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x03run\x18\x03 \x01(\x0b\x32\x1b.swanlab.run.v1.StartRecord\x12\x0c\n\x04path\x18\x04 \x01(\t\x12\x0c\n\x04name\x18\x05 \x01(\t\"w\n\x0c\x46inishRecord\x12\'\n\x05state\x18\x01 \x01(\x0e\x32\x18.swanlab.run.v1.RunState\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12/\n\x0b\x66inished_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"2\n\x0e\x46inishResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*g\n\x08RunState\x12\x15\n\x11RUN_STATE_RUNNING\x10\x00\x12\x16\n\x12RUN_STATE_FINISHED\x10\x01\x12\x15\n\x11RUN_STATE_CRASHED\x10\x02\x12\x15\n\x11RUN_STATE_ABORTED\x10\x03*P\n\nResumeMode\x12\x15\n\x11RESUME_MODE_NEVER\x10\x00\x12\x15\n\x11RESUME_MODE_ALLOW\x10\x01\x12\x14\n\x10RESUME_MODE_MUST\x10\x02\x42=Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,16 +33,16 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'swanlab.run.v1.run_pb2', _g
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1'
-  _globals['_RUNSTATE']._serialized_start=626
-  _globals['_RUNSTATE']._serialized_end=729
-  _globals['_RESUMEMODE']._serialized_start=731
-  _globals['_RESUMEMODE']._serialized_end=811
+  _globals['_RUNSTATE']._serialized_start=640
+  _globals['_RUNSTATE']._serialized_end=743
+  _globals['_RESUMEMODE']._serialized_start=745
+  _globals['_RESUMEMODE']._serialized_end=825
   _globals['_STARTRECORD']._serialized_start=78
   _globals['_STARTRECORD']._serialized_end=344
   _globals['_STARTRESPONSE']._serialized_start=346
-  _globals['_STARTRESPONSE']._serialized_end=451
-  _globals['_FINISHRECORD']._serialized_start=453
-  _globals['_FINISHRECORD']._serialized_end=572
-  _globals['_FINISHRESPONSE']._serialized_start=574
-  _globals['_FINISHRESPONSE']._serialized_end=624
+  _globals['_STARTRESPONSE']._serialized_end=465
+  _globals['_FINISHRECORD']._serialized_start=467
+  _globals['_FINISHRECORD']._serialized_end=586
+  _globals['_FINISHRESPONSE']._serialized_start=588
+  _globals['_FINISHRESPONSE']._serialized_end=638
 # @@protoc_insertion_point(module_scope)

--- a/swanlab/proto/swanlab/run/v1/run_pb2.pyi
+++ b/swanlab/proto/swanlab/run/v1/run_pb2.pyi
@@ -59,16 +59,18 @@ class StartRecord(_message.Message):
     def __init__(self, project: _Optional[str] = ..., workspace: _Optional[str] = ..., public: bool = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., tags: _Optional[_Iterable[str]] = ..., group: _Optional[str] = ..., job_type: _Optional[str] = ..., color: _Optional[str] = ..., id: _Optional[str] = ..., resume: _Optional[_Union[ResumeMode, str]] = ..., started_at: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
 
 class StartResponse(_message.Message):
-    __slots__ = ("success", "message", "run", "path")
+    __slots__ = ("success", "message", "run", "path", "name")
     SUCCESS_FIELD_NUMBER: _ClassVar[int]
     MESSAGE_FIELD_NUMBER: _ClassVar[int]
     RUN_FIELD_NUMBER: _ClassVar[int]
     PATH_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
     success: bool
     message: str
     run: StartRecord
     path: str
-    def __init__(self, success: bool = ..., message: _Optional[str] = ..., run: _Optional[_Union[StartRecord, _Mapping]] = ..., path: _Optional[str] = ...) -> None: ...
+    name: str
+    def __init__(self, success: bool = ..., message: _Optional[str] = ..., run: _Optional[_Union[StartRecord, _Mapping]] = ..., path: _Optional[str] = ..., name: _Optional[str] = ...) -> None: ...
 
 class FinishRecord(_message.Message):
     __slots__ = ("state", "error", "finished_at")

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -517,7 +517,7 @@ def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
             {
                 "project.workspace": resp.run.workspace,
                 "project.name": resp.run.project,
-                "experiment.name": resp.run.name,
+                "experiment.name": resp.name,
                 "experiment.color": resp.run.color,
             },
             strip_empty_str=True,

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -147,6 +147,7 @@ class CorePython(CoreProtocol):
             tags=list(record.tags),
             created_at=record.started_at,
         )
+        assert experiment.get("name"), "create_or_resume_experiment() returned an experiment without a name."
         # 2. resume 时，向后端获取数据
         # TODO resume 时向后端获取数据或向本地获取数据
 
@@ -168,7 +169,7 @@ class CorePython(CoreProtocol):
         # /:username/:project_name
         project_path = project_info["path"]
         path = f"{project_path}/{run_id}"
-        return StartResponse(success=True, message="OK", run=start_record, path=path)
+        return StartResponse(success=True, message="OK", run=start_record, path=path, name=experiment.get("name"))
 
     # ---------------------------------- 数据上报 ----------------------------------
 

--- a/swanlab/sdk/typings/core_python/api/experiment.py
+++ b/swanlab/sdk/typings/core_python/api/experiment.py
@@ -13,3 +13,5 @@ class InitExperimentType(TypedDict):
     cuid: str
     # 实验slug(run id)
     slug: Optional[str]
+    # 实验名称
+    name: str

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -41,6 +41,7 @@ WEB_HOST = "https://test.swanlab.cn"
 USERNAME = "test-user"
 PROJECT = "test-project"
 RUN_ID = "test-run-id"
+EXPERIMENT_CUID = "test-experiment-cuid"
 API_KEY = "test-api-key"
 
 
@@ -85,7 +86,7 @@ def make_project_detail_resp(experiment_count: int = 0, **overrides) -> dict:
 
 def make_experiment_resp(**overrides) -> dict:
     """POST /api/project/{username}/{project}/experiment 响应体"""
-    return {"cuid": RUN_ID, **overrides}
+    return {"cuid": EXPERIMENT_CUID, "slug": RUN_ID, "name": "test-experiment", **overrides}
 
 
 def make_stop_experiment_resp(**overrides) -> dict:
@@ -183,7 +184,7 @@ def mock_experiment_stop_api(rsps):
     """注册 PUT /api/project/{username}/{project}/runs/{cuid}/state 端点（停止实验）"""
     rsps.add(
         responses_lib.PUT,
-        f"{API_HOST}/api/project/{USERNAME}/{PROJECT}/runs/{RUN_ID}/state",
+        f"{API_HOST}/api/project/{USERNAME}/{PROJECT}/runs/{EXPERIMENT_CUID}/state",
         json=make_stop_experiment_resp(),
         status=200,
     )
@@ -195,7 +196,7 @@ def mock_profile_api(rsps):
     """注册 PUT /api/project/{username}/{project}/runs/{cuid}/profile 端点（环境信息上传）"""
     rsps.add(
         responses_lib.PUT,
-        f"{API_HOST}/api/project/{USERNAME}/{PROJECT}/runs/{RUN_ID}/profile",
+        f"{API_HOST}/api/project/{USERNAME}/{PROJECT}/runs/{EXPERIMENT_CUID}/profile",
         json=make_profile_resp(),
         status=200,
     )
@@ -207,7 +208,7 @@ def mock_columns_api(rsps):
     """注册 POST /api/experiment/{experiment_id}/columns 端点（列信息上传）"""
     rsps.add(
         responses_lib.POST,
-        f"{API_HOST}/api/experiment/{RUN_ID}/columns",
+        f"{API_HOST}/api/experiment/{EXPERIMENT_CUID}/columns",
         json=make_columns_resp(),
         status=200,
     )


### PR DESCRIPTION
## Summary

- Proto 新增 `name` 字段到 `StartResponse`，用于返回实验名称
- `CorePython._report_run_start` 从实验响应中提取 `name` 并写入 `StartResponse`
- `make_experiment_resp` 响应体区分 `cuid` 和 `slug`，新增 `name` 字段
- 测试中 `/runs/{cuid}/` 路径使用 `EXPERIMENT_CUID` 而非 `RUN_ID`（slug）

## Changed Files

| File | Change |
|------|--------|
| `protos/swanlab/run/v1/run.proto` | StartResponse 新增 `name` 字段 |
| `swanlab/proto/swanlab/run/v1/run_pb2.py` | 重新生成 proto |
| `swanlab/sdk/typings/core_python/api/experiment.py` | `InitExperimentType` 新增 `name` 和 `slug` 字段 |
| `swanlab/sdk/internal/core_python/__init__.py` | 从实验响应提取 `name` 写入 StartResponse |
| `swanlab/sdk/cmd/init.py` | 从 StartResponse 读取实验名称 |
| `tests/unit/sdk/cmd/init/test_init_e2e.py` | 区分 cuid/slug，新增 `EXPERIMENT_CUID` 常量 |



closes: #1422 