### PR TITLE
fix: update fancy-pypi-readme substitutions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,12 +120,24 @@ content-type = "text/markdown"
 fragments = [{ path = "README.md" }]
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
-pattern = "(readme_files)/"
+pattern = "(?:\\./)?(readme_files)/"
 replacement = 'https://raw.githubusercontent.com/SwanHubX/swanlab/main/\g<1>/'
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
-pattern = "README_en.md"
-replacement = 'https://github.com/SwanHubX/SwanLab/blob/main/README_en.md'
+pattern = "README_EN.md"
+replacement = 'https://github.com/SwanHubX/SwanLab/blob/main/README_EN.md'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = "README_JP.md"
+replacement = 'https://github.com/SwanHubX/SwanLab/blob/main/README_JP.md'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = "README_RU.md"
+replacement = 'https://github.com/SwanHubX/SwanLab/blob/main/README_RU.md'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = "CONTRIBUTING.md"
+replacement = "https://github.com/SwanHubX/SwanLab/blob/main/CONTRIBUTING.md"
 
 [[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
 pattern = "README.md"


### PR DESCRIPTION
Broaden the readme_files substitution regex to accept an optional './' prefix and normalize README filename case. Add substitutions for README_EN.md, README_JP.md, README_RU.md, and CONTRIBUTING.md pointing to their GitHub Blob/raw URLs on the SwanHubX/SwanLab main branch so language-specific READMEs and the contributing guide are linked correctly in the generated PyPI README.

