### PR TITLE
Fix/save batch split

### DIFF
--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -271,15 +271,17 @@ class HttpRecordSender:
             console.warning("No valid files to save.")
             return
 
-        # 2. 校验批次限制：数量超限时直接拒绝整个批次
-        # FIXME: pending过长时根据save_batch分片，而非直接拒绝
-        if len(pending) > config.save_batch:
-            console.warning(
-                f"Save batch size ({len(pending)}) exceeds limit ({config.save_batch}), skipping entire batch"
-            )
+        if config.save_batch <= 0:
+            console.warning(f"Invalid save batch size ({config.save_batch}), skipping save upload")
             return
 
-        # 3. 异步计算 MD5 + 按大小分流上传
+        # 2. 按 save_batch 拆分文件列表，避免单次 prepare/complete 超过后端限制
+        for index in range(0, len(pending), config.save_batch):
+            self._upload_save_batch(pending[index : index + config.save_batch])
+
+    def _upload_save_batch(self, pending: Sequence[tuple[str, int, str]]) -> None:
+        """上传一个 save_batch 内的文件列表。"""
+        config = self._ctx.config
         with safe.block(message="Failed to upload save files, skipping"):
             file_entries: list[SaveFileEntry] = []
             with SafeThreadPoolExecutor(max_workers=4) as executor:

--- a/tests/unit/sdk/internal/core_python/transport/test_sender.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_sender.py
@@ -7,7 +7,7 @@ from swanlab.sdk.internal.core_python.context import CoreConfig, CoreContext
 from swanlab.sdk.internal.core_python.transport.sender import HttpRecordSender
 
 
-def _make_sender(tmp_path: Path) -> HttpRecordSender:
+def _make_sender(tmp_path: Path, save_batch: int = 100) -> HttpRecordSender:
     ctx = CoreContext(
         config=CoreConfig(
             run_id="test-run-id",
@@ -18,7 +18,7 @@ def _make_sender(tmp_path: Path) -> HttpRecordSender:
             save_split=100 * 1024 * 1024,
             save_size=50 * 1024 * 1024 * 1024,
             save_part=32 * 1024 * 1024,
-            save_batch=100,
+            save_batch=save_batch,
         )
     )
     return HttpRecordSender(
@@ -88,3 +88,40 @@ def test_upload_save_skips_complete_when_s3_upload_fails(tmp_path: Path):
 
     # 上传失败时仍应调用 complete，但标记为 FAILED
     mock_complete.assert_called_once_with("experiment-id", files=[{"path": "failed.bin", "state": "FAILED"}])
+
+
+def test_upload_save_splits_pending_files_by_save_batch(tmp_path: Path):
+    records = []
+    for index in range(5):
+        source = tmp_path / f"model-{index}.txt"
+        source.write_text(f"weights-{index}", encoding="utf-8")
+        records.append(_make_save_record(source, name=f"checkpoints/model-{index}.txt"))
+
+    sender = _make_sender(tmp_path, save_batch=2)
+    session = MagicMock()
+
+    def _fake_prepare(_, *, files):
+        return {"urls": [f"https://s3.test/{item['path']}" for item in files]}
+
+    def _fake_upload(_, *, resources):
+        return {r["source_path"] for r in resources}
+
+    with (
+        patch(
+            "swanlab.sdk.internal.core_python.transport.sender.prepare_save_files",
+            side_effect=_fake_prepare,
+        ) as mock_prepare,
+        patch("swanlab.sdk.internal.core_python.transport.sender.complete_save_files") as mock_complete,
+        patch("swanlab.sdk.internal.core_python.transport.sender.client.session.create", return_value=session),
+        patch(
+            "swanlab.sdk.internal.core_python.transport.sender.upload_saves",
+            side_effect=_fake_upload,
+        ) as mock_upload_saves,
+    ):
+        sender.upload_save(records)
+
+    assert mock_prepare.call_count == 3
+    assert mock_upload_saves.call_count == 3
+    assert mock_complete.call_count == 3
+    assert [len(call.kwargs["files"]) for call in mock_prepare.call_args_list] == [2, 2, 1]
+    assert [len(call.kwargs["files"]) for call in mock_complete.call_args_list] == [2, 2, 1]


### PR DESCRIPTION
## 说明

修复 `save` 文件上传批次超过 `save_batch` 时整批被跳过的问题。

此前 `upload_save()` 在合法待上传文件数量超过 `config.save_batch` 时，会直接拒绝整个批次，导致这些 save
records 被 transport 视为已处理，但实际文件没有上传到云端，也不会再自动重试。

本次调整为：

- 收集合法 `pending` 文件后，按 `config.save_batch` 对文件列表切分
- 每个子批次单独执行 MD5 计算、小文件/大文件分流和上传流程
- 保持原有单文件大小校验、小文件上传、大文件分片上传逻辑不变
- 增加对应的单元测试