### PR TITLE
fix: raise AuthenticationError on missing API key and detect Jupyter stdin availability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ dev = [
     "omegaconf",
     "ipython",
     "ipykernel",
+    "nbconvert",
+    "nbclient",
     "torch>=2.5.0",
     "torchvision>=0.12.0",
     "pandas",

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -121,7 +121,7 @@ def login_raw(
             )
         else:
             if global_settings.api_key is None:
-                raise ValueError("No API key provided and no stored API key found. Please provide an API key.")
+                raise AuthenticationError("No API key provided and no stored API key found. Please provide an API key.")
             api_key = global_settings.api_key
     api_host = host or global_settings.api_host
     login_settings = Settings.model_validate({"api_key": api_key, "api_host": api_host, "web_host": host})

--- a/swanlab/sdk/internal/pkg/helper/env.py
+++ b/swanlab/sdk/internal/pkg/helper/env.py
@@ -9,7 +9,7 @@ import io
 import os
 import sys
 
-__all__ = ["is_jupyter", "is_interactive", "DEBUG"]
+__all__ = ["is_jupyter", "is_interactive", "is_jupyter_supports_stdin", "DEBUG"]
 
 # 设计上，DEBUG 变量独立于其他模块，包括 settings。但是我们又希望有一个环境变量去控制是否打印 debug 信息，所以这里额外绑定一个环境变量
 DEBUG = os.getenv("SWANLAB_DEBUG", "false").lower() in ["true", "1", "yes", "on"]
@@ -38,14 +38,34 @@ def is_jupyter() -> bool:
         return False
 
 
+def is_jupyter_supports_stdin() -> bool:
+    """检查 Jupyter kernel 是否支持 stdin 输入（如 nbconvert --execute 不支持）"""
+    # noinspection PyBroadException
+    try:
+        from IPython.core.getipython import get_ipython
+
+        ip = get_ipython()
+        kernel = getattr(ip, "kernel", None)
+        if kernel is not None and hasattr(kernel, "_allow_stdin"):
+            return getattr(kernel, "_allow_stdin")
+    except Exception:
+        pass
+    # 无法确定时保守返回 True（交互式 Jupyter 更常见）
+    return True
+
+
 def is_interactive() -> bool:
     """
     是否为可交互式环境（输入连接tty设备）
-    特殊的环境：jupyter notebook
+    特殊的环境：jupyter notebook（但排除 nbconvert 等不支持 stdin 的场景）
     """
     try:
         fd = sys.stdin.fileno()
-        return os.isatty(fd) or is_jupyter()
+        if os.isatty(fd):
+            return True
+        if is_jupyter():
+            return is_jupyter_supports_stdin()
+        return False
     # 当使用 capsys、capfd 或 monkeypatch 等 fixture 来捕获或修改标准输入输出时
     # 会抛出 io.UnsupportedOperation，多为测试情况，视为可交互
     except io.UnsupportedOperation:

--- a/tests/unit/sdk/cmd/login/test_login_e2e.py
+++ b/tests/unit/sdk/cmd/login/test_login_e2e.py
@@ -368,8 +368,8 @@ class TestLoginE2E:
 
     @responses.activate
     def test_login_no_key_raises(self):
-        """测试：没有 api_key 且全局也无存储凭证时，login 应抛出 ValueError"""
-        with pytest.raises(ValueError, match="No API key provided"):
+        """测试：没有 api_key 且全局也无存储凭证时，login 应抛出 AuthenticationError"""
+        with pytest.raises(AuthenticationError, match="No API key provided"):
             login()
 
     @responses.activate

--- a/tests/unit/sdk/cmd/login/test_login_nbconvert_e2e.py
+++ b/tests/unit/sdk/cmd/login/test_login_nbconvert_e2e.py
@@ -1,0 +1,102 @@
+"""
+@author: cunyue
+@file: test_login_nbconvert_e2e.py
+@time: 2026/4/29
+@description: 测试 swanlab.login() 在 jupyter nbconvert --execute 环境下的行为 (issue #1334)
+
+在 nbconvert --execute 环境中，kernel 不支持 stdin（_allow_stdin=False），
+调用 swanlab.login() 不带参数时应抛出 AuthenticationError 而非 StdinNotImplementedError。
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+NOTEBOOK_TEMPLATE = {
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": None,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import os\n",
+                "os.environ.pop('SWANLAB_API_KEY', None)\n",
+                "from swanlab.exceptions import AuthenticationError\n",
+                "from swanlab.sdk.cmd.login import login\n",
+                "try:\n",
+                "    login()\n",
+                "    print('LOGIN_SUCCESS')\n",
+                "except AuthenticationError:\n",
+                "    print('AuthenticationError_CAUGHT')\n",
+                "except Exception as e:\n",
+                "    print(f'UNEXPECTED_{type(e).__name__}')\n",
+            ],
+        }
+    ],
+    "metadata": {
+        "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+        "language_info": {"name": "python", "version": "3.11.0"},
+    },
+    "nbformat": 4,
+    "nbformat_minor": 4,
+}
+
+
+def _execute_nbconvert(notebook_path: str, home_dir: str) -> tuple:
+    """在隔离 HOME 下执行 nbconvert --execute，返回 (subprocess result, cell stdout)"""
+    output_path = notebook_path.replace(".ipynb", "_executed.ipynb")
+    env = os.environ.copy()
+    env["HOME"] = home_dir
+    env.pop("SWANLAB_API_KEY", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "jupyter",
+            "nbconvert",
+            "--execute",
+            notebook_path,
+            "--to",
+            "notebook",
+            "--output",
+            output_path,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    # 读取执行后的 notebook
+    with open(output_path) as f:
+        nb = json.load(f)
+    # 提取第一个 code cell 的 stdout
+    stdout_text = ""
+    for out in nb["cells"][0].get("outputs", []):
+        if out.get("output_type") == "stream" and out.get("name") == "stdout":
+            stdout_text = "".join(out.get("text", []))
+    return result, stdout_text
+
+
+@pytest.mark.skipif(
+    not subprocess.run([sys.executable, "-m", "jupyter", "--version"], capture_output=True).returncode == 0,
+    reason="jupyter not installed",
+)
+def test_login_raises_authentication_error_in_nbconvert(tmp_path):
+    """在 nbconvert --execute 环境下，login() 无 API key 应抛出 AuthenticationError"""
+    # 写入 notebook
+    nb_path = str(tmp_path / "test_login.ipynb")
+    with open(nb_path, "w") as f:
+        json.dump(NOTEBOOK_TEMPLATE, f)
+    # 隔离 HOME，确保无 .netrc 凭证
+    home_dir = str(tmp_path / "home")
+    os.makedirs(home_dir, exist_ok=True)
+
+    result, stdout = _execute_nbconvert(nb_path, home_dir)
+    assert "AuthenticationError_CAUGHT" in stdout, (
+        f"Expected AuthenticationError_CAUGHT, got: {stdout}\nstderr: {result.stderr}"
+    )

--- a/tests/unit/sdk/internal/pkg/helper/test_pkg_env.py
+++ b/tests/unit/sdk/internal/pkg/helper/test_pkg_env.py
@@ -1,0 +1,72 @@
+"""
+@author: cunyue
+@file: test_pkg_env.py
+@time: 2026/4/29
+@description: 测试 is_interactive / is_jupyter / is_jupyter_supports_stdin
+"""
+
+from unittest.mock import MagicMock, patch
+
+from swanlab.sdk.internal.pkg.helper.env import is_interactive, is_jupyter_supports_stdin
+
+
+class TestJupyterSupportsStdin:
+    """测试 is_jupyter_supports_stdin 函数"""
+
+    def test_kernel_allows_stdin(self):
+        """kernel._allow_stdin=True 时返回 True"""
+        ip = MagicMock()
+        ip.kernel._allow_stdin = True
+        with patch("IPython.core.getipython.get_ipython", return_value=ip):
+            assert is_jupyter_supports_stdin() is True
+
+    def test_kernel_disallows_stdin(self):
+        """kernel._allow_stdin=False 时返回 False（如 nbconvert --execute）"""
+        ip = MagicMock()
+        ip.kernel._allow_stdin = False
+        with patch("IPython.core.getipython.get_ipython", return_value=ip):
+            assert is_jupyter_supports_stdin() is False
+
+    def test_no_kernel_attribute(self):
+        """没有 kernel 属性时保守返回 True"""
+        ip = MagicMock(spec=[])  # 空 spec，无任何属性
+        with patch("IPython.core.getipython.get_ipython", return_value=ip):
+            assert is_jupyter_supports_stdin() is True
+
+    def test_exception_returns_true(self):
+        """异常时保守返回 True"""
+        with patch("IPython.core.getipython.get_ipython", side_effect=RuntimeError):
+            assert is_jupyter_supports_stdin() is True
+
+
+class TestIsInteractiveJupyterStdin:
+    """测试 is_interactive 对 Jupyter stdin 的处理"""
+
+    def test_jupyter_nbconvert_not_interactive(self, monkeypatch):
+        """nbconvert 环境下 is_interactive 应返回 False"""
+        monkeypatch.setattr("swanlab.sdk.internal.pkg.helper.env.is_jupyter", lambda: True)
+        monkeypatch.setattr("swanlab.sdk.internal.pkg.helper.env.is_jupyter_supports_stdin", lambda: False)
+        # mock stdin 有 fileno 且非 tty
+        mock_stdin = MagicMock()
+        mock_stdin.fileno.return_value = 0
+        monkeypatch.setattr("sys.stdin", mock_stdin)
+        monkeypatch.setattr("os.isatty", lambda fd: False)
+        assert is_interactive() is False
+
+    def test_jupyter_interactive_notebook(self, monkeypatch):
+        """正常 Jupyter Notebook 下 is_interactive 应返回 True"""
+        monkeypatch.setattr("swanlab.sdk.internal.pkg.helper.env.is_jupyter", lambda: True)
+        monkeypatch.setattr("swanlab.sdk.internal.pkg.helper.env.is_jupyter_supports_stdin", lambda: True)
+        mock_stdin = MagicMock()
+        mock_stdin.fileno.return_value = 0
+        monkeypatch.setattr("sys.stdin", mock_stdin)
+        monkeypatch.setattr("os.isatty", lambda fd: False)
+        assert is_interactive() is True
+
+    def test_tty_always_interactive(self, monkeypatch):
+        """TTY 环境始终为可交互"""
+        mock_stdin = MagicMock()
+        mock_stdin.fileno.return_value = 0
+        monkeypatch.setattr("sys.stdin", mock_stdin)
+        monkeypatch.setattr("os.isatty", lambda fd: True)
+        assert is_interactive() is True


### PR DESCRIPTION
## Summary

Fixes #1334

在 `jupyter nbconvert --execute` 等非交互式 Jupyter 环境中，`swanlab.login()` 不带参数时抛出 `StdinNotImplementedError`，不是 SwanLab 定义的异常，用户无法在 CI 中优雅地捕获并回退到 offline/local 模式。

## Changes

- **`swanlab/sdk/cmd/login.py`**: `login_raw()` 无 API key 时将 `ValueError` 改为 `AuthenticationError`，用户可以 `except AuthenticationError` 优雅回退
- **`swanlab/sdk/internal/pkg/helper/env.py`**: 新增 `is_jupyter_supports_stdin()` 检查 Jupyter kernel 的 `_allow_stdin` 属性；`is_interactive()` 在检测到 Jupyter 环境时进一步判断 stdin 可用性，`nbconvert --execute` 不再被误判为可交互
- 新增测试覆盖 `is_jupyter_supports_stdin` 和 `is_interactive` 的 Jupyter stdin 场景