### PR TITLE
feat: support custom and truncated run directory names

### DIFF
--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -474,6 +474,7 @@ def _generate_run_dir_name(run_id: str, max_length: int) -> Tuple[str, bool]:
     prefix = f"run-{timestamp}-truncated-"
     suffix = f"-{digest}"
     run_id_max_length = max_length - len(prefix) - len(suffix)
+    # max 防止 run_id_max_length 为 0，虽然在上层settings中存在约束，这里加一层约束能更安全一些
     truncated_run_id = run_id[: max(1, run_id_max_length)]
     truncated_name = f"{prefix}{truncated_run_id}{suffix}"
     return truncated_name, True

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -13,6 +13,7 @@ import os
 import time
 from datetime import datetime
 from functools import partial
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -410,40 +411,72 @@ def send_webhook(ctx: RunContext) -> Tuple[bool, bool]:
     return True, True
 
 
-def ensure_run_dir(log_dir: Path, run_id: str, max_retries: int = 10, retry_interval: float = 1.0) -> Path:
+def ensure_run_dir(
+    log_dir: Path,
+    run_id: str,
+    max_retries: int = 10,
+    retry_interval: float = 1.0,
+    dir_max_length: int = 255,
+    dir_name: Optional[str] = None,
+) -> Path:
     """
     原子化地创建一个不与已有目录冲突的 run_dir。
 
     通过 ``mkdir(exist_ok=False)`` 将"检查不存在 + 创建目录"合并为一个原子操作：
     创建成功即拥有该目录；若抛出 FileExistsError，则等待 retry_interval 秒后，用新时间戳重试，最多重试 max_retries 次。
 
+    当 ``dir_name`` 不为 None 时，直接使用指定目录名，仅创建一次，不重试，失败直接抛错。
+
     :param log_dir: 日志根目录（必须已存在）
     :param run_id: 当前运行的唯一标识符
     :param max_retries: 最大重试次数
     :param retry_interval: 目录冲突时等待的秒数
+    :param dir_max_length: run_dir 目录名最大长度
+    :param dir_name: 用户指定的 run_dir 目录名，指定后仅创建一次不重试
     :return: 创建成功的 run_dir 路径
     :raises RuntimeError: 超过最大重试次数仍无法创建唯一目录
+    :raises FileExistsError: 指定 dir_name 时目录已存在
     """
+    if dir_name is not None:
+        run_dir = log_dir / dir_name
+        fs.safe_mkdir(run_dir, ensure_clean=True)
+        return run_dir
     for i in range(max_retries):
-        run_dir = log_dir / _generate_run_dir_name(run_id)
+        run_dir_name, truncated = _generate_run_dir_name(run_id, dir_max_length)
+        run_dir = log_dir / run_dir_name
         try:
             fs.safe_mkdir(run_dir, ensure_clean=True)
+            if truncated:
+                console.warning(f"Run directory name length exceeds limit, truncated to '{run_dir_name}'.")
             return run_dir
         except FileExistsError:
             if i == max_retries - 1:
                 break
             time.sleep(retry_interval)
+            console.debug(f"Retrying to create a unique run directory, attempt {i + 1} of {max_retries}")
     raise RuntimeError(f"Failed to create a unique run directory after {max_retries} attempts")
 
 
-def _generate_run_dir_name(run_id: str) -> str:
+def _generate_run_dir_name(run_id: str, max_length: int) -> Tuple[str, bool]:
     """
-    生成 run_dir 的目录名，格式为 ``run-{timestamp}-{run_id}``。
+    生成 run_dir 的目录名，格式为 ``run-{timestamp}-{run_id}``，超长时截断。
 
     :param run_id: 当前运行的唯一标识符
-    :return: run_dir 目录名（非完整路径）
+    :param max_length: 目录名最大长度
+    :return: run_dir 目录名（非完整路径）和是否截断
     """
-    return "run-" + datetime.now().strftime("%Y%m%d_%H%M%S") + "-" + run_id
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    name = f"run-{timestamp}-{run_id}"
+    if len(name) <= max_length:
+        return name, False
+
+    digest = sha256(run_id.encode("utf-8")).hexdigest()[:8]
+    prefix = f"run-{timestamp}-truncated-"
+    suffix = f"-{digest}"
+    run_id_max_length = max_length - len(prefix) - len(suffix)
+    truncated_run_id = run_id[:run_id_max_length]
+    truncated_name = f"{prefix}{truncated_run_id}{suffix}"
+    return truncated_name, True
 
 
 def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[RunContext, Optional[str]]:
