### PR TITLE
feat: enforce media size/length limits in RecordBuilder

### DIFF
--- a/swanlab/sdk/internal/bus/events.py
+++ b/swanlab/sdk/internal/bus/events.py
@@ -72,4 +72,4 @@ EventPayload = Union[
 ]
 
 # 数据解析返回类型
-ParseResult = Tuple[Union[MediaRecord, ScalarRecord], Type[TransformData]]
+ParseResult = Tuple[Optional[Union[MediaRecord, ScalarRecord]], Type[TransformData]]

--- a/swanlab/sdk/internal/run/components/builder/__init__.py
+++ b/swanlab/sdk/internal/run/components/builder/__init__.py
@@ -92,7 +92,10 @@ class RecordBuilder:
         path = self._ctx.media_dir / adapter.medium[cls.column_type()]
         fs.safe_mkdir(path)
         values = [item.transform(step=step, path=path) for item in value]
-        return cls.build_data_record(key=key, step=step, timestamp=timestamp, data=values), cls
+        media_record = self._ensure_media_size(
+            cls.build_data_record(key=key, step=step, timestamp=timestamp, data=values)
+        )
+        return media_record, cls
 
     @build_log.register(TransformMedia)
     def _(self, value: TransformMedia, key: str, timestamp: Timestamp, step: int) -> ParseResult:
@@ -101,7 +104,10 @@ class RecordBuilder:
         path = self._ctx.media_dir / adapter.medium[cls.column_type()]
         fs.safe_mkdir(path)
         values = [value.transform(step=step, path=path)]
-        return cls.build_data_record(key=key, step=step, timestamp=timestamp, data=values), cls
+        media_record = self._ensure_media_size(
+            cls.build_data_record(key=key, step=step, timestamp=timestamp, data=values)
+        )
+        return media_record, cls
 
     def build_column_from_log(self, cls: Type[TransformData], key: str) -> ColumnRecord:
         """隐式创建列：从 TransformType 推断 ColumnType，并同步 RunMetrics"""

