### PR TITLE
feat: add step deduplication for metrics and rename check_if_logged

### DIFF
--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -5,12 +5,16 @@
 @description: SwanLab 运行时指标管理
 """
 
+import math
 import sys
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional, Set, Union
+from typing import Any, Dict, Optional, Set, Union
 
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord
+from swanlab.sdk.internal.pkg import console
 
 # 开启 slots 可以减少内存占用，提高性能，但是仅适用于 Python 3.10 及以上版本
 # 因此我们动态判断版本：如果是 3.10 及以上，开启 slots；否则传空字典
@@ -18,7 +22,7 @@ DATACLASS_KWARGS = {"slots": True} if sys.version_info >= (3, 10) else {}
 
 
 @dataclass(**DATACLASS_KWARGS)
-class BaseMetric:
+class BaseMetric(ABC):
     _column: ColumnRecord
     steps: Set[int] = field(default_factory=set, init=False)
 
@@ -46,6 +50,9 @@ class BaseMetric:
         self.steps.add(step)
         return False
 
+    @abstractmethod
+    def update(self, data_record: Any): ...
+
 
 # 使用解包的方式传入参数
 @dataclass(**DATACLASS_KWARGS)
@@ -57,24 +64,35 @@ class ScalarMetric(BaseMetric):
     # 指标的最小值
     min: Optional[Union[float, int]] = None
 
-    def update(self, value: Union[float, int]) -> bool:
+    def update(self, data_record: ScalarRecord):
         """
         更新标量指标值
-        :param value: 标量指标值
-        :return: 是否成功更新
+        :param data_record: 标量指标记录
         """
-        self.latest = value
-        if self.max is None or value > self.max:
-            self.max = value
-        if self.min is None or value < self.min:
-            self.min = value
-        return True
+        value = data_record.value.number
+        # 1. 如果为有效值，则更新
+        if math.isfinite(value):
+            self.latest = value
+            if self.max is None or value > self.max:
+                self.max = value
+            if self.min is None or value < self.min:
+                self.min = value
+            return
+        # 2. 如果为无效值，则忽略
+        key = self._column.column_key
+        console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
 
 
 @dataclass(**DATACLASS_KWARGS)
 class MediaMetric(BaseMetric):
     # 媒体存储路径，绝对路径
     path: Path
+
+    def update(self, data_record: Any):
+        """
+        更新媒体指标值，媒体指标目前没什么可更新的，因此直接pass
+        """
+        pass
 
 
 # 指标状态，实验运行过程中不断更新

--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -9,7 +9,7 @@ import math
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Set, Union
 
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
 from swanlab.sdk.internal.pkg import console
@@ -19,11 +19,39 @@ from swanlab.sdk.internal.pkg import console
 DATACLASS_KWARGS = {"slots": True} if sys.version_info >= (3, 10) else {}
 
 
+@dataclass(**DATACLASS_KWARGS)
+class BaseMetric:
+    _column: ColumnRecord
+    steps: Set[int] = field(default_factory=set, init=False)
+
+    @property
+    def type(self) -> ColumnType:
+        return self._column.column_type
+
+    def ensure_type_match(self, key: str, metric_type: ColumnType):
+        if self.type != metric_type:
+            raise TypeError(
+                f"Metric '{key}' has already been defined as "
+                f"{ColumnType.Name(self.type)}, not {ColumnType.Name(metric_type)}."
+            )
+
+    def check_if_logged(self, step: int) -> bool:
+        """
+        确保step已经被记录，如果已经记录则返回True，否则返回False
+        取消此方法是实现 https://github.com/SwanHubX/SwanLab/issues/1576 的前置条件
+        我们需要等待后端准备好
+        :param step: 步数
+        :return: 是否已经记录
+        """
+        if step in self.steps:
+            return True
+        self.steps.add(step)
+        return False
+
+
 # 使用解包的方式传入参数
 @dataclass(**DATACLASS_KWARGS)
-class ScalarMetric:
-    # 指标列记录
-    _column: ColumnRecord
+class ScalarMetric(BaseMetric):
     # 指标最新值
     latest: Optional[Union[float, int]] = None
     # 指标的最大值
@@ -44,21 +72,11 @@ class ScalarMetric:
             self.min = value
         return True
 
-    @property
-    def type(self):
-        return self._column.column_type
-
 
 @dataclass(**DATACLASS_KWARGS)
-class MediaMetric:
-    # 指标列记录
-    _column: ColumnRecord
+class MediaMetric(BaseMetric):
     # 媒体存储路径，绝对路径
     path: Path
-
-    @property
-    def type(self):
-        return self._column.column_type
 
 
 # 指标状态，实验运行过程中不断更新
@@ -93,6 +111,37 @@ class RunMetrics:
         self._global_step += 1
         return self._global_step
 
+    def define_scalar(self, *, key: str, column: ColumnRecord) -> ScalarMetric:
+        """
+        定义一个标量指标
+        :param key: 指标键
+        :param column: 指标列记录
+        """
+        assert key not in self._metrics, f"Metric '{key}' already exists."
+        scalar_metric = ScalarMetric(_column=column)
+        self._metrics[key] = scalar_metric
+        return scalar_metric
+
+    def define_media(self, *, key: str, column: ColumnRecord, path: Path) -> MediaMetric:
+        """
+        定义媒体指标
+        :param key: 指标键
+        :param column: 指标列记录
+        :param path: 媒体存储路径，绝对路径
+        """
+        assert key not in self._metrics, f"Metric '{key}' already exists."
+        media_metric = MediaMetric(_column=column, path=path)
+        self._metrics[key] = media_metric
+        return media_metric
+
+    def get(self, key: str) -> Optional[Union[ScalarMetric, MediaMetric]]:
+        """
+        根据key获取指标
+        :param key: 指标键
+        :return: 指标对象，如果不存在则返回None
+        """
+        return self._metrics.get(key)
+
     def update_scalar(self, key: str, value: Union[float, int]):
         """
         更新标量指标状态