@@ -464,9 +497,20 @@ def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[R
         # 安全创建目录，并写入 .gitignore（如果目录为空）
         helper.mkdir_and_append_gitignore(run_settings.log_dir)
         # 创建运行子目录，run_dir 必须是新建的，防止误覆盖已有实验数据
-        run_dir = ensure_run_dir(run_settings.log_dir, run_id, max_retries=run_settings.run.mkdir_retries)
+        run_dir = ensure_run_dir(
+            run_settings.log_dir,
+            run_id,
+            max_retries=run_settings.run.dir_create_retries,
+            dir_max_length=run_settings.run.dir_max_length,
+            dir_name=run_settings.run.dir,
+        )
     else:
-        run_dir = run_settings.log_dir / _generate_run_dir_name(run_id)
+        # 禁用模式下的run_dir为一个示例目录，仅用于满足上下文类型限制
+        if run_settings.run.dir:
+            run_dir = run_settings.log_dir / run_settings.run.dir
+        else:
+            run_dir_name, _ = _generate_run_dir_name(run_id, run_settings.run.dir_max_length)
+            run_dir = run_settings.log_dir / run_dir_name
     # 3. 创建一个临时的上下文，避免出现任何问题导致上下文残留
     with use_context(RunContext(config=RunConfig(settings=run_settings, run_dir=run_dir), callbacks=callbacks)) as ctx:
         assert run_settings.project.name, "Project name is required."

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -474,8 +474,7 @@ def _generate_run_dir_name(run_id: str, max_length: int) -> Tuple[str, bool]:
     prefix = f"run-{timestamp}-truncated-"
     suffix = f"-{digest}"
     run_id_max_length = max_length - len(prefix) - len(suffix)
-    # max 防止 run_id_max_length 为 0，虽然在上层settings中存在约束，这里加一层约束能更安全一些
-    truncated_run_id = run_id[: max(1, run_id_max_length)]
+    truncated_run_id = run_id[: max(0, run_id_max_length)]
     truncated_name = f"{prefix}{truncated_run_id}{suffix}"
     return truncated_name, True
 

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -474,7 +474,7 @@ def _generate_run_dir_name(run_id: str, max_length: int) -> Tuple[str, bool]:
     prefix = f"run-{timestamp}-truncated-"
     suffix = f"-{digest}"
     run_id_max_length = max_length - len(prefix) - len(suffix)
-    truncated_run_id = run_id[:run_id_max_length]
+    truncated_run_id = run_id[: max(1, run_id_max_length)]
     truncated_name = f"{prefix}{truncated_run_id}{suffix}"
     return truncated_name, True
 

--- a/swanlab/sdk/internal/pkg/constraints/__init__.py
+++ b/swanlab/sdk/internal/pkg/constraints/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "Group",
     "JobType",
     "RunId",
+    "RunDir",
     "MetricKey",
     "MetricName",
     # TypeAdapters
@@ -39,6 +40,13 @@ __all__ = [
     # value
     "METRIC_KEY_MAX_LENGTH",
 ]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+METRIC_KEY_MAX_LENGTH = 512
+
+OS_SAFE_PATTERN = r'^[^<>:"/\\|?*#%\x00-\x1f\x7f]+$'
 
 # ---------------------------------------------------------------------------
 # Annotated types — single source of truth for field constraints
@@ -85,9 +93,15 @@ JobType = Annotated[str, Field(min_length=1, max_length=512)]
 
 RunId = Annotated[
     str,
-    Field(min_length=1, max_length=512, pattern=r"^[^/\\#?%:]+$"),
+    Field(min_length=1, max_length=512, pattern=OS_SAFE_PATTERN),
 ]
-"""Run ID: 1-512 chars, must not contain ``/``, ``\\``, ``#``, ``?``, ``%``, or ``:``."""
+"""Run ID: 1-512 chars, must not contain OS-reserved characters or control characters."""
+
+RunDir = Annotated[
+    str,
+    Field(min_length=1, max_length=255, pattern=OS_SAFE_PATTERN),
+]
+"""Custom run directory name: 1-255 chars, must not contain OS-reserved characters or control characters."""
 
 
 def _no_dot_slash_edges(v: str) -> str:
@@ -95,8 +109,6 @@ def _no_dot_slash_edges(v: str) -> str:
         raise ValueError(f"Key '{v}' cannot start or end with '.' or '/'.")
     return v
 
-
-METRIC_KEY_MAX_LENGTH = 512
 
 MetricKey = Annotated[
     str,

--- a/swanlab/sdk/internal/run/components/__init__.py
+++ b/swanlab/sdk/internal/run/components/__init__.py
@@ -153,6 +153,6 @@ def _factory_terminal(ctx: RunContext, e: EmitterProtocol, init_pid: int) -> Ter
     return TerminalProxy(
         emitter=e,
         proxy_type=settings.terminal.proxy_type,
-        max_log_length=settings.terminal.max_log_length,
+        max_log_length=settings.terminal.max_length,
         init_pid=init_pid,
     )

--- a/swanlab/sdk/internal/settings/experiment.py
+++ b/swanlab/sdk/internal/settings/experiment.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 from typing import Annotated, Any, List, Literal, Optional, cast
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import NoDecode
 
 from swanlab.sdk.internal.pkg import constraints as const
@@ -221,8 +221,30 @@ class RunSettings(BaseModel):
     Config file path or dict for this SwanLab run.
     """
 
-    mkdir_retries: int = Field(default=10, ge=1)
+    dir: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        pattern=r"^[^/\\#?%:\x00-\x1f\x7f]+$",
+    )
+    """
+    Custom run directory name. When specified, dir_create_retries is ignored
+    and the directory is created exactly once; creation failure raises an error.
+    """
+
+    dir_max_length: int = Field(default=255, ge=50, le=255)
+    """
+    Maximum length for the generated run directory name.
+    """
+
+    dir_create_retries: int = Field(default=10, ge=1)
     """
     Maximum number of retries for creating a unique run directory.
     If the generated directory name conflicts with an existing one, a new name will be generated after a short delay, up to this many times.
     """
+
+    @model_validator(mode="after")
+    def validate_dir_length(self) -> "RunSettings":
+        if self.dir is not None and len(self.dir) > self.dir_max_length:
+            raise ValueError(f"run.dir length ({len(self.dir)}) exceeds run.dir_max_length ({self.dir_max_length})")
+        return self

--- a/swanlab/sdk/internal/settings/experiment.py
+++ b/swanlab/sdk/internal/settings/experiment.py
@@ -221,12 +221,7 @@ class RunSettings(BaseModel):
     Config file path or dict for this SwanLab run.
     """
 
-    dir: Optional[str] = Field(
-        default=None,
-        min_length=1,
-        max_length=255,
-        pattern=r"^[^/\\#?%:\x00-\x1f\x7f]+$",
-    )
+    dir: Optional[const.RunDir] = Field(default=None)
     """
     Custom run directory name. When specified, dir_create_retries is ignored
     and the directory is created exactly once; creation failure raises an error.

--- a/swanlab/sdk/internal/settings/terminal.py
+++ b/swanlab/sdk/internal/settings/terminal.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class TerminalSettings(BaseModel):
     proxy_type: Literal["all", "stdout", "stderr", "none"] = "all"
     """Terminal log proxy strategy."""
-    max_log_length: int = Field(default=1024, ge=500, le=4096)
+    max_length: int = Field(default=1024, ge=500, le=4096)
     """Maximum character length per line for terminal log collection."""
 
     model_config = ConfigDict(frozen=True)

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -6,6 +6,7 @@
 """
 
 import json
+from hashlib import sha256
 from unittest.mock import MagicMock
 
 import pytest
@@ -308,6 +309,26 @@ class TestEnsureRunDir:
         name2, _ = _generate_run_dir_name("a" * 511 + "2", 80)
 
         assert name1 != name2
+
+    def test_generate_run_dir_name_zero_id_space(self, monkeypatch):
+        """max_length 刚好等于 prefix + suffix 长度时，run_id 被完全截去，结果不超限"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
+        timestamp = "20260101_000000"
+        monkeypatch.setattr(
+            "swanlab.sdk.cmd.init.datetime", MagicMock(now=lambda: MagicMock(strftime=lambda _: timestamp))
+        )
+
+        run_id = "a" * 512
+        prefix = f"run-{timestamp}-truncated-"
+        digest = sha256(run_id.encode("utf-8")).hexdigest()[:8]
+        suffix = f"-{digest}"
+        max_length = len(prefix) + len(suffix)
+
+        name, truncated = _generate_run_dir_name(run_id, max_length)
+
+        assert len(name) == max_length
+        assert name == prefix + suffix
+        assert truncated is True
 
     def test_ensure_run_dir_warns_only_for_created_truncated_name(self, tmp_path, monkeypatch):
         """重试创建目录时，只对最终创建成功的截断目录告警"""

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -10,7 +10,14 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from swanlab.sdk.cmd.init import compatible_kwargs, ensure_run_dir, load_config, prompt_init_mode, set_nested_value
+from swanlab.sdk.cmd.init import (
+    _generate_run_dir_name,
+    compatible_kwargs,
+    ensure_run_dir,
+    load_config,
+    prompt_init_mode,
+    set_nested_value,
+)
 
 
 # ==========================================
@@ -215,14 +222,14 @@ class TestEnsureRunDir:
         )._generate_run_dir_name
         this_run_dir = ""
 
-        def mock_generate(run_id):
+        def mock_generate(run_id, max_length):
             nonlocal call_count, this_run_dir
             call_count += 1
             # 第一次生成一个已被占用的名字，第二次正常生成
             if call_count == 1:
-                return "run-20260101_000000-conflict"
-            this_run_dir = original_generate(run_id)
-            return this_run_dir
+                return "run-20260101_000000-conflict", False
+            this_run_dir, truncated = original_generate(run_id, max_length)
+            return this_run_dir, truncated
 
         monkeypatch.setattr("swanlab.sdk.cmd.init._generate_run_dir_name", mock_generate)
 
@@ -257,10 +264,98 @@ class TestEnsureRunDir:
 
     def test_raises_when_max_retries_exceeded(self, tmp_path, monkeypatch):
         """超过最大重试次数仍无法创建唯一目录时，应抛出 RuntimeError"""
-        monkeypatch.setattr("swanlab.sdk.cmd.init._generate_run_dir_name", lambda _: "run-20260101_000000-conflict")
+        monkeypatch.setattr(
+            "swanlab.sdk.cmd.init._generate_run_dir_name",
+            lambda _run_id, _max_length: ("run-20260101_000000-conflict", False),
+        )
 
         # 预先创建冲突目录
         (tmp_path / "run-20260101_000000-conflict").mkdir()
 
         with pytest.raises(RuntimeError, match="Failed to create a unique run directory after 2 attempts"):
             ensure_run_dir(tmp_path, "abc123", max_retries=2, retry_interval=0.01)
+
+    def test_generate_run_dir_name_keeps_short_name(self, monkeypatch):
+        """未超过长度限制时，应保持原始格式且不告警"""
+        warning = MagicMock()
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
+
+        name, truncated = _generate_run_dir_name("myrun42", 255)
+
+        assert name.startswith("run-")
+        assert name.endswith("-myrun42")
+        assert "truncated" not in name
+        assert truncated is False
+        warning.assert_not_called()
+
+    def test_generate_run_dir_name_truncates_long_name(self, monkeypatch):
+        """超过长度限制时，应截断并在目录名中体现 truncated 语义"""
+        warning = MagicMock()
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
+
+        name, truncated = _generate_run_dir_name("a" * 512, 80)
+
+        assert len(name) <= 80
+        assert "truncated" in name
+        assert truncated is True
+        warning.assert_not_called()
+
+    def test_generate_run_dir_name_uses_hash_to_reduce_conflicts(self, monkeypatch):
+        """相同长前缀但不同内容的 run_id 截断后仍应生成不同名称"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
+
+        name1, _ = _generate_run_dir_name("a" * 511 + "1", 80)
+        name2, _ = _generate_run_dir_name("a" * 511 + "2", 80)
+
+        assert name1 != name2
+
+    def test_ensure_run_dir_warns_only_for_created_truncated_name(self, tmp_path, monkeypatch):
+        """重试创建目录时，只对最终创建成功的截断目录告警"""
+        warning = MagicMock()
+        call_count = 0
+
+        def mock_generate(_run_id, _max_length):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "run-20260101_000000-conflict", True
+            return "run-20260101_000001-success", True
+
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
+        monkeypatch.setattr("swanlab.sdk.cmd.init._generate_run_dir_name", mock_generate)
+        (tmp_path / "run-20260101_000000-conflict").mkdir()
+
+        run_dir = ensure_run_dir(tmp_path, "a" * 512, max_retries=2, retry_interval=0.01, dir_max_length=80)
+
+        assert run_dir.name == "run-20260101_000001-success"
+        warning.assert_called_once()
+        assert "run-20260101_000001-success" in warning.call_args.args[0]
+
+    def test_ensure_run_dir_does_not_warn_when_truncated_name_never_created(self, tmp_path, monkeypatch):
+        """全部重试失败时，不应对未使用的截断目录告警"""
+        warning = MagicMock()
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
+        monkeypatch.setattr(
+            "swanlab.sdk.cmd.init._generate_run_dir_name",
+            lambda _run_id, _max_length: ("run-20260101_000000-conflict", True),
+        )
+        (tmp_path / "run-20260101_000000-conflict").mkdir()
+
+        with pytest.raises(RuntimeError, match="Failed to create a unique run directory after 2 attempts"):
+            ensure_run_dir(tmp_path, "a" * 512, max_retries=2, retry_interval=0.01, dir_max_length=80)
+
+        warning.assert_not_called()
+
+    def test_ensure_run_dir_with_dir_name_creates_once(self, tmp_path):
+        """指定 dir_name 时直接使用，仅创建一次"""
+        run_dir = ensure_run_dir(tmp_path, "abc123", dir_name="my-custom-dir")
+
+        assert run_dir.exists()
+        assert run_dir.name == "my-custom-dir"
+
+    def test_ensure_run_dir_with_dir_name_conflict_raises(self, tmp_path):
+        """指定 dir_name 时目录已存在，直接抛错"""
+        (tmp_path / "my-custom-dir").mkdir()
+
+        with pytest.raises(FileExistsError):
+            ensure_run_dir(tmp_path, "abc123", dir_name="my-custom-dir")

--- a/tests/unit/sdk/internal/pkg/constraints/test_pkg_constraints.py
+++ b/tests/unit/sdk/internal/pkg/constraints/test_pkg_constraints.py
@@ -1,6 +1,6 @@
 """
 @author: cunyue
-@file: test_constraints.py
+@file: test_pkg_constraints.py
 @time: 2026/3/13
 @description: 测试 swanlab.sdk.internal.pkg.constraints 字段约束模块
 """
@@ -16,6 +16,7 @@ from swanlab.sdk.internal.pkg.constraints import (
     JobType,
     MetricKey,
     ProjectName,
+    RunDir,
     RunId,
     TagString,
     Workspace,
@@ -236,6 +237,51 @@ class TestRunId:
             "run?id",  # contains ?
             "run%id",  # contains %
             "run:id",  # contains :
+            "run<id",  # contains <
+            "run>id",  # contains >
+            'run"id',  # contains "
+            "run|id",  # contains |
+            "run*id",  # contains *
+            "run\x00id",  # contains control char
+        ],
+    )
+    def test_invalid(self, value):
+        with pytest.raises(ValidationError):
+            self.adapter.validate_python(value)
+
+
+# ---------------------------------------------------------------------------
+# RunDir
+# ---------------------------------------------------------------------------
+
+
+class TestRunDir:
+    adapter = TypeAdapter(RunDir)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["my-custom-dir", "run_001", "d" * 255, "实验目录", "dir with spaces"],
+    )
+    def test_valid(self, value):
+        assert self.adapter.validate_python(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",  # empty
+            "d" * 256,  # too long
+            "bad/dir",  # contains /
+            "bad\\dir",  # contains \
+            "bad#dir",  # contains #
+            "bad?dir",  # contains ?
+            "bad%dir",  # contains %
+            "bad:dir",  # contains :
+            "bad<dir",  # contains <
+            "bad>dir",  # contains >
+            'bad"dir',  # contains "
+            "bad|dir",  # contains |
+            "bad*dir",  # contains *
+            "bad\x00dir",  # contains control char
         ],
     )
     def test_invalid(self, value):