--- a/swanlab/sdk/internal/run/components/builder/__init__.py
+++ b/swanlab/sdk/internal/run/components/builder/__init__.py
@@ -6,7 +6,7 @@
 """
 
 from functools import singledispatchmethod
-from typing import List, Type
+from typing import List, Optional, Type
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -18,19 +18,58 @@ from swanlab.proto.swanlab.metric.column.v1.column_pb2 import (
     MetricColors,
     SectionType,
 )
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord
 from swanlab.proto.swanlab.system.v1.console_pb2 import ConsoleRecord
 from swanlab.sdk.internal.bus.events import ConfigEvent, ConsoleEvent, ParseResult, ScalarDefineEvent
 from swanlab.sdk.internal.context import RunContext, TransformMedia
 from swanlab.sdk.internal.context.transformer import TransformData
-from swanlab.sdk.internal.pkg import adapter, fs
+from swanlab.sdk.internal.pkg import adapter, console, fs
 from swanlab.sdk.internal.run.transforms import Scalar
 
 
 class RecordBuilder:
+    _MEDIA_MAX_SIZE = 10 * 1024**2  # 10 MB
+    _MEDIA_MAX_LENGTH = 108
+
     def __init__(self, ctx: RunContext):
         self._ctx = ctx
         # 由 BackgroundConsumer 单线程调用，无需锁
         self._num: int = 0
+
+    def _ensure_media_size(self, record: MediaRecord) -> Optional[MediaRecord]:
+        """
+        确保媒体记录长度不超过限制，否则截断
+        确保媒体记录每一项大小不超过限制
+        """
+        items = list(record.value.items)
+        # 1. 过滤掉超过单条大小限制的项
+        valid_items = []
+        for item in items:
+            if item.size > self._MEDIA_MAX_SIZE:
+                console.warning(
+                    f"Media '{item.filename}' in key '{record.key}' step {record.step} "
+                    f"exceeds size limit ({item.size} > {self._MEDIA_MAX_SIZE} bytes), dropped"
+                )
+                continue
+            valid_items.append(item)
+        # 2. 全部被过滤则返回 None
+        if not valid_items:
+            return None
+        # 3. 超过长度限制则截断
+        if len(valid_items) > self._MEDIA_MAX_LENGTH:
+            console.warning(
+                f"Media record key '{record.key}' step {record.step} "
+                f"has {len(valid_items)} items, exceeding limit {self._MEDIA_MAX_LENGTH}, truncated"
+            )
+            valid_items = valid_items[: self._MEDIA_MAX_LENGTH]
+        # 如果没有变化，直接返回原 record
+        if len(valid_items) == len(items) and all(a is b for a, b in zip(valid_items, items)):
+            return record
+        new_record = MediaRecord()
+        new_record.CopyFrom(record)
+        del new_record.value.items[:]
+        new_record.value.items.extend(valid_items)
+        return new_record
 
     # ── 用户数据 ──
 

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -179,6 +179,9 @@ class BackgroundConsumer(ConsumerProtocol):
         for key, value in event.data.items():
             with safe.block(message=f"Error when parsing metric '{key}'"):
                 data_record, cls = self._builder.build_log(value, key, event.timestamp, event.step)
+                if data_record is None:
+                    console.warning(f"Metric '{key}' at step {event.step} returned no data, skipped")
+                    continue
                 defined = self._metrics.ensure_defined_as(key, cls.column_type())
                 if not defined:
                     this_column = self._builder.build_column_from_log(cls, key)

--- a/tests/unit/sdk/internal/run/components/test_builder.py
+++ b/tests/unit/sdk/internal/run/components/test_builder.py
@@ -1,0 +1,102 @@
+"""
+@author: cunyue
+@file: test_builder.py
+@time: 2026/4/29
+@description: RecordBuilder 单元测试
+"""
+
+import pytest
+
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaItem, MediaRecord
+from swanlab.sdk.internal.run.components.builder import RecordBuilder
+
+
+def _make_media_record(key: str = "test", step: int = 0, items=None) -> MediaRecord:
+    """构造一个 MediaRecord，items 为 (filename, size) 元组列表"""
+    record = MediaRecord(key=key, step=step)
+    if items:
+        for filename, size in items:
+            record.value.items.append(MediaItem(filename=filename, size=size))
+    return record
+
+
+class TestEnsureMediaSize:
+    """RecordBuilder._ensure_media_size 单元测试"""
+
+    # 不依赖 RunContext，直接实例化并覆盖类属性
+    @pytest.fixture
+    def builder(self):
+        b = object.__new__(RecordBuilder)
+        b._MEDIA_MAX_SIZE = 100  # 100 bytes  # type: ignore
+        b._MEDIA_MAX_LENGTH = 3  # type: ignore
+        return b
+
+    def test_all_items_within_limits_returns_original(self, builder):
+        """所有项都在限制内，返回原 record"""
+        record = _make_media_record(items=[("a.png", 10), ("b.png", 20)])
+        result = builder._ensure_media_size(record)
+        assert result is record
+
+    def test_single_item_exceeds_size_dropped(self, builder):
+        """单条超过大小限制的项被丢弃"""
+        record = _make_media_record(items=[("small.png", 10), ("big.png", 200)])
+        result = builder._ensure_media_size(record)
+        assert result is not None
+        assert len(result.value.items) == 1
+        assert result.value.items[0].filename == "small.png"
+
+    def test_all_items_exceed_size_returns_none(self, builder):
+        """所有项都超过大小限制，返回 None"""
+        record = _make_media_record(items=[("big1.png", 200), ("big2.png", 300)])
+        result = builder._ensure_media_size(record)
+        assert result is None
+
+    def test_items_truncated_to_max_length(self, builder):
+        """超过长度限制的项被截断"""
+        record = _make_media_record(items=[("a.png", 10), ("b.png", 10), ("c.png", 10), ("d.png", 10)])
+        result = builder._ensure_media_size(record)
+        assert result is not None
+        assert len(result.value.items) == 3
+        assert [item.filename for item in result.value.items] == ["a.png", "b.png", "c.png"]
+
+    def test_size_and_length_limits_combined(self, builder):
+        """大小和长度限制同时生效：先过滤超大小，再截断超长度"""
+        record = _make_media_record(
+            items=[("a.png", 10), ("big.png", 200), ("b.png", 10), ("c.png", 10), ("d.png", 10)]
+        )
+        result = builder._ensure_media_size(record)
+        # big.png 被过滤，剩余 a/b/c/d 共 4 项，截断为 3 项
+        assert result is not None
+        assert len(result.value.items) == 3
+        assert [item.filename for item in result.value.items] == ["a.png", "b.png", "c.png"]
+
+    def test_empty_record_returns_none(self, builder):
+        """空 record（无 items）返回 None"""
+        record = _make_media_record()
+        result = builder._ensure_media_size(record)
+        assert result is None
+
+    def test_preserved_fields_in_new_record(self, builder):
+        """新 record 保留了 key、step、type、timestamp 等字段"""
+        record = _make_media_record(key="train/img", step=42, items=[("a.png", 10), ("big.png", 200)])
+        from google.protobuf.timestamp_pb2 import Timestamp
+
+        ts = Timestamp(seconds=1000)
+        record.timestamp.CopyFrom(ts)
+        result = builder._ensure_media_size(record)
+        assert result is not None
+        assert result.key == "train/img"
+        assert result.step == 42
+        assert result.timestamp == ts
+
+    def test_exact_boundary_size_not_dropped(self, builder):
+        """大小恰好等于限制的项不被丢弃"""
+        record = _make_media_record(items=[("exact.png", 100)])
+        result = builder._ensure_media_size(record)
+        assert result is record
+
+    def test_exact_boundary_length_not_truncated(self, builder):
+        """长度恰好等于限制的项不被截断"""
+        record = _make_media_record(items=[("a.png", 10), ("b.png", 10), ("c.png", 10)])
+        result = builder._ensure_media_size(record)
+        assert result is record


### PR DESCRIPTION
## 变更内容

为 `RecordBuilder` 添加媒体记录的大小和长度校验，防止超大或超长的媒体数据进入流水线。

### 具体修改

- **`builder/__init__.py`**: 新增 `_ensure_media_size` 方法
  - 过滤超过单条大小限制 (`_MEDIA_MAX_SIZE = 10MB`) 的项，打印警告并丢弃
  - 超过长度限制 (`_MEDIA_MAX_LENGTH = 108`) 时截断并打印警告
  - 无变化时直接返回原 record，避免不必要的 protobuf 拷贝
  - 全部被过滤则返回 `None`
- **`consumer/__init__.py`**: 处理 `build_log` 返回 `None` 的情况，打印友好警告信息
- **`events.py`**: `ParseResult` 类型中 data_record 改为 `Optional`，与 `None` 返回语义一致
- **新增测试**: `tests/unit/sdk/internal/run/components/test_builder.py` — 9 个用例覆盖大小过滤、长度截断、边界值、字段保留等场景