### PR TITLE
feat: add swanlab.merge_callbacks API and callbacker tests

### DIFF
--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -31,6 +31,7 @@ from swanlab.sdk import (
     log_text,
     log_video,
     login,
+    merge_callbacks,
     merge_settings,
     plot,
 )
@@ -42,6 +43,7 @@ __version__ = helper.get_swanlab_version()
 
 __all__ = [
     # cmd
+    "merge_callbacks",
     "merge_settings",
     "init",
     "finish",

--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -85,6 +85,7 @@ __all__ = [
     "roc_curve",
     "pr_curve",
     "confusion_matrix",
+    "register_callbacks",
 ]
 
 
@@ -126,3 +127,13 @@ def confusion_matrix(*args, **kwargs):
         stacklevel=2,
     )
     return echarts.confusion_matrix(*args, **kwargs)
+
+
+@deprecated("use `swanlab.merge_callbacks()` instead")
+def register_callbacks(*args, **kwargs):
+    warnings.warn(
+        "`swanlab.register_callbacks()` is deprecated, use `swanlab.merge_callbacks()` instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return merge_callbacks(*args, **kwargs)

--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -7,7 +7,7 @@ to swanlab/__init__.py.
 """
 
 from concurrent.futures import Future
-from typing import Any, Callable, List, Mapping, Optional, Union
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
 from . import utils
 from .api import Api
@@ -28,6 +28,7 @@ __version__: str
 
 __all__ = [
     # cmd
+    "merge_callbacks",
     "merge_settings",
     "init",
     "finish",
@@ -226,6 +227,30 @@ def merge_settings(settings: Union[Settings, dict]) -> None:
 
         >>> import swanlab
         >>> swanlab.merge_settings({"mode": "local", "logdir": "./my_logs"})
+        >>> swanlab.init()
+    """
+    ...
+
+def merge_callbacks(callbacks: Union[Iterable[Callback], Callback]) -> None:
+    """Merge custom callbacks into the global SwanLab callback registry.
+
+    This function allows you to register callbacks before initializing a run.
+    It must be called before `swanlab.init()`.
+
+    :param callbacks: Custom callbacks to merge. Can be a single Callback object or an iterable of Callback objects.
+    :raises RuntimeError: If called while a run is active.
+
+    Examples:
+
+        >>> import swanlab
+        >>> from swanlab import Callback
+        >>> class MyCallback(Callback):
+        ...     @property
+        ...     def name(self) -> str:
+        ...         return "my_callback"
+        ...     def on_run_initialized(self, run_dir, path):
+        ...         print("Run initialized!")
+        >>> swanlab.merge_callbacks(MyCallback())
         >>> swanlab.init()
     """
     ...

--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -7,12 +7,13 @@ to swanlab/__init__.py.
 """
 
 from concurrent.futures import Future
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
+from typing import Any, Callable, List, Mapping, Optional, Union
 
 from . import utils
 from .api import Api
 from .sdk import Audio, Callback, ECharts, Image, Molecule, Object3D, Run, Settings, Text, Video, config, echarts, plot
 from .sdk.typings.cmd import ConfigLike, LoginType
+from .sdk.typings.context import CallbacksType
 from .sdk.typings.run import AsyncLogType, FinishType, ModeType, ResumeType
 from .sdk.typings.run.column import ScalarXAxisType
 from .sdk.typings.run.transforms import CaptionsType
@@ -88,7 +89,7 @@ def init(
     resume: Optional[Union[ResumeType, bool]] = None,
     config: Optional[ConfigLike] = None,
     settings: Optional[Settings] = None,
-    callbacks: Optional[List[Callback]] = None,
+    callbacks: Optional[CallbacksType] = None,
     **kwargs: Any,
 ) -> Run:
     """Initialize a new SwanLab run to track experiments.
@@ -231,7 +232,7 @@ def merge_settings(settings: Union[Settings, dict]) -> None:
     """
     ...
 
-def merge_callbacks(callbacks: Union[Iterable[Callback], Callback]) -> None:
+def merge_callbacks(callbacks: CallbacksType) -> None:
     """Merge custom callbacks into the global SwanLab callback registry.
 
     This function allows you to register callbacks before initializing a run.

--- a/swanlab/sdk/__init__.py
+++ b/swanlab/sdk/__init__.py
@@ -10,6 +10,7 @@ from swanlab.sdk.internal.run.components.config import config
 from .cmd.init import init
 from .cmd.login import login, login_cli
 from .cmd.logout import logout_cli
+from .cmd.merge_callbacks import merge_callbacks
 from .cmd.merge_settings import merge_settings
 from .cmd.run import (
     async_log,
@@ -49,6 +50,7 @@ __all__ = [
     "logout_cli",
     "define_scalar",
     "merge_settings",
+    "merge_callbacks",
     "login_cli",
     # run
     "has_run",

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -14,7 +14,7 @@ import time
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import requests
 import yaml
@@ -25,7 +25,6 @@ from swanlab.sdk.cmd.guard import with_cmd_lock
 from swanlab.sdk.internal.context import (
     RunConfig,
     RunContext,
-    callbacker,
     use_context,
 )
 from swanlab.sdk.internal.core_python import client
@@ -102,7 +101,7 @@ def init(
     resume: Optional[Union[ResumeType, bool]] = None,
     config: Optional[ConfigLike] = None,
     settings: Optional[Settings] = None,
-    callbacks: Optional[List[Callback]] = None,
+    callbacks: Optional[Iterable[Callback]] = None,
     **kwargs,
 ) -> Run:
     """Initialize a new SwanLab run to track experiments.
@@ -230,13 +229,11 @@ def init(
         elif run_settings.run.resume == "never":
             assert run_settings.run.id is None, "Run id should not be provided when resume=never."
     # ---------------------------------- 初始化 ----------------------------------
-    # 合并回调
-    callbacker.merge_callbacks(callbacks or [])
     # 开始初始化
     generate_ctx = _init
     if run_settings.mode == "online":
         generate_ctx = utils.with_loading_animation()(_init)
-    ctx, path = generate_ctx(run_settings)
+    ctx, path = generate_ctx(run_settings, callbacks)
     # 初始化run
     run = Run(ctx, path)
     # 发送webhook回调，在除了disabled模式外，都会触发
@@ -445,7 +442,7 @@ def _generate_run_dir_name(run_id: str) -> str:
     return "run-" + datetime.now().strftime("%Y%m%d_%H%M%S") + "-" + run_id
 
 
-def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
+def _init(run_settings: Settings, callbacks: Optional[Iterable[Callback]]) -> Tuple[RunContext, Optional[str]]:
     """
     初始化运行时配置，在这之前，所有引导式交互都已经完成
     上下文生命周期通过 `Run` 管理，而非全局 `ContextVar`
@@ -469,7 +466,7 @@ def _init(run_settings: Settings) -> Tuple[RunContext, Optional[str]]:
     else:
         run_dir = run_settings.log_dir / _generate_run_dir_name(run_id)
     # 3. 创建一个临时的上下文，避免出现任何问题导致上下文残留
-    with use_context(RunContext(config=RunConfig(settings=run_settings, run_dir=run_dir))) as ctx:
+    with use_context(RunContext(config=RunConfig(settings=run_settings, run_dir=run_dir), callbacks=callbacks)) as ctx:
         assert run_settings.project.name, "Project name is required."
         # 1. online 模式前置：确保 client 已就绪
         if mode == "online":

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -468,9 +468,14 @@ def _init(run_settings: Settings, callbacks: Optional[Iterable[Callback]]) -> Tu
     # 3. 创建一个临时的上下文，避免出现任何问题导致上下文残留
     with use_context(RunContext(config=RunConfig(settings=run_settings, run_dir=run_dir), callbacks=callbacks)) as ctx:
         assert run_settings.project.name, "Project name is required."
-        # 1. online 模式前置：确保 client 已就绪
+        # 1. 前置操作
+        # online 模式前置：确保 client 已就绪
         if mode == "online":
             _ensure_online_client(run_settings)
+        # local 模式前置：注入 LocalCallback 到 callbacks 中
+        elif mode == "local":
+            # TODO: 注入回调器
+            ...
         # 2. 确定默认 workspace 并生成本地 name/color，合并到 settings
         workspace = run_settings.project.workspace
         name = generate_name("beauty")

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -14,7 +14,7 @@ import time
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
 import yaml
@@ -29,8 +29,8 @@ from swanlab.sdk.internal.context import (
 )
 from swanlab.sdk.internal.core_python import client
 from swanlab.sdk.internal.pkg import adapter, console, fs, helper, safe
-from swanlab.sdk.protocol import Callback
 from swanlab.sdk.typings.cmd import ConfigLike
+from swanlab.sdk.typings.context import CallbacksType
 from swanlab.utils import generate_color, generate_id, generate_name
 
 from ..internal.run import Run, get_run, has_run
@@ -101,7 +101,7 @@ def init(
     resume: Optional[Union[ResumeType, bool]] = None,
     config: Optional[ConfigLike] = None,
     settings: Optional[Settings] = None,
-    callbacks: Optional[Iterable[Callback]] = None,
+    callbacks: Optional[CallbacksType] = None,
     **kwargs,
 ) -> Run:
     """Initialize a new SwanLab run to track experiments.
@@ -442,7 +442,7 @@ def _generate_run_dir_name(run_id: str) -> str:
     return "run-" + datetime.now().strftime("%Y%m%d_%H%M%S") + "-" + run_id
 
 
-def _init(run_settings: Settings, callbacks: Optional[Iterable[Callback]]) -> Tuple[RunContext, Optional[str]]:
+def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[RunContext, Optional[str]]:
     """
     初始化运行时配置，在这之前，所有引导式交互都已经完成
     上下文生命周期通过 `Run` 管理，而非全局 `ContextVar`

--- a/swanlab/sdk/cmd/merge_callbacks.py
+++ b/swanlab/sdk/cmd/merge_callbacks.py
@@ -1,0 +1,55 @@
+"""
+@author: cunyue
+@file: merge_callbacks.py
+@time: 2026/4/30
+@description: swanlab.merge_callbacks 方法，合并自定义回调函数
+"""
+
+from typing import Iterable, Union
+
+from swanlab.sdk.cmd.guard import with_cmd_lock, without_run
+from swanlab.sdk.internal.context.components.callbacker import global_callbacker
+from swanlab.sdk.protocol import Callback
+
+__all__ = ["merge_callbacks"]
+
+
+@with_cmd_lock
+@without_run("merge_callbacks")
+def merge_callbacks(callbacks: Union[Iterable[Callback], Callback]) -> None:
+    """Merge custom callbacks into the global SwanLab callback registry.
+
+    This function allows you to register callbacks before initializing a run.
+    It must be called before `swanlab.init()`.
+
+    :param callbacks: Custom callbacks to merge. Can be a single Callback object or an iterable of Callback objects.
+
+    Examples:
+
+        Merge a single callback:
+
+        >>> import swanlab
+        >>> from swanlab import Callback
+        >>> class MyCallback(Callback):
+        ...     @property
+        ...     def name(self) -> str:
+        ...         return "my_callback"
+        ...     def on_run_initialized(self, run_dir, path):
+        ...         print("Run initialized!")
+        >>> swanlab.merge_callbacks(MyCallback())
+        >>> swanlab.init()
+
+        Merge multiple callbacks:
+
+        >>> class AnotherCallback(Callback):
+        ...     @property
+        ...     def name(self) -> str:
+        ...         return "another_callback"
+        ...     def on_run_initialized(self, run_dir, path):
+        ...         print("Run initialized by another callback!")
+        >>> swanlab.merge_callbacks([MyCallback(), AnotherCallback()])
+        >>> swanlab.init()
+    """
+    if isinstance(callbacks, Callback):
+        callbacks = [callbacks]
+    global_callbacker.merge_callbacks(callbacks)

--- a/swanlab/sdk/cmd/merge_callbacks.py
+++ b/swanlab/sdk/cmd/merge_callbacks.py
@@ -5,18 +5,16 @@
 @description: swanlab.merge_callbacks 方法，合并自定义回调函数
 """
 
-from typing import Iterable, Union
-
 from swanlab.sdk.cmd.guard import with_cmd_lock, without_run
 from swanlab.sdk.internal.context.components.callbacker import global_callbacker
-from swanlab.sdk.protocol import Callback
+from swanlab.sdk.typings.context import CallbacksType
 
 __all__ = ["merge_callbacks"]
 
 
 @with_cmd_lock
 @without_run("merge_callbacks")
-def merge_callbacks(callbacks: Union[Iterable[Callback], Callback]) -> None:
+def merge_callbacks(callbacks: CallbacksType) -> None:
     """Merge custom callbacks into the global SwanLab callback registry.
 
     This function allows you to register callbacks before initializing a run.
@@ -50,6 +48,4 @@ def merge_callbacks(callbacks: Union[Iterable[Callback], Callback]) -> None:
         >>> swanlab.merge_callbacks([MyCallback(), AnotherCallback()])
         >>> swanlab.init()
     """
-    if isinstance(callbacks, Callback):
-        callbacks = [callbacks]
     global_callbacker.merge_callbacks(callbacks)

--- a/swanlab/sdk/internal/context/__init__.py
+++ b/swanlab/sdk/internal/context/__init__.py
@@ -10,11 +10,11 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Generator, Iterable, Optional
+from typing import Generator, Optional
 
 from swanlab.sdk.internal.context.components.probe import create_probe
 from swanlab.sdk.internal.settings import Settings
-from swanlab.sdk.protocol.callbacker import Callback
+from swanlab.sdk.typings.context import CallbacksType
 
 from .components import CallbackManager, create_callback_manager, create_core
 from .metrics import MediaMetric, RunMetrics, ScalarMetric
@@ -44,7 +44,7 @@ class RunConfig:
 
 # 上下文宿主
 class RunContext:
-    def __init__(self, config: RunConfig, callbacks: Optional[Iterable[Callback]] = None):
+    def __init__(self, config: RunConfig, callbacks: Optional[CallbacksType] = None):
         self.config: RunConfig = config
         self.callbacker = create_callback_manager(callbacks=callbacks)
         self.metrics: RunMetrics = RunMetrics()

--- a/swanlab/sdk/internal/context/__init__.py
+++ b/swanlab/sdk/internal/context/__init__.py
@@ -10,19 +10,19 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Generator, Optional
+from typing import Generator, Iterable, Optional
 
 from swanlab.sdk.internal.context.components.probe import create_probe
 from swanlab.sdk.internal.settings import Settings
+from swanlab.sdk.protocol.callbacker import Callback
 
-from .components import CallbackManager, callbacker, create_callback_manager, create_core
+from .components import CallbackManager, create_callback_manager, create_core
 from .metrics import MediaMetric, RunMetrics, ScalarMetric
 from .transformer import TransformData, TransformMedia
 
 __all__ = [
     # value
     "use_context",
-    "callbacker",
     # class
     "RunContext",
     "RunConfig",
@@ -44,11 +44,9 @@ class RunConfig:
 
 # 上下文宿主
 class RunContext:
-    def __init__(self, config: RunConfig):
+    def __init__(self, config: RunConfig, callbacks: Optional[Iterable[Callback]] = None):
         self.config: RunConfig = config
-        self.callbacker = create_callback_manager()
-        # 使用 callbacker.registered_callbacks 作为初始回调集合
-        self.callbacker.merge_callbacks(callbacker.registered_callbacks)
+        self.callbacker = create_callback_manager(callbacks=callbacks)
         self.metrics: RunMetrics = RunMetrics()
         self.core = create_core(self)
         self.probe = create_probe(self)

--- a/swanlab/sdk/internal/context/components/__init__.py
+++ b/swanlab/sdk/internal/context/components/__init__.py
@@ -14,8 +14,8 @@ PS: 考虑到未来多语言SDK的支持，在设计上core和system在未来会
 TODO system 组件暂时挂在 run 对象上，后续迁移到上下文中
 """
 
-from .callbacker import CallbackManager, callbacker, create_callback_manager
+from .callbacker import CallbackManager, create_callback_manager
 from .core import create_core
 from .probe import create_probe
 
-__all__ = ["CallbackManager", "callbacker", "create_callback_manager", "create_core", "create_probe"]
+__all__ = ["CallbackManager", "create_callback_manager", "create_core", "create_probe"]

--- a/swanlab/sdk/internal/context/components/callbacker/__init__.py
+++ b/swanlab/sdk/internal/context/components/callbacker/__init__.py
@@ -17,16 +17,13 @@ class _CallbackManager:
     维护当前上下文中的全局回调状态，支持批量合并与指定移除。
     """
 
-    def __init__(self, callbacks_dict: Optional[Dict[str, Callback]] = None):
+    def __init__(self):
         """
         初始化回调管理器
-        :param callbacks_dict: 回调函数字典，key为回调函数名称，value为回调函数实例
         """
-        if callbacks_dict is None:
-            callbacks_dict = {}
-        self._callbacks: Dict[str, Callback] = callbacks_dict
+        self._callbacks: Dict[str, Callback] = {}
 
-    def merge_callbacks(self, callbacks: Iterable[Callback]) -> None:
+    def merge_callbacks(self, callbacks: Optional[Iterable[Callback]]) -> None:
         """批量合并回调函数到当前管理器中"""
         if not callbacks:
             return
@@ -96,13 +93,10 @@ def create_callback_manager(callbacks: Optional[Iterable[Callback]]) -> Callback
     创建一个新的回调管理器，继承全局回调的同时，支持注入局部回调（当前run有效的回调）
     优先级是局部回调大于全局回调
     """
-    callbacks_dict: Dict[str, Callback] = {}
-    for global_cb in global_callbacker.registered_callbacks:
-        callbacks_dict[global_cb.name] = global_cb
-    if callbacks:
-        for cb in callbacks:
-            callbacks_dict[cb.name] = cb
-    return CallbackManager(callbacks_dict=callbacks_dict)
+    cm = CallbackManager()
+    cm.merge_callbacks(global_callbacker.registered_callbacks)
+    cm.merge_callbacks(callbacks)
+    return cm
 
 
 __all__ = ["CallbackManager", "global_callbacker", "create_callback_manager"]

--- a/swanlab/sdk/internal/context/components/callbacker/__init__.py
+++ b/swanlab/sdk/internal/context/components/callbacker/__init__.py
@@ -5,10 +5,11 @@
 @description: SwanLab 回调模块
 """
 
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from swanlab.sdk.internal.pkg import console, safe
 from swanlab.sdk.protocol import Callback
+from swanlab.sdk.typings.context import CallbacksType
 
 
 class _CallbackManager:
@@ -23,10 +24,12 @@ class _CallbackManager:
         """
         self._callbacks: Dict[str, Callback] = {}
 
-    def merge_callbacks(self, callbacks: Optional[Iterable[Callback]]) -> None:
+    def merge_callbacks(self, callbacks: Optional[CallbacksType]) -> None:
         """批量合并回调函数到当前管理器中"""
-        if not callbacks:
+        if callbacks is None:
             return
+        if isinstance(callbacks, Callback):
+            callbacks = [callbacks]
 
         for cb in callbacks:
             if not isinstance(cb, Callback):
@@ -88,7 +91,7 @@ else:
     CallbackManager = _CallbackManager
 
 
-def create_callback_manager(callbacks: Optional[Iterable[Callback]]) -> CallbackManager:
+def create_callback_manager(callbacks: Optional[CallbacksType]) -> CallbackManager:
     """
     创建一个新的回调管理器，继承全局回调的同时，支持注入局部回调（当前run有效的回调）
     优先级是局部回调大于全局回调

--- a/swanlab/sdk/internal/context/components/callbacker/__init__.py
+++ b/swanlab/sdk/internal/context/components/callbacker/__init__.py
@@ -5,7 +5,7 @@
 @description: SwanLab 回调模块
 """
 
-from typing import TYPE_CHECKING, Dict, Iterable, List
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
 from swanlab.sdk.internal.pkg import console, safe
 from swanlab.sdk.protocol import Callback
@@ -17,9 +17,14 @@ class _CallbackManager:
     维护当前上下文中的全局回调状态，支持批量合并与指定移除。
     """
 
-    def __init__(self):
-        # 使用字典保证顺序并天然去重
-        self._callbacks: Dict[str, Callback] = {}
+    def __init__(self, callbacks_dict: Optional[Dict[str, Callback]] = None):
+        """
+        初始化回调管理器
+        :param callbacks_dict: 回调函数字典，key为回调函数名称，value为回调函数实例
+        """
+        if callbacks_dict is None:
+            callbacks_dict = {}
+        self._callbacks: Dict[str, Callback] = callbacks_dict
 
     def merge_callbacks(self, callbacks: Iterable[Callback]) -> None:
         """批量合并回调函数到当前管理器中"""
@@ -68,6 +73,9 @@ class _CallbackManager:
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
 
+# 全局 CallBacker，主要用处是存储全局注册的回调函数
+global_callbacker = _CallbackManager()
+
 # =========================================================================
 # IDE 类型欺骗 (Type Hinting Magic)
 # 这一段代码在真实运行时根本不会被执行，它完全是写给 PyCharm/VSCode 看的
@@ -79,15 +87,22 @@ if TYPE_CHECKING:
         def name(self) -> str:
             return "FakeCallback"
 
-    callbacker: CallbackManager
 else:
     CallbackManager = _CallbackManager
-    # 全局 CallBacker
-    callbacker = CallbackManager()
 
 
-def create_callback_manager() -> CallbackManager:
-    return CallbackManager()
+def create_callback_manager(callbacks: Optional[Iterable[Callback]]) -> CallbackManager:
+    """
+    创建一个新的回调管理器，继承全局回调的同时，支持注入局部回调（当前run有效的回调）
+    优先级是局部回调大于全局回调
+    """
+    callbacks_dict: Dict[str, Callback] = {}
+    for global_cb in global_callbacker.registered_callbacks:
+        callbacks_dict[global_cb.name] = global_cb
+    if callbacks:
+        for cb in callbacks:
+            callbacks_dict[cb.name] = cb
+    return CallbackManager(callbacks_dict=callbacks_dict)
 
 
-__all__ = ["callbacker", "CallbackManager", "create_callback_manager"]
+__all__ = ["CallbackManager", "global_callbacker", "create_callback_manager"]

--- a/swanlab/sdk/typings/context/__init__.py
+++ b/swanlab/sdk/typings/context/__init__.py
@@ -1,0 +1,15 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2026/4/30
+@description: SwanLab SDK context 模块的类型定义和导出
+"""
+
+from typing import Iterable, Union
+
+from swanlab.sdk.protocol import Callback
+
+CallbacksType = Union[Iterable[Callback], Callback]
+"""
+swanlab 回调函数参数类型，支持单个 Callback 对象或可迭代对象
+"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 import swanlab
-from swanlab.sdk.internal.context import callbacker
+from swanlab.sdk.internal.context.components.callbacker import global_callbacker
 from swanlab.sdk.internal.core_python import client
 from swanlab.sdk.internal.pkg import console
 from swanlab.sdk.internal.run import clear_run
@@ -66,8 +66,8 @@ def isolate_sdk_environment(tmp_path, monkeypatch):
     reset_config()
 
     # 7. 清理 callbacker
-    for callback in callbacker.registered_callbacks:
-        callbacker.remove_callback(callback.name)
+    for callback in global_callbacker.registered_callbacks:
+        global_callbacker.remove_callback(callback.name)
 
     yield
 

--- a/tests/unit/sdk/internal/context/components/callbacker/test_callbacker.py
+++ b/tests/unit/sdk/internal/context/components/callbacker/test_callbacker.py
@@ -1,0 +1,124 @@
+"""
+@author: cunyue
+@file: test_callbacker.py
+@time: 2026/4/30
+@description: CallbackManager 及 create_callback_manager 单元测试
+"""
+
+import pytest
+
+from swanlab.sdk.internal.context.components.callbacker import (
+    CallbackManager,
+    create_callback_manager,
+    global_callbacker,
+)
+from swanlab.sdk.protocol import Callback
+
+
+class _AlphaCallback(Callback):
+    @property
+    def name(self) -> str:
+        return "alpha"
+
+
+class _BetaCallback(Callback):
+    @property
+    def name(self) -> str:
+        return "beta"
+
+
+class _AlphaDupCallback(Callback):
+    """与 Alpha 同名，用于测试覆盖"""
+
+    @property
+    def name(self) -> str:
+        return "alpha"
+
+
+class TestCallbackManager:
+    """_CallbackManager 基础操作"""
+
+    def test_merge_callbacks(self):
+        mgr = CallbackManager()
+        mgr.merge_callbacks([_AlphaCallback(), _BetaCallback()])
+        assert {cb.name for cb in mgr.registered_callbacks} == {"alpha", "beta"}
+
+    def test_merge_overwrites_duplicate(self):
+        mgr = CallbackManager()
+        mgr.merge_callbacks([_AlphaCallback()])
+        mgr.merge_callbacks([_AlphaDupCallback()])
+        assert len(mgr.registered_callbacks) == 1
+        assert isinstance(mgr.registered_callbacks[0], _AlphaDupCallback)
+
+    def test_merge_none_or_empty(self):
+        mgr = CallbackManager()
+        mgr.merge_callbacks(None)
+        mgr.merge_callbacks([])
+        assert len(mgr.registered_callbacks) == 0
+
+    def test_merge_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="Expected swanlab.Callback"):
+            CallbackManager().merge_callbacks(["not_a_callback"])  # type: ignore
+
+    def test_remove_callback(self):
+        mgr = CallbackManager()
+        mgr.merge_callbacks([_AlphaCallback()])
+        mgr.remove_callback("alpha")
+        assert len(mgr.registered_callbacks) == 0
+        mgr.remove_callback("nonexistent")  # 不存在时不报错
+
+    def test_dispatch_forwards_to_callback(self):
+        calls = []
+
+        class Rec(Callback):
+            @property
+            def name(self) -> str:
+                return "rec"
+
+            def on_run_finished(self, state, error=None):
+                calls.append(state)
+
+        mgr = CallbackManager()
+        mgr.merge_callbacks([Rec()])
+        mgr.on_run_finished("success")
+        assert calls == ["success"]
+
+    def test_dispatch_unknown_raises(self):
+        with pytest.raises(AttributeError):
+            CallbackManager().nonexistent_method()
+
+
+class TestCreateCallbackManager:
+    """create_callback_manager 工厂函数"""
+
+    def test_empty_when_no_callbacks(self):
+        assert len(create_callback_manager(None).registered_callbacks) == 0
+
+    def test_local_only(self):
+        mgr = create_callback_manager([_AlphaCallback()])
+        assert {cb.name for cb in mgr.registered_callbacks} == {"alpha"}
+
+    def test_global_and_local_merged(self):
+        global_callbacker.merge_callbacks([_AlphaCallback()])
+        try:
+            mgr = create_callback_manager([_BetaCallback()])
+            assert {cb.name for cb in mgr.registered_callbacks} == {"alpha", "beta"}
+        finally:
+            global_callbacker.remove_callback("alpha")
+
+    def test_local_overwrites_global(self):
+        global_callbacker.merge_callbacks([_AlphaCallback()])
+        try:
+            mgr = create_callback_manager([_AlphaDupCallback()])
+            assert len(mgr.registered_callbacks) == 1
+            assert isinstance(mgr.registered_callbacks[0], _AlphaDupCallback)
+        finally:
+            global_callbacker.remove_callback("alpha")
+
+    def test_local_does_not_pollute_global(self):
+        global_callbacker.merge_callbacks([_AlphaCallback()])
+        try:
+            create_callback_manager([_BetaCallback()])
+            assert "beta" not in {cb.name for cb in global_callbacker.registered_callbacks}
+        finally:
+            global_callbacker.remove_callback("alpha")

--- a/tests/unit/sdk/internal/context/components/callbacker/test_callbacker.py
+++ b/tests/unit/sdk/internal/context/components/callbacker/test_callbacker.py
@@ -43,6 +43,13 @@ class TestCallbackManager:
         mgr.merge_callbacks([_AlphaCallback(), _BetaCallback()])
         assert {cb.name for cb in mgr.registered_callbacks} == {"alpha", "beta"}
 
+    def test_merge_single_callback(self):
+        """支持传入单个 Callback 对象"""
+        mgr = CallbackManager()
+        mgr.merge_callbacks(_AlphaCallback())
+        assert len(mgr.registered_callbacks) == 1
+        assert mgr.registered_callbacks[0].name == "alpha"
+
     def test_merge_overwrites_duplicate(self):
         mgr = CallbackManager()
         mgr.merge_callbacks([_AlphaCallback()])
@@ -96,6 +103,11 @@ class TestCreateCallbackManager:
 
     def test_local_only(self):
         mgr = create_callback_manager([_AlphaCallback()])
+        assert {cb.name for cb in mgr.registered_callbacks} == {"alpha"}
+
+    def test_local_single_callback(self):
+        """支持传入单个 Callback 对象"""
+        mgr = create_callback_manager(_AlphaCallback())
         assert {cb.name for cb in mgr.registered_callbacks} == {"alpha"}
 
     def test_global_and_local_merged(self):


### PR DESCRIPTION
## Summary

- 新增 `swanlab.merge_callbacks()` 公开 API，允许用户在 `swanlab.init()` 之前注册全局回调
- 重构 `CallbackManager`，移除 `callbacks_dict` 构造参数，统一通过 `merge_callbacks` 注入
- 新增 `callbacker` 模块单元测试（12 cases）

## Changes

| 文件 | 说明 |
|------|------|
| `swanlab/sdk/cmd/merge_callbacks.py` | 新增 `merge_callbacks` 命令实现 |
| `swanlab/__init__.py` | 对外暴露 `merge_callbacks` |
| `swanlab/__init__.pyi` | 添加 `merge_callbacks` 类型声明 |
| `swanlab/sdk/__init__.py` | 导出 `merge_callbacks` |
| `swanlab/sdk/internal/context/components/callbacker/__init__.py` | 重构 CallbackManager |
| `tests/unit/sdk/internal/context/components/callbacker/test_callbacker.py` | 新增单元测试 |

## Usage

```python
import swanlab
from swanlab import Callback

class MyCallback(Callback):
    @property
    def name(self) -> str:
        return "my_callback"

    def on_run_initialized(self, run_dir, path):
        print("Run initialized!")

# 单个
swanlab.merge_callbacks(MyCallback())
# 多个
swanlab.merge_callbacks([MyCallback(), AnotherCallback()])

swanlab.init()
```