### PR TITLE
feat: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate tag format
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.]?[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid tag format: $TAG"
+            exit 1
+          fi
+          echo "Tag format valid: $TAG"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv and set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Build
+        run: make build VERSION=${GITHUB_REF#refs/tags/v}
+
+      - name: Publish
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: make publish
+
+      - run: cp dist/*.whl .
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            *.whl

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,20 @@ bench:
 	uv run pytest tests/benchmark
 
 build:
+	@if [ -n "$(VERSION)" ]; then \
+		python -c "import json; data=json.load(open('swanlab/package.json')); data['version']='$(VERSION)'; json.dump(data,open('swanlab/package.json','w'),indent=2)" && \
+		echo "Updated swanlab/package.json version to $(VERSION)"; \
+	else \
+		echo "VERSION not set, using default version in swanlab/package.json"; \
+	fi
 	uv build
+
+publish:
+	@if [ -z "$$PYPI_TOKEN" ]; then \
+		echo "PYPI_TOKEN not set"; \
+		exit 1; \
+	fi
+	UV_PUBLISH_TOKEN="$$PYPI_TOKEN" uv publish
 
 clean:
 	@bash scripts/clean_pycache.sh .


### PR DESCRIPTION
增加 PyPI 自动发包 GitHub Action，包含：

- 基于 uv 的 build & publish 流程
- tag 格式校验（支持正式版和 rc/beta 预发布版本）
- 自动将 tag 版本号写入 swanlab/package.json
- 发包后自动创建 GitHub Release 并上传 whl 文件
- Makefile 封装 build/publish 命令