### PR TITLE
Fix/validate run save params

### DIFF
--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -647,7 +647,7 @@ class Run:
     @with_api("run.save()")
     def save(
         self,
-        glob_str: Union[str, bytes],
+        glob_str: Union[str, bytes, Path],
         base_path: Optional[Union[str, Path]] = None,
         policy: Literal["now", "end", "live"] = "live",
     ) -> List[str]:

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -45,7 +45,7 @@ from swanlab.sdk.internal.run.transforms import (
     Video,
     normalize_media_input,
 )
-from swanlab.sdk.typings.run import AsyncLogType, FinishType, ModeType
+from swanlab.sdk.typings.run import AsyncLogType, FinishType, ModeType, SaveType
 from swanlab.sdk.typings.run.column import ScalarXAxisType
 from swanlab.sdk.typings.run.transforms import CaptionsType
 from swanlab.sdk.typings.run.transforms.audio import AudioDatasType, AudioRatesType
@@ -663,6 +663,10 @@ class Run:
 
         :return: List of matched file paths (relative to base_path).
         """
+        if not (this_policy := fmt.safe_validate_save_policy(policy)):
+            console.error(f"Invalid save policy: {policy}, allowed values are {get_args(SaveType)}")
+            return []
+
         resolved_paths = fmt.resolve_save_paths(glob_str, base_path)
         if resolved_paths is None:
             return []
@@ -702,7 +706,7 @@ class Run:
             event = FileSaveEvent(
                 source_path=str(source_path),
                 name=str(rel_path),
-                policy=policy,
+                policy=this_policy,
             )
             self._components.emitter.emit(event)
             results.append(str(rel_path))

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -240,7 +240,7 @@ def _infer_save_base_path(glob_path: Path) -> Path:
 
 
 def resolve_save_paths(
-    glob_str: Union[str, bytes],
+    glob_str: Union[str, bytes, Path],
     base_path: Optional[Union[str, Path]] = None,
 ) -> Optional[Tuple[Path, Path]]:
     """Validate and resolve glob and base paths for swanlab.save().
