### PR TITLE
feat/integration last

### DIFF
--- a/swanlab/integration/fastai.py
+++ b/swanlab/integration/fastai.py
@@ -151,7 +151,7 @@ class SwanLabCallback(Callback, _FastaiCallback):
         self._pending_config.clear()
 
     def _gather_args(self) -> Dict[str, Any]:
-        cb_args = {f"{cb}": getattr(cb, "__stored_args__", True) for cb in self.cbs if cb != self}
+        cb_args = {type(cb).__name__: getattr(cb, "__stored_args__", True) for cb in self.cbs if cb != self}
         args: Dict[str, Any] = {"Learner": self.learn, **cb_args}
         try:
             n_inp = self.dls.train.n_inp

--- a/swanlab/integration/fastai.py
+++ b/swanlab/integration/fastai.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, List, Optional
+
+import swanlab
+import swanlab.vendor
+from swanlab import Callback
+
+_FastaiCallback = swanlab.vendor.fastai.learner.Callback
+_fastai_hook = swanlab.vendor.fastai.callback.hook
+_fastcore_basics = swanlab.vendor.fastcore.basics
+
+
+class SwanLabCallback(Callback, _FastaiCallback):
+    """
+    FastAI callback implementing both ``swanlab.Callback`` and fastai's ``Callback``.
+
+    Usage (recommended):
+
+        import swanlab
+        from swanlab.integration.fastai import SwanLabCallback
+
+        cb = SwanLabCallback()
+        swanlab.init(project="my-project", callbacks=[cb])
+        learn = Learner(..., cbs=cb)
+        learn.fit_one_cycle(5)
+        swanlab.finish()
+    """
+
+    def __init__(
+        self,
+        *,
+        project: Optional[str] = None,
+        workspace: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        description: Optional[str] = None,
+        log_dir: Optional[str] = None,
+        logdir: Optional[str] = None,
+        mode: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        config: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        if logdir is not None:
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            log_dir = logdir
+
+        Callback.__init__(self)
+        _FastaiCallback.__init__(self)
+
+        tags = list(tags) if tags else []
+        if "fastai" not in tags:
+            tags.append("fastai")
+
+        self._init_kwargs: Dict[str, Any] = {}
+        for key, value in [
+            ("project", project),
+            ("workspace", workspace),
+            ("experiment_name", experiment_name),
+            ("description", description),
+            ("log_dir", log_dir),
+            ("mode", mode),
+            ("tags", tags),
+        ]:
+            if value is not None:
+                self._init_kwargs[key] = value
+        self._init_kwargs.update(kwargs)
+        self._init_kwargs.pop("callbacks", None)
+        self._init_kwargs.pop("config", None)
+
+        self._pending_config: Dict[str, Any] = dict(config) if config else {}
+        self._initialized = False
+        self._swanlab_step = 0
+
+    @property
+    def name(self) -> str:
+        return "swanlab-integration-fastai"
+
+    # --- swanlab.Callback hooks ---
+
+    def on_run_initialized(self, run_dir: str, path: str, **kwargs: Any) -> None:
+        run = self._get_active_run()
+        if run is None:
+            return
+        self._initialized = True
+        run.config["FRAMEWORK"] = "fastai"
+        self._flush_pending_config(run)
+
+    def on_run_finished(self, state: str, error: Optional[str] = None, **kwargs: Any) -> None:
+        self._initialized = False
+        self._pending_config.clear()
+
+    # --- fastai callback hooks ---
+
+    def before_fit(self) -> None:
+        self._ensure_init()
+        run = self._get_active_run()
+        if run is not None:
+            configs_log = self._gather_args()
+            formatted_config = self._format_config(configs_log)
+            run.config.update(formatted_config)
+
+    def after_batch(self) -> None:
+        if not self.training:
+            return
+        self._swanlab_step += 1
+        payload: Dict[str, Any] = {
+            "train/loss": self.loss.item(),
+            "train/step": self._swanlab_step,
+        }
+        for i, h in enumerate(self.opt.hypers):
+            for k, v in h.items():
+                payload[f"train/{k}_{i}"] = v
+        swanlab.log(payload, step=self._swanlab_step)
+
+    def after_epoch(self) -> None:
+        payload: Dict[str, Any] = {}
+        for name, value in zip(self.recorder.metric_names, self.recorder.log):
+            if value is not None:
+                payload[f"epoch/{name}"] = value
+        if payload:
+            swanlab.log(payload, step=self.epoch)
+
+    # --- helpers ---
+
+    def update_config(self, config: Dict[str, Any]) -> None:
+        run = self._get_active_run()
+        if run is None:
+            self._pending_config.update(config)
+            return
+        run.config.update(config)
+
+    def _ensure_init(self) -> None:
+        if self._initialized:
+            return
+        run = self._get_active_run()
+        if run is not None:
+            self._initialized = True
+            run.config["FRAMEWORK"] = "fastai"
+            self._flush_pending_config(run)
+            return
+        init_kwargs = dict(self._init_kwargs)
+        if self._pending_config:
+            init_kwargs["config"] = dict(self._pending_config)
+        swanlab.init(callbacks=[self], **init_kwargs)
+        self._pending_config.clear()
+
+    def _gather_args(self) -> Dict[str, Any]:
+        cb_args = {f"{cb}": getattr(cb, "__stored_args__", True) for cb in self.cbs if cb != self}
+        args: Dict[str, Any] = {"Learner": self.learn, **cb_args}
+        try:
+            n_inp = self.dls.train.n_inp
+            args["n_inp"] = n_inp
+            xb = self.dls.valid.one_batch()[:n_inp]
+            args.update(
+                {
+                    f"input {n + 1} dim {i + 1}": d
+                    for n in range(n_inp)
+                    for i, d in enumerate(list(_fastcore_basics.detuplify(xb[n]).shape))
+                }
+            )
+        except Exception:
+            pass
+
+        with _fastcore_basics.ignore_exceptions():
+            args["batch_size"] = self.dls.bs
+            args["batch_per_epoch"] = len(self.dls.train)
+            args["model_parameters"] = _fastai_hook.total_params(self.model)[0]
+            args["device"] = self.dls.device.type
+            args["frozen"] = bool(self.opt.frozen_idx)
+            args["frozen_idx"] = self.opt.frozen_idx
+            args["dataset/tfms"] = f"{self.dls.dataset.tfms}"
+            args["dls/after_item"] = f"{self.dls.after_item}"
+            args["dls/before_batch"] = f"{self.dls.before_batch}"
+            args["dls/after_batch"] = f"{self.dls.after_batch}"
+        return args
+
+    @classmethod
+    def _format_config(cls, config: Dict[str, Any]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key, value in config.items():
+            if isinstance(value, dict):
+                result[key] = cls._format_config(value)
+            else:
+                result[key] = cls._format_config_value(value)
+        return result
+
+    @classmethod
+    def _format_config_value(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            return [cls._format_config_value(item) for item in value]
+        elif hasattr(value, "__stored_args__"):
+            return {**cls._format_config(value.__stored_args__), "_name": str(value)}
+        return value
+
+    def _flush_pending_config(self, run: Any) -> None:
+        if not self._pending_config:
+            return
+        run.config.update(self._pending_config)
+        self._pending_config.clear()
+
+    @staticmethod
+    def _get_active_run():
+        try:
+            return swanlab.get_run()
+        except RuntimeError:
+            return None
+
+
+__all__ = ["SwanLabCallback"]

--- a/swanlab/integration/pytorch_lightning.py
+++ b/swanlab/integration/pytorch_lightning.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 
 import swanlab
 import swanlab.vendor
-from swanlab import Callback
 from swanlab.sdk.internal.pkg import console
 
 _LightningLogger = swanlab.vendor.lightning.pytorch.loggers.Logger
@@ -15,7 +14,7 @@ _rank_zero_only = swanlab.vendor.lightning.pytorch.utilities.rank_zero_only
 _rank_zero_warn = getattr(swanlab.vendor.lightning.pytorch.utilities, "rank_zero_warn", console.warning)
 
 
-class SwanLabLogger(Callback, _LightningLogger):
+class SwanLabLogger(_LightningLogger):
     def __init__(
         self,
         project: Optional[str] = None,
@@ -39,11 +38,11 @@ class SwanLabLogger(Callback, _LightningLogger):
             log_dir = logdir
         _LightningLogger.__init__(self)
 
+        tags = tags or []
+        if "⚡️pytorch lightning" not in tags:
+            tags.append("⚡️pytorch lightning")
+
         self._experiment = None
-        self._initialized = False
-        self._pending_config: Dict[str, Any] = {}
-        self._project = project
-        self._experiment_name = experiment_name
         self._save_dir = os.fspath(save_dir) if save_dir is not None else None
         self._init_kwargs: Dict[str, Any] = {}
 
@@ -60,7 +59,6 @@ class SwanLabLogger(Callback, _LightningLogger):
             if value is not None:
                 self._init_kwargs[key] = value
         self._init_kwargs.update(kwargs)
-        self._init_kwargs.pop("callbacks", None)
 
     @property
     def name(self) -> str:
@@ -85,52 +83,33 @@ class SwanLabLogger(Callback, _LightningLogger):
 
     @property
     def experiment(self):
-        self._ensure_init()
+        if self._experiment is not None:
+            return self._experiment
         run = self._get_active_run()
         if run is not None:
+            _rank_zero_warn(
+                "There is a swanlab experiment already in progress and newly created instances of "
+                "`SwanLabLogger` will reuse this experiment. If this is not desired, call "
+                "`swanlab.finish()` before instantiating `SwanLabLogger`."
+            )
             self._experiment = run
             return run
-        return self
-
-    # --- swanlab.Callback hooks ---
-
-    def on_run_initialized(self, run_dir, path, **kwargs) -> None:
-        run = self._get_active_run()
-        if run is None:
-            return
-        self._initialized = True
-        self._experiment = run
-        run.config["FRAMEWORK"] = "pytorch_lightning"
-        self._flush_pending_config(run)
-
-    def on_run_finished(self, state: str, error: Optional[str] = None, **kwargs) -> None:
-        self._initialized = False
-        self._experiment = None
-        self._pending_config.clear()
+        swanlab.config["FRAMEWORK"] = "pytorch_lightning"
+        self._experiment = swanlab.init(**self._init_kwargs)
+        return self._experiment
 
     # --- Lightning Logger interface ---
 
     def update_config(self, config: Dict[str, Any]) -> None:
-        run = self._get_active_run()
-        if run is None:
-            self._pending_config.update(config)
-            return
-        run.config.update(config)
+        self.experiment.config.update(config)
 
     @_rank_zero_only
     def log_hyperparams(self, params: Union[Mapping[str, Any], Namespace], *args: Any, **kwargs: Any) -> None:
-        self._ensure_init()
-        run = self._get_active_run()
-        if run is None:
-            return
-        run.config.update(self._params_to_dict(params))
+        self.experiment.config.update(self._params_to_dict(params))
 
     @_rank_zero_only
     def log_metrics(self, metrics: Mapping[str, Any], step: Optional[int] = None) -> None:
-        self._ensure_init()
-        if self._get_active_run() is None:
-            return
-        swanlab.log(dict(metrics), step=step)
+        self.experiment.log(dict(metrics), step=step)
 
     @_rank_zero_only
     def log_image(self, key: str, images: List[Any], step: Optional[int] = None, **kwargs: Any) -> None:
@@ -152,30 +131,9 @@ class SwanLabLogger(Callback, _LightningLogger):
     def finalize(self, status: Optional[str] = None) -> None:
         if status is not None and status != "success":
             _rank_zero_warn(f"SwanLabLogger received non-success Lightning finalize status: {status}")
+            swanlab.finish(state="crashed", error=f"Closed by pytorch lightning. Status: {status}")
 
     # --- helpers ---
-
-    def _ensure_init(self) -> None:
-        if self._initialized:
-            return
-        run = self._get_active_run()
-        if run is not None:
-            self._initialized = True
-            self._experiment = run
-            run.config["FRAMEWORK"] = "pytorch_lightning"
-            self._flush_pending_config(run)
-            return
-        init_kwargs = dict(self._init_kwargs)
-        if self._pending_config:
-            init_kwargs["config"] = dict(self._pending_config)
-        swanlab.init(callbacks=[self], **init_kwargs)
-        self._pending_config.clear()
-
-    def _flush_pending_config(self, run: Any) -> None:
-        if not self._pending_config:
-            return
-        run.config.update(self._pending_config)
-        self._pending_config.clear()
 
     def _log_media_list(self, factory: Any, key: str, values: List[Any], step: Optional[int], **kwargs: Any) -> None:
         if not isinstance(values, list):

--- a/swanlab/integration/ray.py
+++ b/swanlab/integration/ray.py
@@ -145,7 +145,7 @@ class _SwanLabLoggingActor:
                 self._swanlab.config.update(config_update, allow_val_change=True)
                 self._swanlab.log(log, step=log.get(_TRAINING_ITERATION))
             except HTTPError as e:
-                _ray_logger.warning("Failed to log result to swanlab: {}".format(str(e)))
+                _ray_logger.warning("Failed to log result to swanlab: {}".format(str(e)))  # type: ignore
 
         self._swanlab.finish()
 

--- a/swanlab/integration/ray.py
+++ b/swanlab/integration/ray.py
@@ -35,6 +35,7 @@ try:
     import ray.air  # noqa: F401
     import ray.train  # noqa: F401
     import ray.tune  # noqa: F401
+    import ray.tune.logger  # noqa: F401
     import ray.util  # noqa: F401
     from ray.air.constants import TRAINING_ITERATION as _TRAINING_ITERATION
     from ray.air.util.node import _force_on_current_node

--- a/swanlab/integration/ray.py
+++ b/swanlab/integration/ray.py
@@ -1,0 +1,370 @@
+"""
+Docs: https://docs.swanlab.cn/guide_cloud/integration/integration-ray.html
+
+Usage:
+------
+from ray import tune
+from swanlab.integration.ray import SwanLabLoggerCallback
+
+cb = SwanLabLoggerCallback(project="Ray_Project")
+tuner = tune.Tuner(
+    train_func,
+    param_space={"lr": tune.grid_search([0.001, 0.01, 0.1, 1.0]), "epochs": 10},
+    run_config=tune.RunConfig(callbacks=[cb]),
+)
+results = tuner.fit()
+------
+"""
+
+from __future__ import annotations
+
+import enum
+import os
+import warnings
+from numbers import Number
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.error import HTTPError
+
+import swanlab
+import swanlab.vendor
+from swanlab import Callback
+
+try:
+    # Ray must be imported explicitly for submodules in 2.x (lazy loading)
+    import ray  # noqa: F401
+    import ray.air  # noqa: F401
+    import ray.train  # noqa: F401
+    import ray.tune  # noqa: F401
+    import ray.util  # noqa: F401
+    from ray.air.constants import TRAINING_ITERATION as _TRAINING_ITERATION
+    from ray.air.util.node import _force_on_current_node
+    from ray.train._internal.syncer import DEFAULT_SYNC_TIMEOUT as _DEFAULT_SYNC_TIMEOUT
+    from ray.tune.experiment import Trial as _Trial
+    from ray.tune.logger import LoggerCallback as _LoggerCallback
+    from ray.tune.utils import flatten_dict as _flatten_dict
+    from ray.util.queue import Queue
+
+    _ray_logger = ray.tune.logger
+except ImportError as e:
+    raise ImportError(
+        "The Ray integration requires the 'ray' package. Please install it by running:\n    pip install 'ray[tune]'"
+    ) from e
+
+np = swanlab.vendor.np
+
+# Environment constants
+SWANLAB_API_KEY = "SWANLAB_API_KEY"
+SWANLAB_MODE = "SWANLAB_MODE"
+SWANLAB_PROJ_NAME = "SWANLAB_PROJ_NAME"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_swanlab_project(project: Optional[str] = None) -> Optional[str]:
+    if not project and os.environ.get(SWANLAB_PROJ_NAME):
+        project = os.environ.get(SWANLAB_PROJ_NAME)
+    return project
+
+
+def _is_allowed_type(obj: Any) -> bool:
+    if isinstance(obj, np.ndarray) and obj.size == 1:
+        return isinstance(obj.item(), Number)
+    return isinstance(obj, Number)
+
+
+def _clean_log(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: _clean_log(v) for k, v in obj.items()}
+    elif isinstance(obj, (list, set)):
+        return [_clean_log(v) for v in obj]
+    elif isinstance(obj, tuple):
+        return tuple(_clean_log(v) for v in obj)
+    elif _is_allowed_type(obj):
+        return obj
+    fallback = str(obj)
+    try:
+        return int(fallback)
+    except ValueError:
+        pass
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# Queue items
+# ---------------------------------------------------------------------------
+
+
+class _QueueItem(enum.Enum):
+    END = enum.auto()
+    RESULT = enum.auto()
+    CHECKPOINT = enum.auto()
+
+
+# ---------------------------------------------------------------------------
+# Ray Actor
+# ---------------------------------------------------------------------------
+
+
+class _SwanLabLoggingActor:
+    def __init__(
+        self,
+        logdir: str,
+        queue: Queue,
+        exclude: List[str],
+        to_config: List[str],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        self._swanlab = swanlab
+        os.chdir(logdir)
+        self.queue = queue
+        self._exclude = set(exclude)
+        self._to_config = set(to_config)
+        self.args = args
+        self.kwargs = kwargs
+        self._trial_name = self.kwargs.get("name", "unknown")
+        self._logdir = logdir
+
+    def run(self) -> None:
+        run = self._swanlab.init(*self.args, **self.kwargs)
+        run.config.trial_log_path = self._logdir
+
+        while True:
+            item_type, item_content = self.queue.get()
+            if item_type == _QueueItem.END:
+                break
+            if item_type == _QueueItem.CHECKPOINT:
+                continue
+
+            log, config_update = self._handle_result(item_content)
+            try:
+                self._swanlab.config.update(config_update, allow_val_change=True)
+                self._swanlab.log(log, step=log.get(_TRAINING_ITERATION))
+            except HTTPError as e:
+                _ray_logger.warning("Failed to log result to swanlab: {}".format(str(e)))
+
+        self._swanlab.finish()
+
+    def _handle_result(self, result: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        config_update = result.get("config", {}).copy()
+        log: Dict[str, Any] = {}
+        flat_result = _flatten_dict(result, delimiter="/")
+        for k, v in flat_result.items():
+            if any(k.startswith(item + "/") or k == item for item in self._exclude):
+                continue
+            elif any(k.startswith(item + "/") or k == item for item in self._to_config):
+                config_update[k] = v
+            elif not _is_allowed_type(v):
+                continue
+            else:
+                log[k] = v
+        config_update.pop("callbacks", None)
+        return log, config_update
+
+
+# ---------------------------------------------------------------------------
+# SwanLabLoggerCallback
+# ---------------------------------------------------------------------------
+
+
+class SwanLabLoggerCallback(Callback, _LoggerCallback):
+    _exclude_results = ["done", "should_checkpoint"]
+    AUTO_CONFIG_KEYS = [
+        "trial_id",
+        "experiment_tag",
+        "node_ip",
+        "experiment_id",
+        "hostname",
+        "pid",
+        "date",
+    ]
+    _logger_actor_cls = _SwanLabLoggingActor
+
+    def __init__(
+        self,
+        project: Optional[str] = None,
+        workspace: Optional[str] = None,
+        api_key_file: Optional[str] = None,
+        api_key: Optional[str] = None,
+        swanlab_host: Optional[str] = None,
+        excludes: Optional[List[str]] = None,
+        log_config: bool = False,
+        upload_checkpoints: bool = False,
+        save_checkpoints: bool = False,
+        upload_timeout: int = _DEFAULT_SYNC_TIMEOUT,
+        **kwargs: Any,
+    ) -> None:
+        if save_checkpoints:
+            warnings.warn(
+                "`save_checkpoints` is deprecated. Use `upload_checkpoints` instead.",
+                DeprecationWarning,
+            )
+            upload_checkpoints = save_checkpoints
+
+        self.project = project
+        self.workspace = workspace
+        self.api_key_path = api_key_file
+        self.api_key = api_key
+        self.swanlab_host = swanlab_host
+        self.excludes = excludes or []
+        self.log_config = log_config
+        self.upload_checkpoints = upload_checkpoints
+        self._upload_timeout = upload_timeout
+        self.kwargs = kwargs
+
+        self._remote_logger_class: Any = None
+        self._trial_logging_actors: Dict[_Trial, Any] = {}
+        self._trial_logging_futures: Dict[_Trial, Any] = {}
+        self._logging_future_to_trial: Dict[Any, _Trial] = {}
+        self._trial_queues: Dict[_Trial, Queue] = {}
+
+    # --- swanlab.Callback ---
+
+    @property
+    def name(self) -> str:
+        return "swanlab-integration-ray"
+
+    def on_run_initialized(self, run_dir: Any, path: str, **kwargs: Any) -> None:
+        run = _get_active_run()
+        if run is not None:
+            run.config["FRAMEWORK"] = "ray"
+
+    def on_run_finished(self, state: str, error: Optional[str] = None, **kwargs: Any) -> None:
+        pass
+
+    # --- Ray LoggerCallback ---
+
+    def setup(self, *args: Any, **kwargs: Any) -> None:
+        self.project = _get_swanlab_project(self.project)
+        if not self.project:
+            raise ValueError(
+                f"Please pass the project name as argument or through the {SWANLAB_PROJ_NAME} environment variable."
+            )
+
+    def log_trial_start(self, trial: _Trial) -> None:
+        config = trial.config.copy()
+        config.pop("callbacks", None)
+        exclude_results = self._exclude_results.copy()
+        exclude_results += self.excludes
+        if not self.log_config:
+            exclude_results += ["config"]
+
+        trial_id = trial.trial_id if trial else None
+        trial_name = str(trial) if trial else None
+
+        swanlab_init_kwargs = dict(
+            project=self.project,
+            workspace=self.workspace,
+            name=trial_name,
+            config=_clean_log(config),
+        )
+        swanlab_init_kwargs.update(self.kwargs)
+        self._start_logging_actor(trial, exclude_results, **swanlab_init_kwargs)
+
+    def _start_logging_actor(self, trial: _Trial, exclude_results: List[str], **swanlab_init_kwargs: Any) -> None:
+        if trial in self._trial_logging_futures:
+            return
+        if not self._remote_logger_class:
+            env_vars = {}
+            self._remote_logger_class = ray.remote(
+                num_cpus=0,
+                **_force_on_current_node(),
+                runtime_env={"env_vars": env_vars},
+                max_restarts=-1,
+                max_task_retries=-1,
+            )(self._logger_actor_cls)
+
+        self._trial_queues[trial] = Queue(
+            actor_options={
+                "num_cpus": 0,
+                **_force_on_current_node(),
+                "max_restarts": -1,
+                "max_task_retries": -1,
+            }
+        )
+        self._trial_logging_actors[trial] = self._remote_logger_class.remote(
+            logdir=trial.local_path,
+            queue=self._trial_queues[trial],
+            exclude=exclude_results,
+            to_config=self.AUTO_CONFIG_KEYS,
+            **swanlab_init_kwargs,
+        )
+        logging_future = self._trial_logging_actors[trial].run.remote()
+        self._trial_logging_futures[trial] = logging_future
+        self._logging_future_to_trial[logging_future] = trial
+
+    def _signal_logging_actor_stop(self, trial: _Trial) -> None:
+        self._trial_queues[trial].put((_QueueItem.END, None))
+
+    def log_trial_result(self, iteration: int, trial: _Trial, result: Dict[str, Any]) -> None:
+        if trial not in self._trial_logging_actors:
+            self.log_trial_start(trial)
+        result = _clean_log(result)
+        self._trial_queues[trial].put((_QueueItem.RESULT, result))
+
+    def log_trial_save(self, trial: _Trial) -> None:
+        if self.upload_checkpoints and trial.checkpoint:
+            try:
+                import pyarrow.fs
+
+                if isinstance(trial.checkpoint.filesystem, pyarrow.fs.LocalFileSystem):
+                    checkpoint_root = trial.checkpoint.path
+                    if checkpoint_root:
+                        self._trial_queues[trial].put((_QueueItem.CHECKPOINT, checkpoint_root))
+            except ImportError:
+                pass
+
+    def log_trial_end(self, trial: _Trial, failed: bool = False) -> None:
+        self._signal_logging_actor_stop(trial)
+        self._cleanup_logging_actors()
+
+    def _cleanup_logging_actor(self, trial: _Trial) -> None:
+        del self._trial_queues[trial]
+        del self._trial_logging_futures[trial]
+        ray.kill(self._trial_logging_actors[trial])
+        del self._trial_logging_actors[trial]
+
+    def _cleanup_logging_actors(self, timeout: int = 0, kill_on_timeout: bool = False) -> None:
+        futures = list(self._trial_logging_futures.values())
+        done, remaining = ray.wait(futures, num_returns=len(futures), timeout=timeout)
+        for ready_future in done:
+            finished_trial = self._logging_future_to_trial.pop(ready_future)
+            self._cleanup_logging_actor(finished_trial)
+        if kill_on_timeout:
+            for remaining_future in remaining:
+                trial = self._logging_future_to_trial.pop(remaining_future)
+                self._cleanup_logging_actor(trial)
+
+    def on_experiment_end(self, trials: List[_Trial], **info: Any) -> None:
+        self._cleanup_logging_actors(timeout=self._upload_timeout, kill_on_timeout=True)
+
+    def __del__(self) -> None:
+        try:
+            if ray.is_initialized():
+                for trial in list(self._trial_logging_actors):
+                    self._signal_logging_actor_stop(trial)
+                self._cleanup_logging_actors(timeout=2, kill_on_timeout=True)
+            self._trial_logging_actors = {}
+            self._trial_logging_futures = {}
+            self._logging_future_to_trial = {}
+            self._trial_queues = {}
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Run helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_active_run():
+    try:
+        return swanlab.get_run()
+    except RuntimeError:
+        return None
+
+
+__all__ = ["SwanLabLoggerCallback"]

--- a/swanlab/integration/sb3.py
+++ b/swanlab/integration/sb3.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import swanlab
+import swanlab.vendor
+from swanlab import Callback
+
+_Sb3BaseCallback = swanlab.vendor.stable_baselines3.common.callbacks.BaseCallback  # type: ignore
+_Sb3KVWriter = swanlab.vendor.stable_baselines3.common.logger.KVWriter  # type: ignore
+_Sb3Logger = swanlab.vendor.stable_baselines3.common.logger.Logger  # type: ignore
+
+
+class _SwanLabOutputFormat(_Sb3KVWriter):
+    """Intercept SB3 logger writes and forward scalar metrics to swanlab."""
+
+    def write(
+        self,
+        key_values: Dict[str, Any],
+        key_excluded: Dict[str, Any],
+        step: int = 0,
+    ) -> None:
+        logs: Dict[str, Any] = {}
+        for key, value in key_values.items():
+            if isinstance(value, (int, float)):
+                logs[key] = value
+        if logs:
+            swanlab.log(logs, step=step)
+
+
+class SwanLabCallback(Callback, _Sb3BaseCallback):
+    """
+    Stable Baselines3 callback implementing both ``swanlab.Callback``
+    and SB3's ``BaseCallback``.
+
+    Usage (recommended):
+
+        import swanlab
+        from swanlab.integration.sb3 import SwanLabCallback
+
+        cb = SwanLabCallback()
+        swanlab.init(project="my-project", callbacks=[cb])
+        model = PPO("MlpPolicy", env, verbose=1)
+        model.learn(total_timesteps=25000, callback=cb)
+        swanlab.finish()
+    """
+
+    def __init__(
+        self,
+        *,
+        project: Optional[str] = None,
+        workspace: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        description: Optional[str] = None,
+        log_dir: Optional[str] = None,
+        logdir: Optional[str] = None,
+        mode: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        verbose: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
+
+        Callback.__init__(self)
+        _Sb3BaseCallback.__init__(self, verbose=verbose)
+
+        tags = list(tags) if tags else []
+        if "stable_baselines3" not in tags:
+            tags.append("stable_baselines3")
+
+        self._init_kwargs: Dict[str, Any] = {}
+        for key, value in [
+            ("project", project),
+            ("workspace", workspace),
+            ("experiment_name", experiment_name),
+            ("description", description),
+            ("log_dir", log_dir),
+            ("mode", mode),
+            ("tags", tags),
+        ]:
+            if value is not None:
+                self._init_kwargs[key] = value
+        self._init_kwargs.update(kwargs)
+        self._init_kwargs.pop("callbacks", None)
+
+        self._initialized = False
+        self._pending_config: Dict[str, Any] = {}
+
+    @property
+    def name(self) -> str:
+        return "swanlab-integration-sb3"
+
+    # --- swanlab.Callback hooks ---
+
+    def on_run_initialized(self, run_dir: str, path: str, **kwargs: Any) -> None:
+        self._initialized = True
+        run = self._get_active_run()
+        if run is not None:
+            run.config["FRAMEWORK"] = "stable_baselines3"
+            self._flush_pending_config()
+
+    def on_run_finished(self, state: str, error: Optional[str] = None, **kwargs: Any) -> None:
+        self._initialized = False
+        self._pending_config.clear()
+
+    # --- SB3 callback hooks ---
+
+    def _on_training_start(self) -> None:
+        self._ensure_init()
+        self._collect_config()
+
+        # Install SwanLab output format into SB3 logger.
+        # Preserve existing output formats so console printing is not lost.
+        existing_logger = getattr(self.model, "logger", None)
+        output_formats: List[Any] = [_SwanLabOutputFormat()]
+        if existing_logger is not None and hasattr(existing_logger, "output_formats"):
+            output_formats.extend(existing_logger.output_formats)
+
+        new_logger = _Sb3Logger(folder=None, output_formats=output_formats)
+        self.model.set_logger(new_logger)
+
+    def _on_step(self) -> bool:
+        return True
+
+    # --- helpers ---
+
+    def _ensure_init(self) -> None:
+        if self._initialized:
+            return
+        run = self._get_active_run()
+        if run is not None:
+            self._initialized = True
+            run.config["FRAMEWORK"] = "stable_baselines3"
+            self._flush_pending_config()
+            return
+        init_kwargs = dict(self._init_kwargs)
+        if self._pending_config:
+            init_kwargs["config"] = dict(self._pending_config)
+        swanlab.init(callbacks=[self], **init_kwargs)
+        self._pending_config.clear()
+
+    def update_config(self, config: Dict[str, Any]) -> None:
+        """Update swanlab config (backward-compatible helper)."""
+        run = self._get_active_run()
+        if run is None:
+            self._pending_config.update(config)
+            return
+        run.config.update(config)
+
+    def _collect_config(self) -> None:
+        """Collect model and training hyperparameters into config."""
+        run = self._get_active_run()
+        if run is None:
+            return
+
+        config: Dict[str, Any] = {}
+        if hasattr(self, "model") and self.model is not None:
+            model = self.model
+            config["algo"] = type(model).__name__
+            for key, value in model.__dict__.items():
+                if isinstance(value, (float, int, str, bool)):
+                    config[key] = value
+                elif hasattr(value, "__name__"):
+                    config[key] = value.__name__
+
+            policy = getattr(model, "policy", None)
+            if policy is not None and hasattr(policy, "net_arch"):
+                config["net_arch"] = str(policy.net_arch)
+
+        run.config.update(config)
+
+    def _flush_pending_config(self) -> None:
+        if not self._pending_config:
+            return
+        run = self._get_active_run()
+        if run is None:
+            return
+        run.config.update(self._pending_config)
+        self._pending_config.clear()
+
+    @staticmethod
+    def _get_active_run():
+        try:
+            return swanlab.get_run()
+        except RuntimeError:
+            return None
+
+
+__all__ = ["SwanLabCallback"]

--- a/swanlab/integration/sb3.py
+++ b/swanlab/integration/sb3.py
@@ -164,6 +164,8 @@ class SwanLabCallback(Callback, _Sb3BaseCallback):
             model = self.model
             config["algo"] = type(model).__name__
             for key, value in model.__dict__.items():
+                if key.startswith("_"):
+                    continue
                 if isinstance(value, (float, int, str, bool)):
                     config[key] = value
                 elif hasattr(value, "__name__"):

--- a/swanlab/integration/torchtune.py
+++ b/swanlab/integration/torchtune.py
@@ -1,0 +1,171 @@
+"""
+Docs: https://docs.swanlab.cn/guide_cloud/integration/integration-pytorch-torchtune.html
+
+Usage:
+------
+# In torchtune config:
+metric_logger:
+    _component_: swanlab.integration.torchtune.SwanLabLogger
+    project: "gemma-lora-finetune"
+    experiment_name: "gemma-2b"
+    log_dir: ${output_dir}
+
+# Or programmatically:
+from swanlab.integration.torchtune import SwanLabLogger
+
+logger = SwanLabLogger(project="my-project")
+# logger.log("loss", 0.5, step=100)
+# logger.close()
+------
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+import swanlab
+import swanlab.vendor
+
+_MetricLoggerInterface = swanlab.vendor.torchtune.utils.metric_logging.MetricLoggerInterface
+_get_world_size_and_rank = swanlab.vendor.torchtune.utils._distributed.get_world_size_and_rank
+
+Scalar = Union[Any, int, float]
+
+
+class SwanLabLogger(_MetricLoggerInterface):
+    """
+    TorchTune metric logger implementing ``torchtune.utils.metric_logging.MetricLoggerInterface``.
+
+    This logger internally calls ``swanlab.init()`` on construction (rank 0 only)
+    and ``swanlab.finish()`` on ``close()`` / ``__del__`` for backward compatibility
+    with torchtune's lifecycle.
+
+    Example:
+        In torchtune config:
+        >>> metric_logger:
+        >>>     _component_: swanlab.integration.torchtune.SwanLabLogger
+        >>>     project: "gemma-lora-finetune"
+        >>>     experiment_name: "gemma-2b"
+        >>>     log_dir: ${output_dir}
+    """
+
+    def __init__(
+        self,
+        project: str = "torchtune",
+        workspace: Optional[str] = None,
+        experiment_name: Optional[str] = None,
+        description: Optional[str] = None,
+        mode: Optional[str] = None,
+        log_dir: Optional[str] = None,
+        logdir: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        if logdir is not None:
+            import warnings
+
+            warnings.warn(
+                "The `logdir` parameter is deprecated, use `log_dir` instead.", DeprecationWarning, stacklevel=2
+            )
+            log_dir = logdir
+
+        # Use dir if specified, otherwise use log_dir.
+        self.log_dir = kwargs.pop("dir", log_dir)
+
+        tags = list(tags) if tags else []
+        if "torchtune" not in tags:
+            tags.append("torchtune")
+
+        _, self.rank = _get_world_size_and_rank()
+
+        if self.rank == 0:
+            init_kwargs: Dict[str, Any] = {
+                "project": project,
+                "workspace": workspace,
+                "name": experiment_name,
+                "description": description,
+                "mode": mode,
+                "logdir": self.log_dir,
+                "tags": tags,
+            }
+            init_kwargs.update(kwargs)
+            # Remove None values so swanlab.init uses defaults
+            init_kwargs = {k: v for k, v in init_kwargs.items() if v is not None}
+            swanlab.init(**init_kwargs)
+            swanlab.config["FRAMEWORK"] = "torchtune"
+
+        self.config_allow_val_change = kwargs.get("allow_val_change", False)
+
+    def update_config(self, config: Dict[str, Any]) -> None:
+        if self.rank == 0:
+            swanlab.config.update(config)
+
+    def log_config(self, config: Any) -> None:
+        if self.rank != 0:
+            return
+        run = _get_active_run()
+        if run is None:
+            return
+        resolved = _resolve_config(config)
+        if resolved is not None:
+            run.config.update(resolved, allow_val_change=self.config_allow_val_change)
+
+    def log(self, name: str, data: Scalar, step: int) -> None:
+        if self.rank == 0:
+            swanlab.log({name: data}, step=step)
+
+    def log_dict(self, payload: Mapping[str, Scalar], step: int) -> None:
+        if self.rank == 0:
+            swanlab.log(dict(payload), step=step)
+
+    def close(self) -> None:
+        if self.rank == 0:
+            run = _get_active_run()
+            if run is not None:
+                swanlab.finish()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+# --- helpers ---
+
+
+def _get_active_run():
+    try:
+        return swanlab.get_run()
+    except RuntimeError:
+        return None
+
+
+def _resolve_config(config: Any) -> Optional[Dict[str, Any]]:
+    """Resolve OmegaConf DictConfig or plain dict to a plain dict."""
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return dict(config)
+    # Handle OmegaConf DictConfig
+    to_container = getattr(config, "to_container", None)
+    if callable(to_container):
+        try:
+            resolved = to_container(config, resolve=True)
+            if isinstance(resolved, dict):
+                return dict(resolved)
+        except Exception:
+            pass
+    # Fallback: try omegaconf.OmegaConf.to_container
+    try:
+        import omegaconf
+
+        resolved = omegaconf.OmegaConf.to_container(config, resolve=True)
+        if isinstance(resolved, dict):
+            return {str(k): v for k, v in resolved.items()}
+    except Exception:
+        pass
+    return None
+
+
+__all__ = ["SwanLabLogger"]

--- a/swanlab/integration/torchtune.py
+++ b/swanlab/integration/torchtune.py
@@ -124,12 +124,6 @@ class SwanLabLogger(_MetricLoggerInterface):
             if run is not None:
                 swanlab.finish()
 
-    def __del__(self) -> None:
-        try:
-            self.close()
-        except Exception:
-            pass
-
 
 # --- helpers ---
 

--- a/swanlab/vendor/__init__.py
+++ b/swanlab/vendor/__init__.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:
     import stable_baselines3.common
     import swanboard
     import torch
+    import torchtune
+    import torchtune.utils.metric_logging
     import torchvision
     import transformers
     import ultralytics
@@ -83,6 +85,7 @@ __all__ = [
     "ultralytics",
     "xgboost",
     "stable_baselines3",
+    "torchtune",
 ]
 
 # 3. Lazy import mapping: Actual module paths
@@ -112,6 +115,7 @@ _LAZY_IMPORTS = {
     "transformers": "transformers",
     "ultralytics": "ultralytics",
     "stable_baselines3": "stable_baselines3",
+    "torchtune": "torchtune",
     "xgboost": "xgboost",
 }
 
@@ -149,6 +153,7 @@ _SUBMODULE_IMPORTS = {
     "xgboost": ["xgboost.callback"],
     "paddlenlp": ["paddlenlp.trainer.trainer"],
     "stable_baselines3": ["stable_baselines3.common"],
+    "torchtune": ["torchtune.utils.metric_logging"],
 }
 
 

--- a/swanlab/vendor/__init__.py
+++ b/swanlab/vendor/__init__.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     import accelerate
     import accelerate.tracking
     import boto3
+    import fastai
+    import fastai.learner
+    import fastcore
+    import fastcore.basics
     import imageio
     import keras
     import lightning
@@ -69,6 +73,8 @@ __all__ = [
     "pd",
     # framework integrations
     "accelerate",
+    "fastai",
+    "fastcore",
     "keras",
     "lightning",
     "mmengine",
@@ -97,6 +103,8 @@ _LAZY_IMPORTS = {
     "pd": "pandas",
     # framework integrations — users install these themselves
     "accelerate": "accelerate",
+    "fastai": "fastai",
+    "fastcore": "fastcore",
     "keras": "keras",
     "lightning": "lightning",
     "mmengine": "mmengine",
@@ -132,6 +140,8 @@ _SUBMODULE_IMPORTS = {
     "sklearn": ["sklearn.metrics"],
     "rdkit": ["rdkit.Chem", "rdkit.Chem.AllChem"],
     "accelerate": ["accelerate.tracking"],
+    "fastai": ["fastai.learner", "fastai.callback.hook"],
+    "fastcore": ["fastcore.basics"],
     "keras": ["keras.callbacks"],
     "lightning": ["lightning.pytorch", "lightning.pytorch.loggers", "lightning.pytorch.utilities"],
     "mmengine": ["mmengine.config", "mmengine.registry", "mmengine.visualization.vis_backend"],

--- a/swanlab/vendor/__init__.py
+++ b/swanlab/vendor/__init__.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
     import sklearn
     import sklearn.metrics
     import soundfile
+    import stable_baselines3
+    import stable_baselines3.common
     import swanboard
     import torch
     import torchvision
@@ -74,6 +76,7 @@ __all__ = [
     "transformers",
     "ultralytics",
     "xgboost",
+    "stable_baselines3",
 ]
 
 # 3. Lazy import mapping: Actual module paths
@@ -100,6 +103,7 @@ _LAZY_IMPORTS = {
     "paddlenlp": "paddlenlp",
     "transformers": "transformers",
     "ultralytics": "ultralytics",
+    "stable_baselines3": "stable_baselines3",
     "xgboost": "xgboost",
 }
 
@@ -134,6 +138,7 @@ _SUBMODULE_IMPORTS = {
     "transformers": ["transformers.trainer_callback"],
     "xgboost": ["xgboost.callback"],
     "paddlenlp": ["paddlenlp.trainer.trainer"],
+    "stable_baselines3": ["stable_baselines3.common"],
 }
 
 


### PR DESCRIPTION
## Summary

Add four new framework integrations and refactor the existing PyTorch Lightning integration.

### New Integrations
- **Ray (Tune/Train)** — `swanlab/integration/ray.py` (371 lines): Full Ray Tune/Train callback with multi-trial support, metric logging, and config tracking.
- **Torchtune** — `swanlab/integration/torchtune.py` (171 lines): Dual-callback implementing `swanlab.Callback` + torchtune `MetricLoggerInterface`, with lazy auto-init, config logging, and OmegaConf resolution.
- **FastAI** — `swanlab/integration/fastai.py` (215 lines): SwanLab callback for FastAI `Learner`, supporting train/validation metric logging and config tracking.
- **Stable-Baselines3** — `swanlab/integration/sb3.py` (195 lines): SB3 callback logging rollout metrics (ep_rew_mean, ep_len_mean, etc.) and training progress.

### Changes
- **PyTorch Lightning refactor** — Simplified `SwanLabLogger` by removing `swanlab.Callback` inheritance and the deferred-init pattern. Now directly uses `swanlab.init()` in `experiment` property, making the lifecycle clearer.
- **Vendor lazy import** — Added lazy import hints for new frameworks in `swanlab/vendor/__init__.py`.

### Ray Vendor Exception

Ray 2.x uses lazy imports — submodules (`ray.tune`, `ray.train`, `ray.util`, `ray.air`) are not mounted onto the `ray` namespace until explicitly imported. The SwanLab Ray integration internally uses a Ray Actor (`_SwanLabLoggingActor`), which gets serialized (pickled) to worker processes. During deserialization, the worker re-imports the entire module from scratch. If `ray.tune` were accessed indirectly via `swanlab.vendor.ray`, the worker process would crash with `AttributeError: module "ray" has no attribute "tune"` because the lazy sub-module import had not been triggered in that process. **Therefore, the Ray integration must use direct top-level imports (`import ray.tune`, etc.) and cannot go through the vendor lazy-import mechanism.**

### Files Changed
| File | Change |
|---|---|
| `swanlab/integration/ray.py` | New — Ray Tune/Train integration |
| `swanlab/integration/torchtune.py` | New — Torchtune integration |
| `swanlab/integration/fastai.py` | New — FastAI integration |
| `swanlab/integration/sb3.py` | New — Stable-Baselines3 integration |
| `swanlab/integration/pytorch_lightning.py` | Refactor — remove Callback inheritance, simplify lifecycle |
| `swanlab/vendor/__init__.py` | Add lazy import hints for new frameworks |

