### PR TITLE
fix: reset client on online finish to avoid stale sid 401

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ playground/
 
 # python
 swanlog/
+.swanlab/
 __pycache__/
 *.py[cod]
 *$py.class

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -115,13 +115,13 @@ def login_raw(
     if api_key is None:
         # host 变了，且 .netrc 中存有旧凭证 —— 旧 key 与新 host 不匹配，不能复用
         if host is not None and host != global_settings.api_host and global_settings.api_key is not None:
-            raise ValueError(
+            raise AuthenticationError(
                 f"Stored API key is for '{global_settings.api_host}', but you are logging in to '{host}'. "
                 "Please provide an API key for the new host."
             )
         else:
             if global_settings.api_key is None:
-                raise ValueError("No API key provided and no stored API key found. Please provide an API key.")
+                raise AuthenticationError("No API key provided and no stored API key found. Please provide an API key.")
             api_key = global_settings.api_key
     api_host = host or global_settings.api_host
     login_settings = Settings.model_validate({"api_key": api_key, "api_host": api_host, "web_host": host})

--- a/tests/unit/sdk/cmd/login/test_login_e2e.py
+++ b/tests/unit/sdk/cmd/login/test_login_e2e.py
@@ -196,7 +196,7 @@ class TestLoginE2E:
 
     @responses.activate
     def test_login_host_changed_raises_without_key(self):
-        """测试：已登录旧 host，切换新 host 且不提供 api_key 时应抛出 ValueError"""
+        """测试：已登录旧 host，切换新 host 且不提供 api_key 时应抛出 AuthenticationError"""
         old_host = "https://old.swanlab.cn"
         old_key = "old-key"
         new_host = "https://private.swanlab.com"
@@ -211,8 +211,8 @@ class TestLoginE2E:
         login(api_key=old_key, host=old_host)
         assert len(responses.calls) == 1
 
-        # 切换到新 host 但不提供 api_key，应抛出 ValueError
-        with pytest.raises(ValueError, match="Stored API key is for"):
+        # 切换到新 host 但不提供 api_key，应抛出 AuthenticationError
+        with pytest.raises(AuthenticationError, match="Stored API key is for"):
             login(api_key=None, host=new_host, relogin=True)
 
     @responses.activate
@@ -314,7 +314,7 @@ class TestLoginE2E:
     @responses.activate
     def test_login_host_change_without_key_raises(self, monkeypatch):
         """测试：环境变量中有 api_key，login 只传新 host 不传 api_key，且本地无 .netrc 时，
-        应抛出 ValueError（旧 key 与新 host 不匹配）"""
+        应抛出 AuthenticationError（旧 key 与新 host 不匹配）"""
         env_key = "key-from-env"
         env_host = "https://env.swanlab.com"
         new_host = "https://new.swanlab.com"
@@ -329,8 +329,8 @@ class TestLoginE2E:
         assert settings.api_host == env_host
         assert not (settings.root / ".netrc").exists()
 
-        # 只传新 host，不传 api_key —— 旧 key 与新 host 不匹配，应抛出 ValueError
-        with pytest.raises(ValueError, match="Stored API key is for"):
+        # 只传新 host，不传 api_key —— 旧 key 与新 host 不匹配，应抛出 AuthenticationError
+        with pytest.raises(AuthenticationError, match="Stored API key is for"):
             login(host=new_host)
 
     @responses.activate
@@ -368,8 +368,8 @@ class TestLoginE2E:
 
     @responses.activate
     def test_login_no_key_raises(self):
-        """测试：没有 api_key 且全局也无存储凭证时，login 应抛出 ValueError"""
-        with pytest.raises(ValueError, match="No API key provided"):
+        """测试：没有 api_key 且全局也无存储凭证时，login 应抛出 AuthenticationError"""
+        with pytest.raises(AuthenticationError, match="No API key provided"):
             login()
 
     @responses.activate


### PR DESCRIPTION
## Summary

在 online 模式下 `Run.finish()` 后销毁 client 单例，确保下一次 `init()` 重新鉴权获取新 sid，避免因服务端 sid 失效导致 401 错误。

## Changes

- `swanlab/sdk/cmd/init.py`: `_ensure_online_client()` 调用 `login_raw()` 时追加 `print_welcome=False`，避免重复打印欢迎信息
- `swanlab/sdk/internal/run/__init__.py`: `Run.finish()` 中在线模式下调用 `client.reset()` 销毁 client 单例
- `tests/unit/sdk/cmd/init/test_init_e2e.py`: 新增 `TestOnlineMultipleInit` 测试类，覆盖多次 init/finish、非 online 模式不触发 reset、disabled 模式不报错、通过 `save=False` 和环境变量重新登录等场景

## Testing

已运行 `uv run pytest tests/unit/sdk/cmd/init/test_init_e2e.py`，所有新增及已有测试通过。

## Notes

- 该实现为临时方案，待认证方式从 sid 改为纯 API Key 后，对应的 `client.reset()` 逻辑和 `[随临时方案删除]` 标注的测试用例应一并删除
- 不影响非 online 模式（local/disabled）的行为

closes: #1715