--- a/tests/unit/sdk/internal/settings/test_settings_experiment.py
+++ b/tests/unit/sdk/internal/settings/test_settings_experiment.py
@@ -98,18 +98,9 @@ class TestMapResumeValue:
 
 
 class TestRunDir:
-    def test_dir_valid(self):
-        s = Settings.model_validate({"run": {"dir": "my-custom-dir"}})
-        assert s.run.dir == "my-custom-dir"
-
     def test_dir_default_none(self):
         s = Settings()
         assert s.run.dir is None
-
-    @pytest.mark.parametrize("value", ["bad/dir", "bad\\dir", "bad#dir", "bad?dir", "bad%dir", "bad:dir"])
-    def test_dir_rejects_invalid_chars(self, value):
-        with pytest.raises(Exception):
-            Settings.model_validate({"run": {"dir": value}})
 
     def test_dir_exceeds_dir_max_length(self):
         with pytest.raises(Exception, match="run.dir length"):

--- a/tests/unit/sdk/internal/settings/test_settings_experiment.py
+++ b/tests/unit/sdk/internal/settings/test_settings_experiment.py
@@ -95,3 +95,32 @@ class TestMapResumeValue:
             map_resume_value("invalid")
         with pytest.raises(ValueError, match="Invalid resume value"):
             map_resume_value("maybe")