@@ -110,44 +159,3 @@ class RunMetrics:
             scalar.max = value
         if scalar.min is None or value < scalar.min:
             scalar.min = value
-
-    def define_scalar(self, key: str, column: ColumnRecord):
-        """
-        定义一个标量指标
-        :param key: 指标键
-        :param column: 指标列记录
-        """
-        assert key not in self._metrics, f"Metric '{key}' already exists."
-        self._metrics[key] = ScalarMetric(_column=column)
-
-    def define_media(self, key: str, column: ColumnRecord, path: Path):
-        """
-        定义媒体指标
-        :param key: 指标键
-        :param column: 指标列记录
-        :param path: 媒体存储路径，绝对路径
-        """
-        assert key not in self._metrics, f"Metric '{key}' already exists."
-        self._metrics[key] = MediaMetric(_column=column, path=path)
-
-    def ensure_defined_as(self, key: str, metric_type: ColumnType) -> bool:
-        """
-        判断指标是否已定义，并确保其类型与预期一致。
-
-        :param key: 指标键
-        :param metric_type: 期望的指标类型
-        :return:
-            - False: 指标尚未定义
-            - True: 指标已定义且类型一致
-        :raise TypeError: 指标已定义但类型不匹配
-        """
-        if key not in self._metrics:
-            return False
-
-        metric = self._metrics[key]
-        if metric.type != metric_type:
-            raise TypeError(
-                f"Metric '{key}' has already been defined as "
-                f"{ColumnType.Name(metric.type)}, not {ColumnType.Name(metric_type)}."
-            )
-        return True

--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -35,7 +35,7 @@ class BaseMetric:
                 f"{ColumnType.Name(self.type)}, not {ColumnType.Name(metric_type)}."
             )
 
