### PR TITLE
Fix/section name

### DIFF
--- a/swanlab/sdk/internal/pkg/builder/__init__.py
+++ b/swanlab/sdk/internal/pkg/builder/__init__.py
@@ -6,13 +6,15 @@
 本模块不负责具体的字符串长度等判断，这交给调用方处理
 """
 
-from typing import Union
+from typing import TYPE_CHECKING, Tuple, Union
 
-from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord, ColumnType
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord, ColumnType, SectionType
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord, ScalarRecord
-from swanlab.sdk.internal.context import RunContext
 
 __all__ = ["build_auto_column", "build_resume_column"]
+
+if TYPE_CHECKING:
+    from swanlab.sdk.internal.context import RunContext
 
 
 def build_resume_column(key: str, *, media: bool = False, system: bool = False) -> ColumnRecord:
@@ -36,14 +38,25 @@ def build_resume_column(key: str, *, media: bool = False, system: bool = False) 
     return column_record
 
 
-def build_auto_column(ctx: RunContext, data_record: Union[ScalarRecord, MediaRecord]) -> ColumnRecord:
+def _split_key_section(key: str, section_rule_index: int) -> Tuple[str, str]:
+    parts = key.split("/")
+    if len(parts) < 2:
+        return "", key
+    cut = section_rule_index % (len(parts) - 1) + 1
+    return "/".join(parts[:cut]), "/".join(parts[cut:])
+
+
+def build_auto_column(ctx: "RunContext", data_record: Union[ScalarRecord, MediaRecord]) -> ColumnRecord:
     """
-    构建一个标量列记录，此函数一般用于自动构建用户已定义的指标
+    构建一个指标列记录，此函数一般用于自动构建用户已定义的指标
     """
-    # TODO: 解析 section name
-    column = ColumnRecord(
+    section_rule_index = ctx.config.settings.core.section_rule_index
+    section_name, _ = _split_key_section(key=data_record.key, section_rule_index=section_rule_index)
+
+    return ColumnRecord(
         column_class=ColumnClass.COLUMN_CLASS_CUSTOM,
         column_key=data_record.key,
         column_type=data_record.type,
+        section_name=section_name,
+        section_type=SectionType.SECTION_TYPE_PUBLIC,
     )
-    return column

--- a/swanlab/sdk/internal/pkg/builder/__init__.py
+++ b/swanlab/sdk/internal/pkg/builder/__init__.py
@@ -6,7 +6,7 @@
 本模块不负责具体的字符串长度等判断，这交给调用方处理
 """
 
-from typing import TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Union
 
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord, ColumnType, SectionType
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord, ScalarRecord
@@ -38,20 +38,16 @@ def build_resume_column(key: str, *, media: bool = False, system: bool = False) 
     return column_record
 
 
-def _split_key_section(key: str, section_rule_index: int) -> Tuple[str, str]:
-    parts = key.split("/")
-    if len(parts) < 2:
-        return "", key
-    cut = section_rule_index % (len(parts) - 1) + 1
-    return "/".join(parts[:cut]), "/".join(parts[cut:])
-
-
 def build_auto_column(ctx: "RunContext", data_record: Union[ScalarRecord, MediaRecord]) -> ColumnRecord:
-    """
-    构建一个指标列记录，此函数一般用于自动构建用户已定义的指标
-    """
+    """Build a column record for auto-created user metrics."""
+    # Split section_name with `section_rule_index` setting
     section_rule_index = ctx.config.settings.core.section_rule_index