+
+
+class TestRunDir:
+    def test_dir_valid(self):
+        s = Settings.model_validate({"run": {"dir": "my-custom-dir"}})
+        assert s.run.dir == "my-custom-dir"
+
+    def test_dir_default_none(self):
+        s = Settings()
+        assert s.run.dir is None
+
+    @pytest.mark.parametrize("value", ["bad/dir", "bad\\dir", "bad#dir", "bad?dir", "bad%dir", "bad:dir"])
+    def test_dir_rejects_invalid_chars(self, value):
+        with pytest.raises(Exception):
+            Settings.model_validate({"run": {"dir": value}})
+
+    def test_dir_exceeds_dir_max_length(self):
+        with pytest.raises(Exception, match="run.dir length"):
+            Settings.model_validate({"run": {"dir": "a" * 51, "dir_max_length": 50}})
+
+    def test_dir_within_dir_max_length(self):
+        s = Settings.model_validate({"run": {"dir": "a" * 50, "dir_max_length": 50}})
+        assert s.run.dir is not None
+        assert len(s.run.dir) == 50
+
+    def test_dir_env_injection(self, monkeypatch):
+        monkeypatch.setenv("SWANLAB_RUN_DIR", "from-env")
+        s = Settings()
+        assert s.run.dir == "from-env"