-    def check_if_logged(self, step: int) -> bool:
+    def check_and_mark_logged(self, step: int) -> bool:
         """
         确保step已经被记录，如果已经记录则返回True，否则返回False
         取消此方法是实现 https://github.com/SwanHubX/SwanLab/issues/1576 的前置条件

--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -5,14 +5,12 @@
 @description: SwanLab 运行时指标管理
 """
 
-import math
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional, Set, Union
 
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
-from swanlab.sdk.internal.pkg import console
 
 # 开启 slots 可以减少内存占用，提高性能，但是仅适用于 Python 3.10 及以上版本
 # 因此我们动态判断版本：如果是 3.10 及以上，开启 slots；否则传空字典
@@ -83,8 +81,7 @@ class MediaMetric(BaseMetric):
 # 注意：此类不加锁保护。设计上对 RunMetrics 的写操作发生在以下线程：
 #   - next_step: 用户主线程（通过 Run.log，已在 with_api 锁内串行化）
 #   - next_system_step: Monitor Timer 线程（独立递增 system_step，与 next_step 互不干扰）
-#   - update_scalar: Consumer 线程（单线程消费队列，与 define_scalar/define_media 串行）
-#   - define_scalar/define_media: Consumer 线程（同上）
+#   - define_scalar/define_media: Consumer 线程（单线程消费队列，串行）
 # 如果未来引入多线程并发写入此对象，需要重新评估线程安全。
 @dataclass
 class RunMetrics:
@@ -141,17 +138,3 @@ class RunMetrics:
         :return: 指标对象，如果不存在则返回None
         """
         return self._metrics.get(key)
-
-    def update_scalar(self, key: str, value: Union[float, int]):
-        """
-        更新标量指标状态
-        :param key: 指标键
-        :param value: 标量值
-        """
-        scalar = self._metrics.get(key)
-        assert scalar is not None, f"Metric '{key}' does not exist."
-        assert isinstance(scalar, ScalarMetric), f"Metric '{key}' is not a scalar metric."
-        if math.isnan(value) or math.isinf(value):
-            console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
-            return
-        scalar.update(value)

--- a/swanlab/sdk/internal/context/metrics.py
+++ b/swanlab/sdk/internal/context/metrics.py
@@ -28,17 +28,17 @@ class BaseMetric:
     def type(self) -> ColumnType:
         return self._column.column_type
 
-    def ensure_type_match(self, key: str, metric_type: ColumnType):
+    def ensure_type_match(self, metric_type: ColumnType):
         if self.type != metric_type:
             raise TypeError(
-                f"Metric '{key}' has already been defined as "
+                f"Metric '{self._column.column_key}' has already been defined as "
                 f"{ColumnType.Name(self.type)}, not {ColumnType.Name(metric_type)}."
             )
 
     def check_and_mark_logged(self, step: int) -> bool:
         """
         确保step已经被记录，如果已经记录则返回True，否则返回False
-        取消此方法是实现 https://github.com/SwanHubX/SwanLab/issues/1576 的前置条件
+        引入此方法是实现 https://github.com/SwanHubX/SwanLab/issues/1576 的前置条件
         我们需要等待后端准备好
         :param step: 步数
         :return: 是否已经记录
@@ -154,8 +154,4 @@ class RunMetrics:
         if math.isnan(value) or math.isinf(value):
             console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
             return
-        scalar.latest = value
-        if scalar.max is None or value > scalar.max:
-            scalar.max = value
-        if scalar.min is None or value < scalar.min:
-            scalar.min = value
+        scalar.update(value)

