### PR TITLE
refactor: rename `logdir` to `log_dir` with backward compatibility

### DIFF
--- a/swanlab/cli/converter/__init__.py
+++ b/swanlab/cli/converter/__init__.py
@@ -38,11 +38,18 @@ import click
     help="The mode of the swanlab run.",
 )
 @click.option(
-    "--logdir",
+    "--log_dir",
     "-l",
     type=str,
     default=None,
     help="The directory where the swanlab log files are stored.",
+)
+@click.option(
+    "--logdir",
+    type=str,
+    default=None,
+    help="Deprecated: use --log_dir instead.",
+    hidden=True,
 )
 # tensorboard options
 @click.option("--tb-logdir", type=str, default=None, help="The directory where the tensorboard log files are stored.")
@@ -67,6 +74,7 @@ def convert(
     project: str,
     mode: str,
     workspace: str,
+    log_dir: str,
     logdir: str,
     tb_logdir: str,
     tb_types: str,
@@ -80,5 +88,9 @@ def convert(
     **kwargs,
 ):
     """Convert the log files of other experiment tracking tools to SwanLab."""
+    if logdir is not None:
+        click.echo("Warning: The option `--logdir` is deprecated, use `--log_dir` instead.")
+        log_dir = logdir
+    print(log_dir)
     # TODO: 接入重构后的 converter 逻辑
     pass

--- a/swanlab/cli/dashboard/__init__.py
+++ b/swanlab/cli/dashboard/__init__.py
@@ -58,7 +58,7 @@ def _get_free_port(address: str = "0.0.0.0", default_port: int = 5092) -> int:
     help="The port of swanlab web, default by 5092",
 )
 @click.option(
-    "--logdir",
+    "--log_dir",
     "-l",
     default=None,
     nargs=1,
@@ -72,22 +72,39 @@ def _get_free_port(address: str = "0.0.0.0", default_port: int = 5092) -> int:
     help="Specify the folder to store Swanlog. Deprecated: use `swanlab watch <LOG PATH>` instead.",
 )
 @click.option(
+    "--logdir",
+    default=None,
+    nargs=1,
+    type=click.Path(
+        exists=True,
+        dir_okay=True,
+        file_okay=False,
+        resolve_path=True,
+        readable=True,
+    ),
+    help="Deprecated: use --log_dir instead.",
+    hidden=True,
+)
+@click.option(
     "--log-level",
     default="info",
     nargs=1,
     type=click.Choice(["debug", "info", "warning", "error", "critical"]),
     help="The level of log, default by info.",
 )
-def watch(path: str, host: str, port: int, logdir: str, log_level: str):
+def watch(path: str, host: str, port: int, log_dir: str, logdir: str, log_level: str):
     """Run this command to turn on the SwanLab dashboard service."""
-    pass
-
-    # logdir 覆盖 path（向后兼容）
+    # logdir 兼容旧参数（向后兼容）
     if logdir is not None:
+        click.echo("Warning: The option `--logdir` is deprecated, use `--log_dir` instead.")
+        log_dir = logdir
+
+    # log_dir 覆盖 path（向后兼容）
+    if log_dir is not None:
         click.echo(
-            "Warning: The option `--logdir` is deprecated, use `swanlab watch [PATH]` to specify the path instead."
+            "Warning: The option `--log_dir` is deprecated, use `swanlab watch [PATH]` to specify the path instead."
         )
-        path = logdir
+        path = log_dir
 
     if path is not None:
         path = os.path.abspath(path)

--- a/swanlab/integration/accelerate.py
+++ b/swanlab/integration/accelerate.py
@@ -21,17 +21,25 @@ class SwanLabTracker(Callback, _GeneralTracker):
         workspace: Optional[str] = None,
         experiment_name: Optional[str] = None,
         description: Optional[str] = None,
+        log_dir: Optional[str] = None,
         logdir: Optional[str] = None,
         mode: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
         self._init_kwargs: dict[str, Any] = {}
         for key, value in [
             ("project", project),
             ("workspace", workspace),
             ("experiment_name", experiment_name),
             ("description", description),
-            ("logdir", logdir),
+            ("log_dir", log_dir),
             ("mode", mode),
         ]:
             if value is not None:

--- a/swanlab/integration/keras.py
+++ b/swanlab/integration/keras.py
@@ -21,12 +21,20 @@ class SwanLabCallback(Callback, _KerasCallback):
         workspace: Optional[str] = None,
         experiment_name: Optional[str] = None,
         description: Optional[str] = None,
+        log_dir: Optional[str] = None,
         logdir: Optional[str] = None,
         mode: Optional[str] = None,
         tags: Optional[List[str]] = None,
         config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
         _KerasCallback.__init__(self)
 
         if log_freq == "batch":
@@ -47,7 +55,7 @@ class SwanLabCallback(Callback, _KerasCallback):
             ("workspace", workspace),
             ("experiment_name", experiment_name),
             ("description", description),