@@ -261,9 +261,12 @@ def resolve_save_paths(
         except UnicodeDecodeError:
             console.error("Glob pattern bytes must be valid UTF-8. SwanLab will ignore this save.")
             return None
+    elif isinstance(glob_str, Path):
+        glob_str = str(glob_str)
     elif not isinstance(glob_str, str):
         console.error(
-            f"Glob pattern must be a string or bytes, but got {type(glob_str).__name__}. SwanLab will ignore this save."
+            f"Glob pattern must be a string, bytes, or Path, but got {type(glob_str).__name__}. "
+            "SwanLab will ignore this save."
         )
         return None
 

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -207,6 +207,8 @@ def safe_validate_save_policy(policy: Any) -> Optional[SaveType]:
     :param policy: 待检查的文件保存策略
     :return: 合法的文件保存策略或 None
     """
+    if isinstance(policy, str):
+        policy = policy.lower()
     if policy not in get_args(SaveType):
         return None
     return cast(SaveType, policy)

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -244,17 +244,13 @@ def resolve_save_paths(
     glob_str: Union[str, bytes, Path],
     base_path: Optional[Union[str, Path]] = None,
 ) -> Optional[Tuple[Path, Path]]:
-    """Validate and resolve glob and base paths for swanlab.save().
+    """验证并解析`swanlab.save()`中的glob模式与基础路径。
 
-    Resolves the glob pattern and base path against the real filesystem,
-    validates that the resolved glob does not escape the base, and returns
-    the resolved pair. Returns ``None`` if the input is invalid.
+    该函数会基于实际文件系统解析glob模式与基础路径，确保解析后的glob路径不会超出基础路径范围，并返回解析后的路径对。若输入无效则返回`None`。
 
-    :param glob_str: Glob pattern matching files to save.
-    :param base_path: Base directory for relative path resolution.
-        Defaults to cwd when the pattern is relative; for absolute patterns
-        the parent directory is used and a warning is printed.
-    :return: ``(resolved_glob, resolved_base)`` or ``None``.
+    :param glob_str: 用于匹配待保存文件的glob模式。
+    :param base_path: 相对路径解析的基准目录。当模式为相对路径时默认为当前工作目录；若为绝对路径，则使用父目录并打印警告信息。
+    :return: 返回``(解析后的glob路径, 解析后的基准路径)``或``None``。
     """
     if isinstance(glob_str, bytes):
         try:
@@ -282,7 +278,7 @@ def resolve_save_paths(
         console.warning(f"'{glob_str}' is a cloud storage URL and cannot be saved to SwanLab.")
         return None
 
-    try:
+    with safe.block(message="SwanLab failed to resolve save paths. SwanLab will ignore this save."):
         glob_path = Path(glob_str)
         resolved_glob = glob_path.resolve()
 
@@ -299,20 +295,16 @@ def resolve_save_paths(
                 "If you want to preserve a different directory structure, "
                 "explicitly pass 'base_path' to swanlab.save"
             )
-    except (TypeError, ValueError, OSError) as e:
-        console.error(f"Failed to resolve save paths: {e}. SwanLab will ignore this save.")
-        return None
-
-    try:
-        resolved_glob.relative_to(resolved_base)
-    except ValueError:
-        console.error(
-            f"Glob pattern '{glob_str}' resolves to '{resolved_glob}', "
-            f"which is outside the base path '{resolved_base}'."
-        )
-        return None
-
-    return resolved_glob, resolved_base
+        try:
+            resolved_glob.relative_to(resolved_base)
+        except ValueError:
+            console.error(
+                f"Glob pattern '{glob_str}' resolves to '{resolved_glob}', "
+                f"which is outside the base path '{resolved_base}'."
+            )
+            return None
+        return resolved_glob, resolved_base
+    return None
 
 
 def fmt_bytes(n: float) -> str:

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -207,8 +207,9 @@ def safe_validate_save_policy(policy: Any) -> Optional[SaveType]:
     :param policy: 待检查的文件保存策略
     :return: 合法的文件保存策略或 None
     """
-    if isinstance(policy, str):
-        policy = policy.lower()
+    if not isinstance(policy, str):
+        return None
+    policy = policy.lower()
     if policy not in get_args(SaveType):
         return None
     return cast(SaveType, policy)

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -6,12 +6,12 @@
 """
 
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Tuple, Union, get_args
+from typing import Any, Dict, Mapping, Optional, Tuple, Union, cast, get_args
 
 from pydantic import ValidationError
 
 from swanlab.sdk.internal.pkg import console, constraints, safe
-from swanlab.sdk.typings.run import FinishType
+from swanlab.sdk.typings.run import FinishType, SaveType
 from swanlab.sdk.typings.run.column import ScalarXAxisType
 
 
@@ -200,6 +200,18 @@ def safe_validate_state(state: FinishType) -> Optional[FinishType]:
     return state
 
 
+def safe_validate_save_policy(policy: Any) -> Optional[SaveType]:
+    """
+    检查文件保存策略，如果出现非法值，返回 None。
+
+    :param policy: 待检查的文件保存策略
+    :return: 合法的文件保存策略或 None
+    """
+    if policy not in get_args(SaveType):
+        return None
+    return cast(SaveType, policy)
+
+
 def _infer_save_base_path(glob_path: Path) -> Path:
     """从绝对 glob 路径推断默认 base_path。
 
@@ -242,28 +254,48 @@ def resolve_save_paths(
     :return: ``(resolved_glob, resolved_base)`` or ``None``.
     """
     if isinstance(glob_str, bytes):
-        glob_str = glob_str.decode("utf-8")
+        try:
+            glob_str = glob_str.decode("utf-8")
+        except UnicodeDecodeError:
+            console.error("Glob pattern bytes must be valid UTF-8. SwanLab will ignore this save.")
+            return None
+    elif not isinstance(glob_str, str):
+        console.error(
+            f"Glob pattern must be a string or bytes, but got {type(glob_str).__name__}. SwanLab will ignore this save."
+        )
+        return None
+
+    if base_path is not None and not isinstance(base_path, (str, Path)):
+        console.error(
+            f"Base path must be a string, Path, or None, but got {type(base_path).__name__}. "
+            "SwanLab will ignore this save."
+        )
+        return None
 
     if glob_str.startswith(("gs://", "s3://")):
         console.warning(f"'{glob_str}' is a cloud storage URL and cannot be saved to SwanLab.")
         return None
 
-    glob_path = Path(glob_str)
-    resolved_glob = glob_path.resolve()
+    try:
+        glob_path = Path(glob_str)
+        resolved_glob = glob_path.resolve()
 
-    if base_path is not None:
-        resolved_base = Path(base_path).resolve()
-    elif not glob_path.is_absolute():
-        resolved_base = Path(".").resolve()
-    else:
-        resolved_base = _infer_save_base_path(resolved_glob)
-        console.warning(
-            f"Saving files from absolute path '{glob_str}' without a base_path. "
-            f"SwanLab will default to base_path='{resolved_base}' "
-            "to preserve the immediate parent directory. "
-            "If you want to preserve a different directory structure, "
-            "explicitly pass 'base_path' to swanlab.save"
-        )
+        if base_path is not None:
+            resolved_base = Path(base_path).resolve()
+        elif not glob_path.is_absolute():
+            resolved_base = Path(".").resolve()
+        else:
+            resolved_base = _infer_save_base_path(resolved_glob)
+            console.warning(
+                f"Saving files from absolute path '{glob_str}' without a base_path. "
+                f"SwanLab will default to base_path='{resolved_base}' "
+                "to preserve the immediate parent directory. "
+                "If you want to preserve a different directory structure, "
+                "explicitly pass 'base_path' to swanlab.save"
+            )
+    except (TypeError, ValueError, OSError) as e:
+        console.error(f"Failed to resolve save paths: {e}. SwanLab will ignore this save.")
+        return None
 
     try:
         resolved_glob.relative_to(resolved_base)

--- a/tests/unit/sdk/internal/run/test_run_fmt.py
+++ b/tests/unit/sdk/internal/run/test_run_fmt.py
@@ -5,6 +5,8 @@
 @description: 测试run工具函数
 """
 
+from pathlib import Path
+
 import pytest
 
 import swanlab.sdk.internal.run.fmt as fmt
@@ -173,6 +175,13 @@ class TestResolveSavePaths:
         monkeypatch.chdir(tmp_path)
 
         resolved = fmt.resolve_save_paths("model.pt")
+
+        assert resolved == ((tmp_path / "model.pt").resolve(), tmp_path.resolve())
+
+    def test_resolve_path_glob_uses_cwd_as_base(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        resolved = fmt.resolve_save_paths(Path("model.pt"))
 
         assert resolved == ((tmp_path / "model.pt").resolve(), tmp_path.resolve())
 

--- a/tests/unit/sdk/internal/run/test_run_fmt.py
+++ b/tests/unit/sdk/internal/run/test_run_fmt.py
@@ -241,7 +241,9 @@ class TestResolveSavePaths:
                 raise OSError("failed to resolve")
             return original_resolve(path)
 
-        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+        monkeypatch.setattr(
+            "swanlab.sdk.internal.run.fmt.console.error", lambda *args, **kwargs: errors.append(args or kwargs)
+        )
         monkeypatch.setattr("swanlab.sdk.internal.run.fmt.Path.resolve", raise_on_model_path)
 
         assert fmt.resolve_save_paths("model.pt") is None

--- a/tests/unit/sdk/internal/run/test_run_fmt.py
+++ b/tests/unit/sdk/internal/run/test_run_fmt.py
@@ -214,7 +214,15 @@ class TestResolveSavePaths:
 
     def test_path_resolve_error_returns_none(self, monkeypatch):
         errors = []
-        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+        original_resolve = fmt.Path.resolve
 
-        assert fmt.resolve_save_paths("bad\0path") is None
+        def raise_on_model_path(path):
+            if str(path) == "model.pt":
+                raise OSError("failed to resolve")
+            return original_resolve(path)
+
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.Path.resolve", raise_on_model_path)
+
+        assert fmt.resolve_save_paths("model.pt") is None
         assert errors

--- a/tests/unit/sdk/internal/run/test_run_fmt.py
+++ b/tests/unit/sdk/internal/run/test_run_fmt.py
@@ -157,7 +157,11 @@ class TestSaveValidators:
     def test_safe_validate_save_policy_accepts_valid_policy(self, policy):
         assert fmt.safe_validate_save_policy(policy) == policy
 
-    @pytest.mark.parametrize("policy", ["invalid", "NOW", "", None, 1])
+    @pytest.mark.parametrize(("policy", "expected"), [("NOW", "now"), ("End", "end"), ("LIVE", "live")])
+    def test_safe_validate_save_policy_normalizes_case(self, policy, expected):
+        assert fmt.safe_validate_save_policy(policy) == expected
+
+    @pytest.mark.parametrize("policy", ["invalid", "", None, 1])
     def test_safe_validate_save_policy_rejects_invalid_policy(self, policy):
         assert fmt.safe_validate_save_policy(policy) is None
 

--- a/tests/unit/sdk/internal/run/test_run_fmt.py
+++ b/tests/unit/sdk/internal/run/test_run_fmt.py
@@ -145,3 +145,76 @@ class TestValidateKey:
         fmt.validate_key("  bad_key2  ")
 
         assert len(mock_warning) == 2
+
+
+# ─────────────────────────── save validators ────────────────────────────
+
+
+class TestSaveValidators:
+    """测试 save 相关校验函数"""
+
+    @pytest.mark.parametrize("policy", ["now", "end", "live"])
+    def test_safe_validate_save_policy_accepts_valid_policy(self, policy):
+        assert fmt.safe_validate_save_policy(policy) == policy
+
+    @pytest.mark.parametrize("policy", ["invalid", "NOW", "", None, 1])
+    def test_safe_validate_save_policy_rejects_invalid_policy(self, policy):
+        assert fmt.safe_validate_save_policy(policy) is None
+
+
+class TestResolveSavePaths:
+    """测试 save 路径解析与校验"""
+
+    def test_resolve_relative_glob_uses_cwd_as_base(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        resolved = fmt.resolve_save_paths("model.pt")
+
+        assert resolved == ((tmp_path / "model.pt").resolve(), tmp_path.resolve())
+
+    @pytest.mark.parametrize("glob_str", [None, 1, object()])
+    def test_invalid_glob_type_returns_none(self, glob_str, monkeypatch):
+        errors = []
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+
+        assert fmt.resolve_save_paths(glob_str) is None  # type: ignore[arg-type]
+        assert errors
+
+    def test_invalid_glob_bytes_returns_none(self, monkeypatch):
+        errors = []
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+
+        assert fmt.resolve_save_paths(b"\xff") is None
+        assert errors
+
+    @pytest.mark.parametrize("base_path", [1, object(), []])
+    def test_invalid_base_path_type_returns_none(self, base_path, monkeypatch):
+        errors = []
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+
+        assert fmt.resolve_save_paths("model.pt", base_path=base_path) is None  # type: ignore[arg-type]
+        assert errors
+
+    def test_glob_outside_base_path_returns_none(self, tmp_path, monkeypatch):
+        errors = []
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+        base_path = tmp_path / "base"
+        base_path.mkdir()
+
+        assert fmt.resolve_save_paths(str(tmp_path / "model.pt"), base_path=base_path) is None
+        assert errors
+
+    @pytest.mark.parametrize("glob_str", ["s3://bucket/model.pt", "gs://bucket/model.pt"])
+    def test_cloud_storage_url_returns_none(self, glob_str, monkeypatch):
+        warnings = []
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.warning", lambda *args: warnings.append(args))
+
+        assert fmt.resolve_save_paths(glob_str) is None
+        assert warnings
+
+    def test_path_resolve_error_returns_none(self, monkeypatch):
+        errors = []
+        monkeypatch.setattr("swanlab.sdk.internal.run.fmt.console.error", lambda *args: errors.append(args))
+
+        assert fmt.resolve_save_paths("bad\0path") is None
+        assert errors

--- a/tests/unit/sdk/internal/run/test_run_fmt.py
+++ b/tests/unit/sdk/internal/run/test_run_fmt.py
@@ -167,6 +167,13 @@ class TestSaveValidators:
     def test_safe_validate_save_policy_rejects_invalid_policy(self, policy):
         assert fmt.safe_validate_save_policy(policy) is None
 
+    def test_safe_validate_save_policy_rejects_non_string_before_comparison(self):
+        class EqualToNow:
+            def __eq__(self, other):
+                return other == "now"
+
+        assert fmt.safe_validate_save_policy(EqualToNow()) is None
+
 
 class TestResolveSavePaths:
     """测试 save 路径解析与校验"""


### PR DESCRIPTION
## 变更说明

本 PR 为 run.save() 补充参数校验，避免非法用户输入继续进入后续事件和后台处理链路。

主要改动：

- 为 policy 增加合法性校验，仅允许 "now"、"end"、"live"。
- 为 glob_str 增加类型校验，仅允许 str | bytes，并处理 bytes UTF-8 解码失败。
- 为 base_path 增加类型校验，仅允许 None | str | Path。
- 对路径解析过程中的可预期异常做兜底，校验失败时返回空列表并输出明确错误信息。