--- a/swanlab/sdk/internal/run/components/builder/__init__.py
+++ b/swanlab/sdk/internal/run/components/builder/__init__.py
@@ -6,7 +6,7 @@
 """
 
 from functools import singledispatchmethod
-from typing import Optional, Type
+from typing import Optional, Tuple, Type, Union
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -22,6 +22,7 @@ from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord
 from swanlab.proto.swanlab.system.v1.console_pb2 import ConsoleRecord
 from swanlab.sdk.internal.bus.events import ConfigEvent, ConsoleEvent, ParseResult, ScalarDefineEvent
 from swanlab.sdk.internal.context import RunContext, TransformData, TransformMedia
+from swanlab.sdk.internal.context.metrics import MediaMetric, ScalarMetric
 from swanlab.sdk.internal.pkg import adapter, console, fs
 from swanlab.sdk.internal.run.transforms import ECharts, Scalar, echarts
 
@@ -123,7 +124,11 @@ class RecordBuilder:
         )
         return media_record, cls
 
-    def build_column_from_log(self, cls: Type[TransformData], key: str) -> ColumnRecord:
+    def build_column_from_log(
+        self,
+        cls: Type[TransformData],
+        key: str,
+    ) -> Tuple[ColumnRecord, Union[ScalarMetric, MediaMetric]]:
         """隐式创建列：从 TransformType 推断 ColumnType，并同步 RunMetrics"""
         column_record = ColumnRecord(
             column_key=key,
@@ -134,15 +139,19 @@ class RecordBuilder:
         )
         col_type = column_record.column_type
         metrics = self._ctx.metrics
+        metric: Union[ScalarMetric, MediaMetric]
         if issubclass(cls, TransformMedia):
             media_type_str = adapter.medium[col_type]
-            metrics.define_media(key, column_record, self._ctx.media_dir / media_type_str)
+            metric = metrics.define_media(key=key, column=column_record, path=self._ctx.media_dir / media_type_str)
         else:
-            metrics.define_scalar(key=key, column=column_record)
+            metric = metrics.define_scalar(key=key, column=column_record)
 
-        return column_record
+        return column_record, metric
 
-    def build_column_from_scalar_define(self, event: ScalarDefineEvent) -> ColumnRecord:
+    def build_column_from_scalar_define(
+        self,
+        event: ScalarDefineEvent,
+    ) -> Tuple[ColumnRecord, ScalarMetric]:
         """显式创建标量列（DefineEvent）"""
         metrics = self._ctx.metrics
         section_type = SectionType.SECTION_TYPE_SYSTEM if event.system else SectionType.SECTION_TYPE_PUBLIC
@@ -157,8 +166,8 @@ class RecordBuilder:
             metric_name=event.name or "",
             metric_colors=MetricColors(light=event.color, dark=event.color) if event.color else None,
         )
-        metrics.define_scalar(key=event.key, column=col)
-        return col
+        metric = metrics.define_scalar(key=event.key, column=col)
+        return col, metric
 
     # ── 系统元数据 ──
     @staticmethod

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -191,7 +191,7 @@ class BackgroundConsumer(ConsumerProtocol):
                     # 确保以定义的指标类型相同
                     metric.ensure_type_match(key, cls.column_type())
                 # 2. 如果指标已定义，则检查是否已记录过此步数，如果已记录过，则跳过，否则记录
-                if metric.check_if_logged(event.step):
+                if metric.check_and_mark_logged(event.step):
                     console.debug(f"Metric '{key}' at step {event.step} has already been logged, skipped")
                     continue
                 # 3. 如果指标是标量，则更新标量指标状态，否则更新媒体指标状态

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -5,7 +5,6 @@
 @description: 后台消费者组件，用于消费运行事件
 """
 
-import math
 import queue
 import threading
 from abc import ABC
@@ -18,7 +17,6 @@ from swanlab.proto.swanlab.system.v1.console_pb2 import ConsoleRecord
 from swanlab.sdk.internal.bus.emitter import RunQueue
 from swanlab.sdk.internal.bus.events import ConfigEvent, ConsoleEvent, MetricLogEvent, ScalarDefineEvent
 from swanlab.sdk.internal.context import RunContext