### PR DESCRIPTION
## Summary
本次变更为 SwanLab 运行目录命名提供自定义名称和自动截断功能，同时规范化相关 Settings 字段与约束定义。

## Changes
- **`swanlab/sdk/cmd/init.py`**: `ensure_run_dir` 新增 `dir_name` 和 `dir_max_length` 参数；`_generate_run_dir_name` 超长时使用 SHA256 截断生成唯一名称，截断成功时输出 warning
- **`swanlab/sdk/internal/pkg/constraints/__init__.py`**: 新增 `OS_SAFE_PATTERN` 常量与 `RunDir` 约束类型；`RunId` pattern 统一引用 `OS_SAFE_PATTERN`，补充对 `<>"|*` 和 `\x00-\x1f\x7f` 控制字符的校验
- **`swanlab/sdk/internal/settings/experiment.py`**: `RunSettings` 新增 `dir`（使用 `const.RunDir`）和 `dir_max_length`；`mkdir_retries` 重命名为 `dir_create_retries`；添加 `model_validator`
- **`swanlab/sdk/internal/settings/terminal.py`**: `max_log_length` 重命名为 `max_length`
- **`swanlab/sdk/internal/run/components/__init__.py`**: 同步更新字段引用
- **Tests**: 新增 `TestRunDir`（5 valid + 14 invalid），`TestRunId` 补充 6 个 invalid 用例

## Testing
- [x] `tests/unit/sdk/cmd/init/test_init_helper.py` — 全部通过
- [x] `tests/unit/sdk/internal/settings/test_settings_experiment.py` — 全部通过
- [x] `tests/unit/sdk/internal/pkg/constraints/test_pkg_constraints.py` — 全部通过
- [x] ruff check — All checks passed
- [x] pyright — 0 errors
- [x] GitHub CI: macOS/Ubuntu/Windows, Python 3.9–3.14 全部通过

## Notes
- `max_log_length` → `max_length`、`mkdir_retries` → `dir_create_retries` 是 breaking changes
- `RunId` 校验收紧为与目录名一致的 `OS_SAFE_PATTERN`，自定义 run_id 若包含 `<>"|*` 等字符将在配置加载时报验证错误