### PR TITLE
feat: add system monitor builder and init global step

### DIFF
--- a/core/proto/swanlab/run/v1/run.pb.go
+++ b/core/proto/swanlab/run/v1/run.pb.go
@@ -266,6 +266,7 @@ type StartResponse struct {
 	Name             string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`                                                    // 对应的实验名称
 	GlobalStep       int64                  `protobuf:"varint,6,opt,name=global_step,json=globalStep,proto3" json:"global_step,omitempty"`                     // 起始全局步数
 	GlobalSystemStep int64                  `protobuf:"varint,7,opt,name=global_system_step,json=globalSystemStep,proto3" json:"global_system_step,omitempty"` // 起始全局系统步数
+	NewExperiment    bool                   `protobuf:"varint,8,opt,name=new_experiment,json=newExperiment,proto3" json:"new_experiment,omitempty"`            // 是否是新实验
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -347,6 +348,13 @@ func (x *StartResponse) GetGlobalSystemStep() int64 {
 		return x.GlobalSystemStep
 	}
 	return 0
+}
+
+func (x *StartResponse) GetNewExperiment() bool {
+	if x != nil {
+		return x.NewExperiment
+	}
+	return false
 }
 
 // Run 结束记录，对应 swanlab.finish() 或进程退出，由sdk前端生成并同步交给后端
@@ -483,7 +491,7 @@ const file_swanlab_run_v1_run_proto_rawDesc = "" +
 	" \x01(\tR\x02id\x122\n" +
 	"\x06resume\x18\v \x01(\x0e2\x1a.swanlab.run.v1.ResumeModeR\x06resume\x129\n" +
 	"\n" +
-	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\"\xe9\x01\n" +
+	"started_at\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\"\x90\x02\n" +
 	"\rStartResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12-\n" +
@@ -492,7 +500,8 @@ const file_swanlab_run_v1_run_proto_rawDesc = "" +
 	"\x04name\x18\x05 \x01(\tR\x04name\x12\x1f\n" +
 	"\vglobal_step\x18\x06 \x01(\x03R\n" +
 	"globalStep\x12,\n" +
-	"\x12global_system_step\x18\a \x01(\x03R\x10globalSystemStep\"\x91\x01\n" +
+	"\x12global_system_step\x18\a \x01(\x03R\x10globalSystemStep\x12%\n" +
+	"\x0enew_experiment\x18\b \x01(\bR\rnewExperiment\"\x91\x01\n" +
 	"\fFinishRecord\x12.\n" +
 	"\x05state\x18\x01 \x01(\x0e2\x18.swanlab.run.v1.RunStateR\x05state\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12;\n" +

--- a/protos/swanlab/run/v1/run.proto
+++ b/protos/swanlab/run/v1/run.proto
@@ -31,6 +31,7 @@ message StartResponse {
   string name              = 5;  // 对应的实验名称
   int64 global_step        = 6;  // 起始全局步数
   int64 global_system_step = 7;  // 起始全局系统步数
+  bool  new_experiment     = 8;  // 是否是新实验
 }
 
 

--- a/swanlab/proto/swanlab/run/v1/run_pb2.py
+++ b/swanlab/proto/swanlab/run/v1/run_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18swanlab/run/v1/run.proto\x12\x0eswanlab.run.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x02\n\x0bStartRecord\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tworkspace\x18\x02 \x01(\t\x12\x0e\n\x06public\x18\x03 \x01(\x08\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12\x0c\n\x04tags\x18\x06 \x03(\t\x12\r\n\x05group\x18\x07 \x01(\t\x12\x10\n\x08job_type\x18\x08 \x01(\t\x12\r\n\x05\x63olor\x18\t \x01(\t\x12\n\n\x02id\x18\n \x01(\t\x12*\n\x06resume\x18\x0b \x01(\x0e\x32\x1a.swanlab.run.v1.ResumeMode\x12.\n\nstarted_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xa8\x01\n\rStartResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x03run\x18\x03 \x01(\x0b\x32\x1b.swanlab.run.v1.StartRecord\x12\x0c\n\x04path\x18\x04 \x01(\t\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x13\n\x0bglobal_step\x18\x06 \x01(\x03\x12\x1a\n\x12global_system_step\x18\x07 \x01(\x03\"w\n\x0c\x46inishRecord\x12\'\n\x05state\x18\x01 \x01(\x0e\x32\x18.swanlab.run.v1.RunState\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12/\n\x0b\x66inished_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"2\n\x0e\x46inishResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*g\n\x08RunState\x12\x15\n\x11RUN_STATE_RUNNING\x10\x00\x12\x16\n\x12RUN_STATE_FINISHED\x10\x01\x12\x15\n\x11RUN_STATE_CRASHED\x10\x02\x12\x15\n\x11RUN_STATE_ABORTED\x10\x03*P\n\nResumeMode\x12\x15\n\x11RESUME_MODE_NEVER\x10\x00\x12\x15\n\x11RESUME_MODE_ALLOW\x10\x01\x12\x14\n\x10RESUME_MODE_MUST\x10\x02\x42=Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x18swanlab/run/v1/run.proto\x12\x0eswanlab.run.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8a\x02\n\x0bStartRecord\x12\x0f\n\x07project\x18\x01 \x01(\t\x12\x11\n\tworkspace\x18\x02 \x01(\t\x12\x0e\n\x06public\x18\x03 \x01(\x08\x12\x0c\n\x04name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12\x0c\n\x04tags\x18\x06 \x03(\t\x12\r\n\x05group\x18\x07 \x01(\t\x12\x10\n\x08job_type\x18\x08 \x01(\t\x12\r\n\x05\x63olor\x18\t \x01(\t\x12\n\n\x02id\x18\n \x01(\t\x12*\n\x06resume\x18\x0b \x01(\x0e\x32\x1a.swanlab.run.v1.ResumeMode\x12.\n\nstarted_at\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"\xc0\x01\n\rStartResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t\x12(\n\x03run\x18\x03 \x01(\x0b\x32\x1b.swanlab.run.v1.StartRecord\x12\x0c\n\x04path\x18\x04 \x01(\t\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x13\n\x0bglobal_step\x18\x06 \x01(\x03\x12\x1a\n\x12global_system_step\x18\x07 \x01(\x03\x12\x16\n\x0enew_experiment\x18\x08 \x01(\x08\"w\n\x0c\x46inishRecord\x12\'\n\x05state\x18\x01 \x01(\x0e\x32\x18.swanlab.run.v1.RunState\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12/\n\x0b\x66inished_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"2\n\x0e\x46inishResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*g\n\x08RunState\x12\x15\n\x11RUN_STATE_RUNNING\x10\x00\x12\x16\n\x12RUN_STATE_FINISHED\x10\x01\x12\x15\n\x11RUN_STATE_CRASHED\x10\x02\x12\x15\n\x11RUN_STATE_ABORTED\x10\x03*P\n\nResumeMode\x12\x15\n\x11RESUME_MODE_NEVER\x10\x00\x12\x15\n\x11RESUME_MODE_ALLOW\x10\x01\x12\x14\n\x10RESUME_MODE_MUST\x10\x02\x42=Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,16 +33,16 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'swanlab.run.v1.run_pb2', _g
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'Z;github.com/swanhubx/swanlab/core/proto/swanlab/run/v1;runv1'
-  _globals['_RUNSTATE']._serialized_start=690
-  _globals['_RUNSTATE']._serialized_end=793
-  _globals['_RESUMEMODE']._serialized_start=795
-  _globals['_RESUMEMODE']._serialized_end=875
+  _globals['_RUNSTATE']._serialized_start=714
+  _globals['_RUNSTATE']._serialized_end=817
+  _globals['_RESUMEMODE']._serialized_start=819
+  _globals['_RESUMEMODE']._serialized_end=899
   _globals['_STARTRECORD']._serialized_start=78
   _globals['_STARTRECORD']._serialized_end=344
   _globals['_STARTRESPONSE']._serialized_start=347
-  _globals['_STARTRESPONSE']._serialized_end=515
-  _globals['_FINISHRECORD']._serialized_start=517
-  _globals['_FINISHRECORD']._serialized_end=636
-  _globals['_FINISHRESPONSE']._serialized_start=638
-  _globals['_FINISHRESPONSE']._serialized_end=688
+  _globals['_STARTRESPONSE']._serialized_end=539
+  _globals['_FINISHRECORD']._serialized_start=541
+  _globals['_FINISHRECORD']._serialized_end=660
+  _globals['_FINISHRESPONSE']._serialized_start=662
+  _globals['_FINISHRESPONSE']._serialized_end=712
 # @@protoc_insertion_point(module_scope)

--- a/swanlab/proto/swanlab/run/v1/run_pb2.pyi
+++ b/swanlab/proto/swanlab/run/v1/run_pb2.pyi
@@ -59,7 +59,7 @@ class StartRecord(_message.Message):
     def __init__(self, project: _Optional[str] = ..., workspace: _Optional[str] = ..., public: bool = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., tags: _Optional[_Iterable[str]] = ..., group: _Optional[str] = ..., job_type: _Optional[str] = ..., color: _Optional[str] = ..., id: _Optional[str] = ..., resume: _Optional[_Union[ResumeMode, str]] = ..., started_at: _Optional[_Union[datetime.datetime, _timestamp_pb2.Timestamp, _Mapping]] = ...) -> None: ...
 
 class StartResponse(_message.Message):
-    __slots__ = ("success", "message", "run", "path", "name", "global_step", "global_system_step")
+    __slots__ = ("success", "message", "run", "path", "name", "global_step", "global_system_step", "new_experiment")
     SUCCESS_FIELD_NUMBER: _ClassVar[int]
     MESSAGE_FIELD_NUMBER: _ClassVar[int]
     RUN_FIELD_NUMBER: _ClassVar[int]
@@ -67,6 +67,7 @@ class StartResponse(_message.Message):
     NAME_FIELD_NUMBER: _ClassVar[int]
     GLOBAL_STEP_FIELD_NUMBER: _ClassVar[int]
     GLOBAL_SYSTEM_STEP_FIELD_NUMBER: _ClassVar[int]
+    NEW_EXPERIMENT_FIELD_NUMBER: _ClassVar[int]
     success: bool
     message: str
     run: StartRecord
@@ -74,7 +75,8 @@ class StartResponse(_message.Message):
     name: str
     global_step: int
     global_system_step: int
-    def __init__(self, success: bool = ..., message: _Optional[str] = ..., run: _Optional[_Union[StartRecord, _Mapping]] = ..., path: _Optional[str] = ..., name: _Optional[str] = ..., global_step: _Optional[int] = ..., global_system_step: _Optional[int] = ...) -> None: ...
+    new_experiment: bool
+    def __init__(self, success: bool = ..., message: _Optional[str] = ..., run: _Optional[_Union[StartRecord, _Mapping]] = ..., path: _Optional[str] = ..., name: _Optional[str] = ..., global_step: _Optional[int] = ..., global_system_step: _Optional[int] = ..., new_experiment: bool = ...) -> None: ...
 
 class FinishRecord(_message.Message):
     __slots__ = ("state", "error", "finished_at")

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -514,6 +514,7 @@ def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[R
         if mode == "online":
             assert path, "Initialization path failed when mode=online"
         ctx.next_step(user_step=resp.global_step)
+        ctx.global_system_step = resp.global_system_step
         # 4. 从 core 响应同步配置（online 模式会覆盖为服务端分配的值）
         sync_args = {}
         merge_dict = helper.strip_none(

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -515,6 +515,19 @@ def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[R
             assert path, "Initialization path failed when mode=online"
         ctx.next_step(user_step=resp.global_step)
         ctx.global_system_step = resp.global_system_step
+        # 暂时不允许resume时、旧实验进行硬件信息采集、终端代理
+        resume_limit_kwargs = {}
+        if not resp.new_experiment:
+            resume_limit_kwargs["environment.hardware"] = False
+            resume_limit_kwargs["environment.requirements"] = False
+            resume_limit_kwargs["environment.conda"] = False
+            resume_limit_kwargs["environment.git"] = False
+            resume_limit_kwargs["environment.swanlab"] = False
+            resume_limit_kwargs["monitor.enable"] = False
+            resume_limit_kwargs["console.proxy_type"] = "none"
+            console.info(
+                "Hardware information collection, monitor, and terminal proxy have been disabled in resume mode."
+            )
         # 4. 从 core 响应同步配置（online 模式会覆盖为服务端分配的值）
         sync_args = {}
         merge_dict = helper.strip_none(
@@ -523,6 +536,7 @@ def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[R
                 "project.name": resp.run.project,
                 "experiment.name": resp.name,
                 "experiment.color": resp.run.color,
+                **resume_limit_kwargs,
             },
             strip_empty_str=True,
         )

--- a/swanlab/sdk/internal/context/__init__.py
+++ b/swanlab/sdk/internal/context/__init__.py
@@ -42,10 +42,26 @@ class RunConfig:
 class RunContext:
     def __init__(self, config: RunConfig, callbacks: Optional[CallbacksType] = None):
         self._global_step: int = 0
+        self._global_system_step: Optional[int] = None
         self.config: RunConfig = config
         self.callbacker = create_callback_manager(callbacks=callbacks)
         self.core = create_core(self)
         self.probe = create_probe(self)
+
+    @property
+    def global_system_step(self) -> int:
+        if self._global_system_step is None:
+            raise RuntimeError("Global system step is not set.")
+        return self._global_system_step
+
+    @global_system_step.setter
+    def global_system_step(self, value: int):
+        """
+        设置全局系统步数，仅用于初始化时设置，后续不允许修改
+        """
+        if self._global_system_step is not None:
+            raise RuntimeError("Global system step is already set.")
+        self._global_system_step = value
 
     def next_step(self, user_step: Optional[int] = None) -> int:
         """

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -194,6 +194,7 @@ class CorePython(CoreProtocol):
             name=experiment.get("name"),
             global_step=global_step,
             global_system_step=global_system_step,
+            new_experiment=new_experiment,
         )
 
     # ---------------------------------- 数据上报 ----------------------------------

--- a/swanlab/sdk/internal/core_python/api/experiment.py
+++ b/swanlab/sdk/internal/core_python/api/experiment.py
@@ -109,4 +109,4 @@ def send_experiment_heartbeat(*, experiment_id: str):
     发送实验心跳，保持实验处于活跃状态
     :param experiment_id: 实验唯一标识符
     """
-    client.post(f"/house/experiments/{experiment_id}/heartbeat")
+    client.post(f"/house/experiments/{experiment_id}/heartbeat", {"flagId": "123456"})

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/apple.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/apple.py
@@ -39,7 +39,7 @@ class Apple(AppleSiliconProtocol):
             cpu_pct = SystemScalar(
                 key="cpu.pct",
                 name="CPU Utilization (%)",
-                chart_name="CPU Utilization",
+                chart_name="CPU Utilization (%)",
                 color=generate_color(0),
             )
             scalars.append(cpu_pct)
@@ -58,7 +58,7 @@ class Apple(AppleSiliconProtocol):
             mem_pct = SystemScalar(
                 key="mem.pct",
                 name="System Memory Utilization (%)",
-                chart_name="System Memory",
+                chart_name="System Memory Utilization (%)",
                 color=generate_color(0),
             )
             scalars.append(mem_pct)
@@ -67,7 +67,7 @@ class Apple(AppleSiliconProtocol):
             mem_proc = SystemScalar(
                 key="mem.proc",
                 name="Process Memory In Use (non-swap) (MB)",
-                chart_name="Process Memory",
+                chart_name="Process Memory In Use (non-swap) (MB)",
                 color=generate_color(0),
             )
             scalars.append(mem_proc)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/cpu.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/cpu.py
@@ -40,7 +40,7 @@ class CPU(CpuProtocol):
         usage = SystemScalar(
             key="cpu.pct",
             name="CPU Utilization (%)",
-            chart_name="CPU Utilization",
+            chart_name="CPU Utilization (%)",
             color=generate_color(0),
         )
         scalars.append(usage)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/memory.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/memory.py
@@ -48,7 +48,7 @@ class Memory(MemoryProtocol):
         mem_pct = SystemScalar(
             key="mem.pct",
             name="System Memory Utilization (%)",
-            chart_name="System Memory",
+            chart_name="System Memory Utilization (%)",
             color=generate_color(0),
         )
         scalars.append(mem_pct)
@@ -57,7 +57,7 @@ class Memory(MemoryProtocol):
         mem_proc = SystemScalar(
             key="mem.proc",
             name="Process Memory In Use (non-swap) (MB)",
-            chart_name="Process Memory",
+            chart_name="Process Memory In Use (non-swap) (MB)",
             color=generate_color(0),
         )
         scalars.append(mem_proc)

--- a/swanlab/sdk/internal/probe_python/monitor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/monitor/__init__.py
@@ -10,11 +10,14 @@ from typing import Dict, List, Optional
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord
 from swanlab.sdk.internal.context import RunContext
-from swanlab.sdk.internal.pkg import console, helper, safe, timer
+from swanlab.sdk.internal.pkg import console, safe, timer
 from swanlab.sdk.internal.probe_python.hardware_vendor.apple import Apple
 from swanlab.sdk.internal.probe_python.hardware_vendor.cpu import CPU
 from swanlab.sdk.internal.probe_python.hardware_vendor.memory import Memory
+from swanlab.sdk.internal.probe_python.monitor import builder
 from swanlab.sdk.protocol import CoreProtocol
 from swanlab.sdk.typings.probe_python import SystemScalars, SystemShim
 from swanlab.sdk.typings.probe_python.hardware_vendor import CollectorProtocol, CollectResult
@@ -35,6 +38,7 @@ class Monitor:
         self._executor: Optional[ThreadPoolExecutor] = None
 
     def start(self, ctx: RunContext) -> Optional["Monitor"]:
+        now_step = ctx.global_system_step
         # 1. 收集采集器
         # 注意 scalars 设计上越靠前的越先发送、在前端显示越靠前
         collectors: List[CollectorProtocol] = []
@@ -57,24 +61,17 @@ class Monitor:
         # 2. 定义指标
         # 有部分指标会聚合到一个图表中，所以需要一个缓存来记录每个指标对应的图表索引
         cache_chart_index: Dict[str, str] = {}
+        column_records: List[ColumnRecord] = []
         for scalar in scalars:
-            key = helper.fmt_system_key(scalar.key)
             if (chart_index := cache_chart_index.get(scalar.chart_name)) is None:
                 chart_index = generate_id(8)
                 cache_chart_index[scalar.chart_name] = chart_index
-            _ = (key, chart_index)
-            # TODO 向Core发送指标定义
-            # emitter.emit(
-            #     ScalarDefineEvent(
-            #         key=key,
-            #         name=scalar.name,
-            #         color=scalar.color,
-            #         system=True,
-            #         x_axis=scalar.x_axis,
-            #         chart=chart_index,
-            #         chart_name=scalar.chart_name,
-            #     )
-            # )
+            with safe.block(message=f"Failed to build column record for scalar {scalar.key}"):
+                column_records.append(builder.build_probe_column(scalar, chart_index=chart_index))
+        if len(column_records) == 0:
+            console.debug("No hardware monitor columns found, skipping creating monitor task")
+            return None
+        self._core.upsert_columns(column_records)
         # 3. 定义并启动任务
         all_handlers = [(type(c).__name__, c.collect) for c in collectors]
         if len(all_handlers) == 0:
@@ -84,6 +81,7 @@ class Monitor:
         self._executor = ThreadPoolExecutor(max_workers=2)
 
         def task():
+            nonlocal now_step
             assert self._executor is not None, "Monitor Executor is not initialized"
             futures = [(n, self._executor.submit(fn)) for n, fn in all_handlers]
             results: List[CollectResult] = []
@@ -93,9 +91,11 @@ class Monitor:
                     results.extend(result)
             ts = Timestamp()
             ts.GetCurrentTime()
-            _ = {helper.fmt_system_key(k): v for k, v in results}
-            # TODO 向Core发送指标数据
-            # emitter.emit(MetricLogEvent(step=step, data=data, timestamp=ts))
+            scalar_records: List[ScalarRecord] = []
+            now_step += 1
+            for k, v in results:
+                scalar_records.append(builder.build_probe_scalar(k, value=v, timestamp=ts, step=now_step))
+            self._core.upsert_scalars(scalar_records)
 
         # 不设置立即执行，以避免产生一些无用的数据
         self._timer = timer.Timer(

--- a/swanlab/sdk/internal/probe_python/monitor/builder.py
+++ b/swanlab/sdk/internal/probe_python/monitor/builder.py
@@ -1,0 +1,57 @@
+"""
+@author: cunyue
+@file: builder.py
+@time: 2026/5/8 22:12
+@description: 构建记录
+"""
+
+from typing import Optional, Union
+
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import (
+    ChartType,
+    ColumnClass,
+    ColumnRecord,
+    ColumnType,
+    MetricColors,
+    SectionType,
+    YRange,
+)
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord, ScalarValue
+from swanlab.sdk.internal.pkg import helper
+from swanlab.sdk.typings.probe_python import SystemScalar
+
+
+def build_probe_column(model: SystemScalar, *, chart_index: str) -> ColumnRecord:
+    y_range: Optional[YRange] = None
+    if model.y_min is not None and model.y_max is not None:
+        if model.y_min >= model.y_max:
+            raise ValueError(f"y_min must be less than y_max, but got {model.y_min} >= {model.y_max}")
+        y_range = YRange(min=model.y_min, max=model.y_max)
+    metric_colors: Optional[MetricColors] = None
+    if model.color is not None:
+        metric_colors = MetricColors(light=model.color, dark=model.color)
+    return ColumnRecord(
+        column_class=ColumnClass.COLUMN_CLASS_SYSTEM,
+        column_type=ColumnType.COLUMN_TYPE_SCALAR,
+        column_key=helper.fmt_system_key(model.key),
+        column_name=model.name,
+        section_type=SectionType.SECTION_TYPE_SYSTEM,
+        y_range=y_range,
+        chart_index=chart_index,
+        chart_name=model.chart_name,
+        chart_type=ChartType.CHART_TYPE_LINE,
+        metric_name=model.name,
+        metric_colors=metric_colors,
+    )
+
+
+def build_probe_scalar(key: str, *, value: Union[int, float], step: int, timestamp: Timestamp) -> ScalarRecord:
+    return ScalarRecord(
+        key=helper.fmt_system_key(key),
+        value=ScalarValue(number=value),
+        type=ColumnType.COLUMN_TYPE_SCALAR,
+        step=step,
+        timestamp=timestamp,
+    )

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -153,6 +153,7 @@ class Run:
         self._callbacker.on_run_initialized(self._ctx.run_dir, run_path, settings=callback_settings)
         # 启动组件
         self._components.start()
+        # 启动硬件监控探针
         self._probe.start()
         console.init(bind_to=self._ctx.debug_dir if self.mode != "disabled" else None)
         greeting.welcome(self._ctx, self)

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -95,7 +95,6 @@ class Settings(BaseSettings):
     Project: ClassVar[Type[ProjectSettings]] = ProjectSettings
     Run: ClassVar[Type[RunSettings]] = RunSettings
     Experiment: ClassVar[Type[ExperimentSettings]] = ExperimentSettings
-    Metadata: ClassVar[Type[EnvironmentSettings]] = EnvironmentSettings
     Monitor: ClassVar[Type[MonitorSettings]] = MonitorSettings
     Console: ClassVar[Type[ConsoleSettings]] = ConsoleSettings
     Integration: ClassVar[Type[IntegrationSettings]] = IntegrationSettings

--- a/swanlab/sdk/typings/probe_python/__init__.py
+++ b/swanlab/sdk/typings/probe_python/__init__.py
@@ -323,16 +323,20 @@ class SystemScalar(BaseModel):
     用于在硬件监控线程启动前批量注册系统标量定义。
     """
 
-    key: str = Field(..., pattern=r"^[a-z\.]+$")
+    key: str = Field(..., pattern=r"^[a-z\.]+$", max_length=512, min_length=1)
     """标量键名，仅允许小写字母和点号"""
-    name: Optional[str] = Field(default=None, max_length=100)
+    name: Optional[str] = Field(default=None, max_length=512, min_length=1)
     """显示名称"""
     color: Optional[str] = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
     """颜色，hex 色值，格式如 #FF5733，如果不指定，则使用默认色值"""
     x_axis: Literal["_step", "_relative_time"] = "_relative_time"
     """x 轴类型，支持系统值 _step、_relative_time 或其他标量键名"""
-    chart_name: str = Field(max_length=100)
-    """所属图表名称，最多 100 字符"""
+    chart_name: str = Field(max_length=512, min_length=1)
+    """所属图表名称，最多 512 字符"""
+    y_min: Optional[float] = None
+    """y 轴最小值"""
+    y_max: Optional[float] = None
+    """y 轴最大值"""
 
     model_config = ConfigDict(frozen=True)
 

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -270,8 +270,10 @@ def mock_resource_upload_api(rsps):
 
 @pytest.fixture
 def mock_online_settings():
-    """将全局 settings 的 api_host/web_host 指向测试 HOST，避免意外触发生产环境"""
-    merge_settings({"api_host": API_HOST, "web_host": WEB_HOST})
+    """将全局 settings 的 api_host/web_host 指向测试 HOST，避免意外触发生产环境
+    同时取消硬件监控，硬件监控不在本端到端测试的覆盖范围
+    """
+    merge_settings({"api_host": API_HOST, "web_host": WEB_HOST, "monitor": {"enable": False}})
 
 
 @pytest.fixture

--- a/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_apple.py
+++ b/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_apple.py
@@ -113,7 +113,12 @@ class TestAppleNew:
         assert result is not None
         _, scalars = result
         chart_names = [s.chart_name for s in scalars]
-        assert chart_names == ["CPU Utilization", "Process CPU Threads", "System Memory", "Process Memory"]
+        assert chart_names == [
+            "CPU Utilization (%)",
+            "Process CPU Threads",
+            "System Memory Utilization (%)",
+            "Process Memory In Use (non-swap) (MB)",
+        ]
 
     def test_collect_returns_four_metrics(self):
         """collect() 返回 4 个 (key, value) 采集结果"""

--- a/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_cpu.py
+++ b/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_cpu.py
@@ -364,7 +364,7 @@ class TestCPUNew:
         assert result is not None
         _, scalars = result
         chart_names = [s.chart_name for s in scalars]
-        assert chart_names == ["CPU Utilization", "Process CPU Threads"]
+        assert chart_names == ["CPU Utilization (%)", "Process CPU Threads"]
 
     def test_collect_returns_two_metrics(self):
         """collect() 返回 2 个 (key, value) 采集结果"""

--- a/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_memory.py
+++ b/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_memory.py
@@ -330,7 +330,7 @@ class TestMemoryNew:
         assert result is not None
         _, scalars = result
         chart_names = [s.chart_name for s in scalars]
-        assert chart_names == ["System Memory", "Process Memory"]
+        assert chart_names == ["System Memory Utilization (%)", "Process Memory In Use (non-swap) (MB)"]
 
     def test_collect_returns_two_metrics(self):
         """collect() 返回 2 个 (key, value) 采集结果"""


### PR DESCRIPTION
恢复部分硬件监控功能，resume时暂时不允许硬件监控，等待 #1576 实现

本PR也考虑了实现 https://github.com/SwanHubX/SwanLab/issues/1600 ，暂时有些困难


closes: #1392