-from swanlab.sdk.internal.context.metrics import ScalarMetric
 from swanlab.sdk.internal.pkg import console, safe
 
 if TYPE_CHECKING:
@@ -198,12 +196,7 @@ class BackgroundConsumer(ConsumerProtocol):
                     continue
                 # 3. 如果指标是标量，则更新标量指标状态，否则更新媒体指标状态
                 if isinstance(data_record, ScalarRecord):
-                    assert isinstance(metric, ScalarMetric), f"Metric '{key}' is not a scalar metric."
-                    value = data_record.value.number
-                    if math.isnan(value) or math.isinf(value):
-                        console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
-                        continue
-                    metric.update(value)
+                    metric.update(data_record)
                     self._scalar_batch.append(data_record)
                 else:
                     self._media_batch.append(data_record)

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -206,7 +206,7 @@ class BackgroundConsumer(ConsumerProtocol):
         # 1. 如果已经定义，则跳过
         metric = self._metrics.get(event.key)
         if metric is not None:
-            console.warning(f"Scalar Column '{event.key}' has already been defined, skip redefine.")
+            console.warning(f"Metric '{event.key}' has already been defined, skip redefine.")
             return
         # 2. 如果未定义，则定义此指标
         this_column, _ = self._builder.build_column_from_scalar_define(event)

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -5,6 +5,7 @@
 @description: 后台消费者组件，用于消费运行事件
 """
 
+import math
 import queue
 import threading
 from abc import ABC
@@ -17,6 +18,7 @@ from swanlab.proto.swanlab.system.v1.console_pb2 import ConsoleRecord
 from swanlab.sdk.internal.bus.emitter import RunQueue
 from swanlab.sdk.internal.bus.events import ConfigEvent, ConsoleEvent, MetricLogEvent, ScalarDefineEvent
 from swanlab.sdk.internal.context import RunContext
+from swanlab.sdk.internal.context.metrics import ScalarMetric
 from swanlab.sdk.internal.pkg import console, safe
 
 if TYPE_CHECKING:
@@ -196,7 +198,12 @@ class BackgroundConsumer(ConsumerProtocol):
                     continue
                 # 3. 如果指标是标量，则更新标量指标状态，否则更新媒体指标状态
                 if isinstance(data_record, ScalarRecord):
-                    self._metrics.update_scalar(key, data_record.value.number)
+                    assert isinstance(metric, ScalarMetric), f"Metric '{key}' is not a scalar metric."
+                    value = data_record.value.number
+                    if math.isnan(value) or math.isinf(value):
+                        console.debug(f"Invalid scalar value: {value} for metric '{key}', ignored when updating.")
+                        continue
+                    metric.update(value)
                     self._scalar_batch.append(data_record)
                 else:
                     self._media_batch.append(data_record)

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -11,7 +11,7 @@ from abc import ABC
 from typing import TYPE_CHECKING, List, Tuple
 
 from swanlab.proto.swanlab.config.v1.config_pb2 import ConfigRecord
-from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord, ScalarRecord
 from swanlab.proto.swanlab.system.v1.console_pb2 import ConsoleRecord
 from swanlab.sdk.internal.bus.emitter import RunQueue
@@ -182,10 +182,19 @@ class BackgroundConsumer(ConsumerProtocol):
                 if data_record is None:
                     console.warning(f"Metric '{key}' at step {event.step} returned no data, skipped")
                     continue
-                defined = self._metrics.ensure_defined_as(key, cls.column_type())
-                if not defined:
-                    this_column = self._builder.build_column_from_log(cls, key)
+                # 1. 如果指标未定义，则定义此指标
+                metric = self._metrics.get(key)
+                if metric is None:
+                    this_column, metric = self._builder.build_column_from_log(cls, key)
                     self._column_batch.append(this_column)
+                else:
+                    # 确保以定义的指标类型相同
+                    metric.ensure_type_match(key, cls.column_type())
+                # 2. 如果指标已定义，则检查是否已记录过此步数，如果已记录过，则跳过，否则记录
+                if metric.check_if_logged(event.step):
+                    console.debug(f"Metric '{key}' at step {event.step} has already been logged, skipped")
+                    continue
+                # 3. 如果指标是标量，则更新标量指标状态，否则更新媒体指标状态
                 if isinstance(data_record, ScalarRecord):
                     self._metrics.update_scalar(key, data_record.value.number)
                     self._scalar_batch.append(data_record)
@@ -193,11 +202,13 @@ class BackgroundConsumer(ConsumerProtocol):
                     self._media_batch.append(data_record)
 
     def _handle_scalar_define(self, event: ScalarDefineEvent) -> None:
-        defined = self._metrics.ensure_defined_as(event.key, ColumnType.COLUMN_TYPE_SCALAR)
-        if defined:
+        # 1. 如果已经定义，则跳过
+        metric = self._metrics.get(event.key)
+        if metric is not None:
             console.warning(f"Scalar Column '{event.key}' has already been defined, skip redefine.")
             return
-        this_column = self._builder.build_column_from_scalar_define(event)
+        # 2. 如果未定义，则定义此指标
+        this_column, _ = self._builder.build_column_from_scalar_define(event)
         self._column_batch.append(this_column)
 
     def _flush(self) -> None:

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -189,7 +189,7 @@ class BackgroundConsumer(ConsumerProtocol):
                     self._column_batch.append(this_column)
                 else:
                     # 确保以定义的指标类型相同
-                    metric.ensure_type_match(key, cls.column_type())
+                    metric.ensure_type_match(cls.column_type())
                 # 2. 如果指标已定义，则检查是否已记录过此步数，如果已记录过，则跳过，否则记录
                 if metric.check_and_mark_logged(event.step):
                     console.debug(f"Metric '{key}' at step {event.step} has already been logged, skipped")

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -41,7 +41,8 @@ class ConsumerProtocol(ABC):
         builder: "RecordBuilder",
         flush_timeout: float = 0.5,
         batch_size: int = 100,
-    ): ...
+    ):
+        _ = (ctx, event_queue, builder, flush_timeout, batch_size)
 
     def start(self) -> None: ...
 
@@ -188,7 +189,7 @@ class BackgroundConsumer(ConsumerProtocol):
                     this_column, metric = self._builder.build_column_from_log(cls, key)
                     self._column_batch.append(this_column)
                 else:
-                    # 确保以定义的指标类型相同
+                    # 确保已定义的指标类型相同
                     metric.ensure_type_match(cls.column_type())
                 # 2. 如果指标已定义，则检查是否已记录过此步数，如果已记录过，则跳过，否则记录
                 if metric.check_and_mark_logged(event.step):


### PR DESCRIPTION
## Summary

为 metrics 添加 step 去重机制（暂时），防止重复 log 同一步数的数据。

### Changes

- **新增 `BaseMetric` 基类**：统一 `ScalarMetric` 和 `MediaMetric` 的类型处理，内含 `steps` 集合用于跟踪已记录的 step
- **Step 去重**：`check_and_mark_logged` 方法检查 step 是否已记录，防止重复写入（原 `check_if_logged` 重命名，语义更清晰——既检查又标记）
- **类型匹配集中化**：`ensure_type_match` 移入 `BaseMetric`，统一列类型校验
- **API 调整**：`RunMetrics.define_scalar`/`define_media` 改为 keyword-only 并返回创建的 metric；新增 `get(key)` 方法；移除 `ensure_defined_as`
- **`RecordBuilder`**：implicit/explicit column 创建时返回 `(ColumnRecord, metric)` 元组
- **`BackgroundConsumer`**：使用新 API，自动 define 缺失 metric，跳过重复 step，处理 scalar/media 更新

Preparation for issue #1576.