### PR TITLE
Add plot transform and deprecated wrappers

### DIFF
--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -100,13 +100,19 @@ def __getattr__(name: str):
 
 @deprecated("use `swanlab.echarts.roc_curve()` instead")
 def roc_curve(*args, **kwargs):
-    warnings.warn("`swanlab.roc_curve()` is deprecated, use `swanlab.echarts.roc_curve()` instead", DeprecationWarning)
+    warnings.warn(
+        "`swanlab.roc_curve()` is deprecated, use `swanlab.echarts.roc_curve()` instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return echarts.roc_curve(*args, **kwargs)
 
 
 @deprecated("use `swanlab.echarts.pr_curve()` instead")
 def pr_curve(*args, **kwargs):
-    warnings.warn("`swanlab.pr_curve()` is deprecated, use `swanlab.echarts.pr_curve()` instead", DeprecationWarning)
+    warnings.warn(
+        "`swanlab.pr_curve()` is deprecated, use `swanlab.echarts.pr_curve()` instead", DeprecationWarning, stacklevel=2
+    )
     return echarts.pr_curve(*args, **kwargs)
 
 
@@ -115,5 +121,6 @@ def confusion_matrix(*args, **kwargs):
     warnings.warn(
         "`swanlab.confusion_matrix()` is deprecated, use `swanlab.echarts.confusion_matrix()` instead",
         DeprecationWarning,
+        stacklevel=2,
     )
     return echarts.confusion_matrix(*args, **kwargs)

--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -1,3 +1,7 @@
+import warnings
+
+from typing_extensions import deprecated
+
 from swanlab.sdk import (
     Audio,
     Callback,
@@ -28,6 +32,7 @@ from swanlab.sdk import (
     log_video,
     login,
     merge_settings,
+    plot,
 )
 
 from . import utils
@@ -66,13 +71,18 @@ __all__ = [
     "Molecule",
     "Object3D",
     "Video",
+    "plot",
+    "echarts",
     # utils
     "utils",
-    "echarts",
     "Settings",
     "Callback",
     # Api
     "Api",
+    # deprecated
+    "roc_curve",
+    "pr_curve",
+    "confusion_matrix",
 ]
 
 
@@ -83,3 +93,27 @@ def __getattr__(name: str):
         except RuntimeError:
             return None
     raise AttributeError(f"module 'swanlab' has no attribute {name!r}")
+
+
+# ---------------------------------- deprecated ----------------------------------
+
+
+@deprecated("use `swanlab.echarts.roc_curve()` instead")
+def roc_curve(*args, **kwargs):
+    warnings.warn("`swanlab.roc_curve()` is deprecated, use `swanlab.echarts.roc_curve()` instead", DeprecationWarning)
+    return echarts.roc_curve(*args, **kwargs)
+
+
+@deprecated("use `swanlab.echarts.pr_curve()` instead")
+def pr_curve(*args, **kwargs):
+    warnings.warn("`swanlab.pr_curve()` is deprecated, use `swanlab.echarts.pr_curve()` instead", DeprecationWarning)
+    return echarts.pr_curve(*args, **kwargs)
+
+
+@deprecated("use `swanlab.echarts.confusion_matrix()` instead")
+def confusion_matrix(*args, **kwargs):
+    warnings.warn(
+        "`swanlab.confusion_matrix()` is deprecated, use `swanlab.echarts.confusion_matrix()` instead",
+        DeprecationWarning,
+    )
+    return echarts.confusion_matrix(*args, **kwargs)

--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -11,7 +11,7 @@ from typing import Any, Callable, List, Mapping, Optional, Union
 
 from . import utils
 from .api import Api
-from .sdk import Audio, Callback, ECharts, Image, Molecule, Object3D, Run, Settings, Text, Video, config, echarts
+from .sdk import Audio, Callback, ECharts, Image, Molecule, Object3D, Run, Settings, Text, Video, config, echarts, plot
 from .sdk.typings.cmd import ConfigLike, LoginType
 from .sdk.typings.run import AsyncLogType, FinishType, ModeType, ResumeType
 from .sdk.typings.run.column import ScalarXAxisType
@@ -57,9 +57,10 @@ __all__ = [
     "Video",
     "Object3D",
     "Molecule",
+    "plot",
+    "echarts",
     # utils
     "utils",
-    "echarts",
     "Settings",
     "Callback",
     # Api

--- a/swanlab/sdk/__init__.py
+++ b/swanlab/sdk/__init__.py
@@ -27,7 +27,7 @@ from .cmd.run import (
 from .cmd.verify import verify_cli
 from .internal.pkg import console, fs, helper, safe
 from .internal.run import Run, clear_run, get_run, has_run, set_run
-from .internal.run.transforms import Audio, ECharts, Image, Molecule, Object3D, Text, Video, echarts
+from .internal.run.transforms import Audio, ECharts, Image, Molecule, Object3D, Text, Video, echarts, plot
 from .internal.settings import Settings
 from .protocol import Callback
 
@@ -64,12 +64,13 @@ __all__ = [
     # data
     "Audio",
     "ECharts",
-    "echarts",
     "Image",
     "Molecule",
     "Object3D",
     "Text",
     "Video",
+    "echarts",
+    "plot",
     # protocol
     "Callback",
     "Settings",

--- a/swanlab/sdk/internal/run/transforms/plot/__init__.py
+++ b/swanlab/sdk/internal/run/transforms/plot/__init__.py
@@ -1,0 +1,15 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2026/4/30 14:02
+@description: SwanLab Plot 自定义图表模块，目前仅做占位，敬请期待～
+"""
+
+from swanlab.sdk.internal.run.transforms.echarts.components import metrics
+
+confusion_matrix = metrics.confusion_matrix
+roc_curve = metrics.roc_curve
+pr_curve = metrics.pr_curve
+
+
+__all__ = ["confusion_matrix", "roc_curve", "pr_curve"]


### PR DESCRIPTION
## 变更内容

- 新增 `swanlab.plot` 模块，作为自定义图表的占位入口，目前从 echarts 组件中导出 `confusion_matrix`、`roc_curve`、`pr_curve`
- 为 `swanlab.roc_curve()`、`swanlab.pr_curve()`、`swanlab.confusion_matrix()` 添加 `@deprecated` 装饰器和弃用警告，引导用户使用 `swanlab.echarts.*` 替代
- 更新 `__init__.pyi` 类型存根，添加 `plot` 导出
- 调整 `__all__` 导出顺序，将 `echarts` 和 `plot` 归类到数据模块组

## 变更文件

- `swanlab/__init__.py` — 添加 plot 导入、deprecated 包装函数
- `swanlab/__init__.pyi` — 添加 plot 类型导出
- `swanlab/sdk/__init__.py` — 添加 plot 导入，调整导出顺序
- `swanlab/sdk/internal/run/transforms/plot/__init__.py` — 新增 plot 模块