-    section_name, _ = _split_key_section(key=data_record.key, section_rule_index=section_rule_index)
+    parts = data_record.key.split("/")
+    if len(parts) >= 2:
+        cut = section_rule_index % (len(parts) - 1) + 1
+        section_name = "/".join(parts[:cut])
+    else:
+        section_name = ""
 
     return ColumnRecord(
         column_class=ColumnClass.COLUMN_CLASS_CUSTOM,

--- a/swanlab/sdk/internal/pkg/builder/__init__.py
+++ b/swanlab/sdk/internal/pkg/builder/__init__.py
@@ -39,7 +39,9 @@ def build_resume_column(key: str, *, media: bool = False, system: bool = False) 
 
 
 def build_auto_column(ctx: "RunContext", data_record: Union[ScalarRecord, MediaRecord]) -> ColumnRecord:
-    """Build a column record for auto-created user metrics."""
+    """
+    构建一个标量列记录，此函数一般用于自动构建用户已定义的指标
+    """
     # Split section_name with `section_rule_index` setting
     section_rule_index = ctx.config.settings.core.section_rule_index
     parts = data_record.key.split("/")

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -35,6 +35,7 @@ from pydantic_settings import (
 from swanlab.sdk.internal.pkg import helper, nrc, safe
 from swanlab.sdk.typings.run import ModeType
 
+from .core import CoreSettings
 from .experiment import ExperimentSettings, ProjectSettings, RunSettings
 from .integration import IntegrationSettings
 from .metadata import ConsoleSettings, EnvironmentSettings, MonitorSettings
@@ -98,6 +99,7 @@ class Settings(BaseSettings):
     Monitor: ClassVar[Type[MonitorSettings]] = MonitorSettings
     Console: ClassVar[Type[ConsoleSettings]] = ConsoleSettings
     Integration: ClassVar[Type[IntegrationSettings]] = IntegrationSettings
+    Core: ClassVar[Type[CoreSettings]] = CoreSettings
 
     interactive: bool = True
     """
@@ -286,6 +288,10 @@ class Settings(BaseSettings):
     integration: IntegrationSettings = Field(default_factory=IntegrationSettings)
     """
     Configuration for SwanLab integrations, including webhook, dashboard, etc.
+    """
+    core: CoreSettings = Field(default_factory=CoreSettings)
+    """
+    Configuration for SwanLab Core behavior.
     """
 
     model_config = SettingsConfigDict(

--- a/swanlab/sdk/internal/settings/core.py
+++ b/swanlab/sdk/internal/settings/core.py
@@ -1,0 +1,27 @@
+"""
+@author: cunyue
+@file: core.py
+@time: 2026/5/8
+@description: SwanLab Core 配置
+"""
+
+import os
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def section_rule_index_factory() -> int:
+    # 向下兼容旧版本环境变量
+    return int(os.environ.get("SWANLAB_CORE_SECTION_RULE_INDEX", os.environ.get("SWANLAB_SECTION_RULE_IDX", "0")))
+
+
+class CoreSettings(BaseModel):
+    section_rule_index: int = Field(default_factory=section_rule_index_factory)
+    """
+    用于将 metric key 拆分为 section name 的斜杠索引。
+    0 表示第一个斜杠，1 表示第二个斜杠，-1 表示最后一个斜杠。
+    超范围时会按 ``idx % slash_count`` 环绕。
+    每次 run 的拆分位置会在 settings 加载时固定。
+    """
+
+    model_config = ConfigDict(frozen=True)

--- a/swanlab/sdk/internal/settings/core.py
+++ b/swanlab/sdk/internal/settings/core.py
@@ -1,9 +1,4 @@
-"""
-@author: cunyue
-@file: core.py
-@time: 2026/5/8
-@description: SwanLab Core 配置
-"""
+"""SwanLab Core settings."""
 
 import os
 
@@ -12,16 +7,16 @@ from pydantic import BaseModel, ConfigDict, Field
 
 def section_rule_index_factory() -> int:
     # 向下兼容旧版本环境变量
-    return int(os.environ.get("SWANLAB_CORE_SECTION_RULE_INDEX", os.environ.get("SWANLAB_SECTION_RULE_IDX", "0")))
+    return int(os.environ.get("SWANLAB_SECTION_RULE_IDX", "0"))
 
 
 class CoreSettings(BaseModel):
     section_rule_index: int = Field(default_factory=section_rule_index_factory)
     """
-    用于将 metric key 拆分为 section name 的斜杠索引。
-    0 表示第一个斜杠，1 表示第二个斜杠，-1 表示最后一个斜杠。
-    超范围时会按 ``idx % slash_count`` 环绕。
-    每次 run 的拆分位置会在 settings 加载时固定。
+    Slash index used to split a metric key into section name and metric name.
+    0 means the first slash, 1 means the second slash, -1 means the last slash.
+    Out-of-range values wrap via ``idx % slash_count``.
+    The split position is fixed when settings are loaded for each run.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,8 +33,6 @@ def isolate_sdk_environment(tmp_path, monkeypatch):
         "SWANLAB_WEB_HOST",
         "SWANLAB_ROOT",
         "SWANLAB_LOG_DIR",
-        "SWANLAB_CORE_SECTION_RULE_INDEX",
-        "SWANLAB_SECTION_RULE_IDX",
     ]:
         monkeypatch.delenv(env_var, raising=False)
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,15 @@ def isolate_sdk_environment(tmp_path, monkeypatch):
 
     # 1. 路径与环境变量隔离
     # 清理可能干扰测试的常见环境变量
-    for env_var in ["SWANLAB_API_KEY", "SWANLAB_API_HOST", "SWANLAB_WEB_HOST", "SWANLAB_ROOT", "SWANLAB_LOG_DIR"]:
+    for env_var in [
+        "SWANLAB_API_KEY",
+        "SWANLAB_API_HOST",
+        "SWANLAB_WEB_HOST",
+        "SWANLAB_ROOT",
+        "SWANLAB_LOG_DIR",
+        "SWANLAB_CORE_SECTION_RULE_INDEX",
+        "SWANLAB_SECTION_RULE_IDX",
+    ]:
         monkeypatch.delenv(env_var, raising=False)
 
     # 切换当前工作目录，防止加载到项目根目录的 .env 或 swanlab.yaml

--- a/tests/unit/sdk/internal/pkg/builder/test_pkg_builder.py
+++ b/tests/unit/sdk/internal/pkg/builder/test_pkg_builder.py
@@ -1,0 +1,64 @@
+"""
+@author: cunyue
+@file: test_pkg_builder.py
+@time: 2026/5/8
+@description: 测试 swanlab.sdk.internal.pkg.builder 模块
+"""
+
+import pytest
+
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnType, SectionType
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord, ScalarRecord
+from swanlab.sdk.internal.context import RunConfig, RunContext
+from swanlab.sdk.internal.pkg import builder
+from swanlab.sdk.internal.settings import Settings
+
+
+def make_ctx(tmp_path, section_rule_index: int) -> RunContext:
+    settings = Settings.model_validate(
+        {"mode": "disabled", "run": {"id": "test-run-id"}, "core": {"section_rule_index": section_rule_index}}
+    )
+    return RunContext(RunConfig(run_dir=tmp_path / "run", settings=settings))
+
+
+class TestBuildAutoColumn:
+    @pytest.mark.parametrize(
+        "index, expected_section",
+        [
+            (0, "train"),
+            (-1, "train/loss"),
+            (5, "train/loss"),
+            (6, "train"),
+        ],
+    )
+    def test_scalar_section_rule(self, tmp_path, index, expected_section):
+        ctx = make_ctx(tmp_path, index)
+        record = ScalarRecord(key="train/loss/epoch", type=ColumnType.COLUMN_TYPE_SCALAR)
+
+        column = builder.build_auto_column(ctx, record)
+
+        assert column.column_class == ColumnClass.COLUMN_CLASS_CUSTOM
+        assert column.column_key == "train/loss/epoch"
+        assert column.column_type == ColumnType.COLUMN_TYPE_SCALAR
+        assert column.section_name == expected_section
+        assert column.section_type == SectionType.SECTION_TYPE_PUBLIC
+        assert column.metric_name == ""
+        assert column.chart_name == ""
+
+    def test_media_section_rule(self, tmp_path):
+        ctx = make_ctx(tmp_path, -1)
+        record = MediaRecord(key="train/image/epoch", type=ColumnType.COLUMN_TYPE_IMAGE)
+
+        column = builder.build_auto_column(ctx, record)
+
+        assert column.column_key == "train/image/epoch"
+        assert column.column_type == ColumnType.COLUMN_TYPE_IMAGE
+        assert column.section_name == "train/image"
+
+    def test_key_without_slash(self, tmp_path):
+        ctx = make_ctx(tmp_path, -1)
+        record = ScalarRecord(key="loss", type=ColumnType.COLUMN_TYPE_SCALAR)
+
+        column = builder.build_auto_column(ctx, record)
+
+        assert column.section_name == ""

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -187,6 +187,34 @@ def test_url_env_resolution(monkeypatch):
     assert s_mixed.web_host == "http://env-web.local"
 
 
+def test_core_section_rule_index_env(monkeypatch):
+    """测试 core section rule index 可通过新版 Settings 环境变量注入"""
+    monkeypatch.setenv("SWANLAB_CORE_SECTION_RULE_INDEX", "-1")
+
+    settings = Settings()
+
+    assert settings.core.section_rule_index == -1
+
+
+def test_legacy_section_rule_idx_env(monkeypatch):
+    """测试旧版 section rule idx 环境变量兼容读取"""
+    monkeypatch.setenv("SWANLAB_SECTION_RULE_IDX", "1")
+
+    settings = Settings()
+
+    assert settings.core.section_rule_index == 1
+
+
+def test_core_section_rule_index_env_overrides_legacy(monkeypatch):
+    """测试新版 core section rule index 环境变量优先于旧版环境变量"""
+    monkeypatch.setenv("SWANLAB_CORE_SECTION_RULE_INDEX", "-1")
+    monkeypatch.setenv("SWANLAB_SECTION_RULE_IDX", "1")
+
+    settings = Settings()
+
+    assert settings.core.section_rule_index == -1
+
+
 @pytest.fixture
 def netrc_file(tmp_path, monkeypatch):
     """


### PR DESCRIPTION
## Summary

- 在新版 SDK `Settings` 中支持 `SWANLAB_SECTION_RULE_IDX`。
- 按配置的斜杠索引拆分 metric key，写入 `section_name` 和 `metric_name`。