### PR TITLE
fix: python -m swanlab CLI entrypoint

### DIFF
--- a/swanlab/__main__.py
+++ b/swanlab/__main__.py
@@ -6,7 +6,7 @@ from swanlab.cli import cli
 
 
 def main() -> None:
-    cli(prog_name="swanlab")
+    cli(prog_name="python -m swanlab")
 
 
 if __name__ == "__main__":

--- a/swanlab/__main__.py
+++ b/swanlab/__main__.py
@@ -1,0 +1,13 @@
+"""
+@description: Package entry point for ``python -m swanlab``.
+"""
+
+from swanlab.cli import cli
+
+
+def main() -> None:
+    cli(prog_name="swanlab")
+
+
+if __name__ == "__main__":
+    main()

--- a/swanlab/cli/__init__.py
+++ b/swanlab/cli/__init__.py
@@ -19,9 +19,10 @@ from .sync import sync
 
 @click.group(invoke_without_command=True)
 @click.version_option(get_swanlab_version(), "--version", "-v", message="SwanLab %(version)s")
-def cli():
-    """SwanLab CLI — Track, compare, and visualize AI experiments."""
-    pass
+@click.pass_context
+def cli(ctx):
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 # ---------------------------------- 注册子命令 ----------------------------------

--- a/swanlab/cli/api/__init__.py
+++ b/swanlab/cli/api/__init__.py
@@ -16,7 +16,7 @@ from .workspace import workspace_cli
 
 @click.group("api")
 def api_cli():
-    """Generic SwanLab API requests."""
+    """Generic SwanLab API requests with CLI."""
     pass
 
 

--- a/swanlab/sdk/internal/probe_python/environment/requirements.py
+++ b/swanlab/sdk/internal/probe_python/environment/requirements.py
@@ -6,6 +6,7 @@
 """
 
 import subprocess
+import sys
 from typing import Optional
 
 from swanlab.sdk.internal.pkg import safe
@@ -32,8 +33,8 @@ def get() -> str:
     if result and result.returncode == 0:
         return result.stdout
 
-    # 尝试 pip
-    result = _try_run(["pip", "list", "--format=freeze"], timeout=15, check=True)
+    # 尝试当前 Python 环境中的 pip
+    result = _try_run([sys.executable, "-m", "pip", "list", "--format=freeze"], timeout=15, check=True)
     if result:
         return result.stdout
 

--- a/swanlab/sdk/internal/probe_python/environment/requirements.py
+++ b/swanlab/sdk/internal/probe_python/environment/requirements.py
@@ -34,8 +34,8 @@ def get() -> str:
         return result.stdout
 
     # 尝试当前 Python 环境中的 pip
-    result = _try_run([sys.executable, "-m", "pip", "list", "--format=freeze"], timeout=15, check=True)
-    if result:
+    result = _try_run([sys.executable, "-m", "pip", "list", "--format=freeze"], timeout=15)
+    if result and result.returncode == 0:
         return result.stdout
 
     raise ValueError("Failed to get environment requirements")

--- a/tests/unit/sdk/internal/probe_python/environment/test_environment_requirements.py
+++ b/tests/unit/sdk/internal/probe_python/environment/test_environment_requirements.py
@@ -5,6 +5,7 @@
 @description: Tests for requirements information collection
 """
 
+import sys
 from subprocess import CalledProcessError, TimeoutExpired
 from unittest.mock import MagicMock, patch
 
@@ -59,7 +60,7 @@ class TestRequirementsGet:
         assert mock_run.call_count == 3
         # 验证 pip 参数
         third_call = mock_run.call_args_list[2]
-        assert third_call[0][0] == ["pip", "list", "--format=freeze"]
+        assert third_call[0][0] == [sys.executable, "-m", "pip", "list", "--format=freeze"]
         assert third_call.kwargs.get("timeout") == 15
 
     @pytest.mark.parametrize(

--- a/tests/unit/sdk/internal/probe_python/environment/test_environment_requirements.py
+++ b/tests/unit/sdk/internal/probe_python/environment/test_environment_requirements.py
@@ -6,7 +6,7 @@
 """
 
 import sys
-from subprocess import CalledProcessError, TimeoutExpired
+from subprocess import TimeoutExpired
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -62,6 +62,7 @@ class TestRequirementsGet:
         third_call = mock_run.call_args_list[2]
         assert third_call[0][0] == [sys.executable, "-m", "pip", "list", "--format=freeze"]
         assert third_call.kwargs.get("timeout") == 15
+        assert third_call.kwargs.get("check") is False
 
     @pytest.mark.parametrize(
         "side_effects",
@@ -69,7 +70,7 @@ class TestRequirementsGet:
             [
                 MagicMock(returncode=1, stdout=""),
                 MagicMock(returncode=1, stdout=""),
-                CalledProcessError(1, "pip"),
+                MagicMock(returncode=1, stdout=""),
             ],
         ],
     )


### PR DESCRIPTION
## 变更内容

  - 新增 `swanlab/__main__.py`，让 `python -m swanlab ...` 复用新版SDK现有的CLI 入口。
  - 环境依赖采集时使用 `sys.executable -m pip list --format=freeze`，确保采集的是当前运行
  SwanLab 的 Python 环境。

  ## 验证
  - `python -m swanlab login --help`
  
  close #1027