-            ("logdir", logdir),
+            ("log_dir", log_dir),
             ("mode", mode),
             ("tags", tags),
         ]:

--- a/swanlab/integration/mmengine.py
+++ b/swanlab/integration/mmengine.py
@@ -89,7 +89,7 @@ class SwanlabVisBackend(Callback, _BaseVisBackend):
     def _init_env(self) -> None:
         if self._save_dir is not None:
             os.makedirs(self._save_dir, exist_ok=True)
-        self._init_kwargs.setdefault("logdir", self._save_dir)
+        self._init_kwargs.setdefault("log_dir", self._save_dir)
 
         if self._get_active_run() is not None:
             self._swanlab_initialized = True

--- a/swanlab/integration/paddlenlp.py
+++ b/swanlab/integration/paddlenlp.py
@@ -63,12 +63,20 @@ class SwanLabCallback(Callback, swanlab.vendor.paddlenlp.trainer.trainer.Trainer
         workspace: Optional[str] = None,
         experiment_name: Optional[str] = None,
         description: Optional[str] = None,
+        log_dir: Optional[str] = None,
         logdir: Optional[str] = None,
         mode: Optional[str] = None,
         tags: Optional[List[str]] = None,
         log_config: bool = True,
         **_kwargs: Any,
     ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
         self._log_config = log_config
         self._init_kwargs: Dict[str, Any] = {}
         for key, value in [
@@ -76,7 +84,7 @@ class SwanLabCallback(Callback, swanlab.vendor.paddlenlp.trainer.trainer.Trainer
             ("workspace", workspace),
             ("experiment_name", experiment_name),
             ("description", description),
-            ("logdir", logdir),
+            ("log_dir", log_dir),
             ("mode", mode),
             ("tags", tags),
         ]:

--- a/swanlab/integration/pytorch_lightning.py
+++ b/swanlab/integration/pytorch_lightning.py
@@ -22,6 +22,7 @@ class SwanLabLogger(Callback, _LightningLogger):
         workspace: Optional[str] = None,
         experiment_name: Optional[str] = None,
         description: Optional[str] = None,
+        log_dir: Optional[str] = None,
         logdir: Optional[str] = None,
         mode: Optional[str] = None,
         save_dir: Optional[Union[str, Path]] = ".",
@@ -29,6 +30,13 @@ class SwanLabLogger(Callback, _LightningLogger):
         id: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
         _LightningLogger.__init__(self)
 
         self._experiment = None
@@ -44,7 +52,7 @@ class SwanLabLogger(Callback, _LightningLogger):
             ("workspace", workspace),
             ("experiment_name", experiment_name),
             ("description", description),
-            ("logdir", logdir),
+            ("log_dir", log_dir),
             ("mode", mode),
             ("tags", tags),
             ("id", id),

--- a/swanlab/integration/transformers.py
+++ b/swanlab/integration/transformers.py
@@ -44,12 +44,20 @@ class SwanLabCallback(Callback, swanlab.vendor.transformers.trainer_callback.Tra
         workspace: Optional[str] = None,
         experiment_name: Optional[str] = None,
         description: Optional[str] = None,
+        log_dir: Optional[str] = None,
         logdir: Optional[str] = None,
         mode: Optional[str] = None,
         tags: Optional[List[str]] = None,
         log_config: bool = True,
         **_kwargs: Any,
     ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
         self._log_config = log_config
         self._init_kwargs: Dict[str, Any] = {}
         for key, value in [
@@ -57,7 +65,7 @@ class SwanLabCallback(Callback, swanlab.vendor.transformers.trainer_callback.Tra
             ("workspace", workspace),
             ("experiment_name", experiment_name),
             ("description", description),
-            ("logdir", logdir),
+            ("log_dir", log_dir),
             ("mode", mode),
             ("tags", tags),
         ]:

--- a/swanlab/integration/ultralytics.py
+++ b/swanlab/integration/ultralytics.py
@@ -43,18 +43,26 @@ class SwanLabCallback(Callback):
         workspace: Optional[str] = None,
         experiment_name: Optional[str] = None,
         description: Optional[str] = None,
+        log_dir: Optional[str] = None,
         logdir: Optional[str] = None,
         mode: Optional[str] = None,
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
         self._init_kwargs: dict[str, Any] = {}
         for key, value in [
             ("project", project),
             ("workspace", workspace),
             ("experiment_name", experiment_name),
             ("description", description),
-            ("logdir", logdir),
+            ("log_dir", log_dir),
             ("mode", mode),
             ("tags", tags),
         ]:
@@ -82,7 +90,7 @@ class SwanLabCallback(Callback):
             run.config["FRAMEWORK"] = "ultralytics"
         self._initialized = True
 
-    def on_run_finished(self, state: str, error: Optional[str] = None) -> None:
+    def on_run_finished(self, state: str, error: Optional[str] = None, **kwargs) -> None:
         self._initialized = False
         self._step_counter.clear()
         _processed_plots.clear()
@@ -129,7 +137,7 @@ class SwanLabCallback(Callback):
 
         if trainer.epoch == 0:
             try:
-                from ultralytics.utils.torch_utils import model_info_for_loggers
+                from ultralytics.utils.torch_utils import model_info_for_loggers  # type: ignore
 
                 swanlab.log(model_info_for_loggers(trainer), step=step)
             except ImportError:
@@ -178,17 +186,23 @@ def add_swanlab_callback(
     workspace: Optional[str] = None,
     experiment_name: Optional[str] = None,
     description: Optional[str] = None,
+    log_dir: Optional[str] = None,
     logdir: Optional[str] = None,
     mode: Optional[str] = None,
     tags: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> Any:
+    if logdir is not None:
+        import warnings
+
+        warnings.warn("The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2)
+        log_dir = logdir
     cb = SwanLabCallback(
         project=project,
         workspace=workspace,
         experiment_name=experiment_name,
         description=description,
-        logdir=logdir,
+        log_dir=log_dir,
         mode=mode,
         tags=tags,
         **kwargs,
@@ -210,17 +224,23 @@ def return_swanlab_callback(
     workspace: Optional[str] = None,
     experiment_name: Optional[str] = None,
     description: Optional[str] = None,
+    log_dir: Optional[str] = None,
     logdir: Optional[str] = None,
     mode: Optional[str] = None,
     tags: Optional[List[str]] = None,
     **kwargs: Any,
 ) -> dict:
+    if logdir is not None:
+        import warnings
+
+        warnings.warn("The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2)
+        log_dir = logdir
     cb = SwanLabCallback(
         project=project,
         workspace=workspace,
         experiment_name=experiment_name,
         description=description,
-        logdir=logdir,
+        log_dir=log_dir,
         mode=mode,
         tags=tags,
         **kwargs,

--- a/swanlab/sdk/cmd/merge_settings.py
+++ b/swanlab/sdk/cmd/merge_settings.py
@@ -29,20 +29,21 @@ def merge_settings(settings: Union[Settings, dict]) -> None:
         Merge settings from a dictionary:
 
         >>> import swanlab
-        >>> swanlab.merge_settings({"mode": "local", "logdir": "./my_logs"})
+        >>> swanlab.merge_settings({"mode": "local", "log_dir": "./my_logs"})
         >>> swanlab.init()
 
         Disable hardware monitoring:
 
         >>> import swanlab
-        >>> swanlab.merge_settings({"hardware": {"monitor": False}})
+        >>> swanlab.merge_settings({"probe": {"monitor": False}})
         >>> swanlab.init()
 
         Use a Settings object:
 
         >>> import swanlab
         >>> from swanlab import Settings
-        >>> custom_settings = Settings(mode="offline", logdir="./experiments")
+        >>> from pathlib import Path
+        >>> custom_settings = Settings(mode="offline", log_dir=Path("./experiments"))
         >>> swanlab.merge_settings(custom_settings)
         >>> swanlab.init()
     """

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -324,7 +324,7 @@ class TestInitDisabledMode:
         assert isinstance(run, Run)
         assert has_run()
 
-    def test_init_does_not_create_logdir(self):
+    def test_init_does_not_create_log_dir(self):
         """disabled 模式不得创建日志目录"""
         run = init(mode="disabled")
         log_dir = run._ctx.config.settings.log_dir
@@ -368,7 +368,7 @@ class TestInitDisabledMode:
 
 
 class TestInitLocalMode:
-    def test_init_creates_logdir_with_gitignore(self):
+    def test_init_creates_log_dir_with_gitignore(self):
         """local 模式应创建日志目录，并在首次创建时写入 .gitignore"""
         run = init(mode="local")
         log_dir = run._ctx.config.settings.log_dir


### PR DESCRIPTION
## Summary

将 `init()` 函数及所有相关模块中的 `logdir` 参数重命名为 `log_dir`，保留旧参数名向后兼容并添加 deprecation warning。

## Changes

### 核心改动
- `swanlab.init(logdir=...)` → `swanlab.init(log_dir=...)`
- 保留 `logdir` 作为兼容参数，传入时发出 `DeprecationWarning`
- 兼容 `SWANLAB_LOGDIR` 环境变量（与 `SWANLAB_SAVE_DIR` 模式一致）
- 更新 `swanlab/__init__.pyi` 类型存根

### 集成模块
- paddlenlp、keras、accelerate、transformers、pytorch_lightning、ultralytics、mmengine 均同步更新
- 保留 `logdir` 兼容参数并 warning

### CLI
- `swanlab watch --logdir` → `--log_dir`，保留隐藏的 `--logdir` 旧选项并 warning
- `swanlab convert --logdir` → `--log_dir`，保留隐藏的 `--logdir` 旧选项并 warning