### PR TITLE
refactor: move online run params into CoreContext and defer Transport sender creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ playground/
 
 
 # IDEs & OS
+.zed/
 .idea/
 .vscode/
 .cursor/

--- a/swanlab/sdk/internal/core_python/__init__.py
+++ b/swanlab/sdk/internal/core_python/__init__.py
@@ -47,7 +47,6 @@ from swanlab.sdk.internal.core_python.metrics import RunMetrics
 from swanlab.sdk.internal.core_python.pkg import builder, counter
 from swanlab.sdk.internal.core_python.store import DataStoreWriter
 from swanlab.sdk.internal.core_python.transport import Transport
-from swanlab.sdk.internal.core_python.transport.sender import HttpRecordSender
 from swanlab.sdk.internal.core_python.watcher import FileWatcher, create_save_links
 from swanlab.sdk.internal.pkg import adapter, console, safe
 from swanlab.sdk.protocol import CoreProtocol
@@ -69,10 +68,6 @@ class CorePython(CoreProtocol):
         self._run_ctx: Optional[CoreContext] = None
         self._store: Optional[DataStoreWriter] = None
         self._transport: Optional[Transport] = None
-        self._username: Optional[str] = None
-        self._project: Optional[str] = None
-        self._project_id: Optional[str] = None
-        self._experiment_id: Optional[str] = None
         # record 构建计数器
         self._counter = counter.Counter()
         # console 行计数器
@@ -133,22 +128,8 @@ class CorePython(CoreProtocol):
         self._ctx = CoreContext.from_proto(start_request.core_settings)
         resp = self._report_run_start(start_request.start_record)
         self._start_store(resp)
-        # Transport initialization is part of startup in online mode.
-        # Fail fast on error instead of degrading silently.
-        assert self._project, "project must be set when starting in online mode"
-        assert self._username, "username must be set when starting in online mode"
-        assert self._project_id, "project id must be set when starting in online mode"
-        assert self._experiment_id, "experiment id must be set when starting in online mode"
-        assert self._metrics, "metrics must be set when starting in online mode"
-        sender = HttpRecordSender(
-            ctx=self._ctx,
-            username=self._username,
-            project=self._project,
-            project_id=self._project_id,
-            experiment_id=self._experiment_id,
-        )
-        self._transport = Transport(ctx=self._ctx, sender=sender)
-        self._heartbeat = Heartbeat(self._experiment_id)
+        self._transport = Transport(ctx=self._ctx)
+        self._heartbeat = Heartbeat(self._ctx.experiment_id)
         self._heartbeat.start()
         return resp
 
@@ -189,14 +170,16 @@ class CorePython(CoreProtocol):
         )
         assert experiment.get("name"), "create_or_resume_experiment() returned an experiment without a name."
         # 3. 记录必要字段
-        self._username = username
-        self._project = project
-        self._project_id = project_info["cuid"]
-        self._experiment_id = experiment["cuid"]
+        self._ctx.set_online_params(
+            username=username,
+            project=project,
+            project_id=project_info["cuid"],
+            experiment_id=experiment["cuid"],
+        )
         # 3. resume 时，向后端获取数据
         summary: Optional[ResumeExperimentSummaryType] = None
         if not new_experiment:
-            summary = get_experiment_summary(self._project_id, self._experiment_id)
+            summary = get_experiment_summary(self._ctx.project_id, self._ctx.experiment_id)
         self._metrics, console_epoch, global_step, global_system_step = RunMetrics.new(summary, ctx=self._ctx)
         self._epoch.reset(console_epoch)
         # 4. 构建记录
@@ -554,17 +537,11 @@ class CorePython(CoreProtocol):
 
     @safe.decorator(message="run finish error")
     def _report_run_finish(self, record: FinishRecord) -> DeliverRunFinishResponse:
-        assert (
-            self._username is not None
-            and self._project is not None
-            and self._project_id is not None
-            and self._experiment_id is not None
-        ), "Cannot finish cloud run: username, project, project_id or experiment_id is missing"
         # 向后端同步运行结束事件
         stop_experiment(
-            self._username,
-            self._project,
-            self._experiment_id,
+            self._ctx.username,
+            self._ctx.project,
+            self._ctx.experiment_id,
             state=record.state,
             finished_at=record.finished_at,
         )

--- a/swanlab/sdk/internal/core_python/context/__init__.py
+++ b/swanlab/sdk/internal/core_python/context/__init__.py
@@ -59,7 +59,6 @@ class CoreContext:
         :param project: 项目名
         :param project_id: 项目id
         :param experiment_id: 实验id
-        :return:
         """
         self._username = username
         self._project = project

--- a/swanlab/sdk/internal/core_python/context/__init__.py
+++ b/swanlab/sdk/internal/core_python/context/__init__.py
@@ -8,6 +8,7 @@
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
+from typing import Optional
 
 from swanlab.proto.swanlab.settings.core.v1.core_pb2 import CoreSettings
 
@@ -30,6 +31,11 @@ class CoreConfig:
 class CoreContext:
     def __init__(self, *, config: CoreConfig):
         self.config = config
+        # 云端信息
+        self._username: Optional[str] = None
+        self._project: Optional[str] = None
+        self._project_id: Optional[str] = None
+        self._experiment_id: Optional[str] = None
 
     @classmethod
     def from_proto(cls, proto: CoreSettings) -> "CoreContext":
@@ -45,6 +51,56 @@ class CoreContext:
             save_batch=proto.save_batch,
         )
         return cls(config=config)
+
+    def set_online_params(self, username: str, project: str, project_id: str, experiment_id: str):
+        """
+        设置云端信息
+        :param username: 用户名
+        :param project: 项目名
+        :param project_id: 项目id
+        :param experiment_id: 实验id
+        :return:
+        """
+        self._username = username
+        self._project = project
+        self._project_id = project_id
+        self._experiment_id = experiment_id
+
+    @cached_property
+    def username(self) -> str:
+        assert self._username is not None, (
+            "ctx.username is not initialized. "
+            "This usually means the current run is not in online mode, "
+            "or an internal initialization bug occurred."
+        )
+        return self._username
+
+    @cached_property
+    def project(self) -> str:
+        assert self._project is not None, (
+            "ctx.project is not initialized. "
+            "This usually means the current run is not in online mode, "
+            "or an internal initialization bug occurred."
+        )
+        return self._project
+
+    @cached_property
+    def project_id(self) -> str:
+        assert self._project_id is not None, (
+            "ctx.project_id is not initialized. "
+            "This usually means the current run is not in online mode, "
+            "or an internal initialization bug occurred."
+        )
+        return self._project_id
+
+    @cached_property
+    def experiment_id(self) -> str:
+        assert self._experiment_id is not None, (
+            "ctx.experiment_id is not initialized. "
+            "This usually means the current run is not in online mode, "
+            "or an internal initialization bug occurred."
+        )
+        return self._experiment_id
 
     @cached_property
     def media_dir(self) -> Path:

--- a/swanlab/sdk/internal/core_python/transport/__init__.py
+++ b/swanlab/sdk/internal/core_python/transport/__init__.py
@@ -5,14 +5,6 @@
 @description: 事件驱动的 Record 上传模块
 """
 
-from .buffer import RecordBuffer
-from .dispatch import Dispatch
-from .sender import HttpRecordSender
 from .thread import Transport
 
-__all__ = [
-    "Dispatch",
-    "HttpRecordSender",
-    "RecordBuffer",
-    "Transport",
-]
+__all__ = ["Transport"]

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -72,12 +72,12 @@ class HttpRecordSender:
     并将其他类型的上传交给上层处理——这部分上传将有重试机制
     """
 
-    def __init__(self, ctx: CoreContext, username: str, project: str, project_id: str, experiment_id: str) -> None:
+    def __init__(self, ctx: CoreContext) -> None:
         self._ctx = ctx
-        self._username = username
-        self._project = project
-        self._project_id = project_id
-        self._experiment_id = experiment_id
+        self._username = ctx.username
+        self._project = ctx.project
+        self._project_id = ctx.project_id
+        self._experiment_id = ctx.experiment_id
         # 资源上传 session，作用在Sender对象中复用TCP链接
         self._buffer_session: Optional[SessionWithRetry] = None
         self._upload_handlers: dict[str, Callable[[Sequence[Record]], None]] = {

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -61,13 +61,7 @@ class Transport:
             return
         self._dispatcher = Dispatch(
             batch_size=self._batch,
-            sender=HttpRecordSender(
-                ctx=self._ctx,
-                username=self._ctx.username,
-                project=self._ctx.project,
-                project_id=self._ctx.project_id,
-                experiment_id=self._ctx.experiment_id,
-            ),
+            sender=HttpRecordSender(ctx=self._ctx),
             upload_callback=self._upload_callback,
         )
         assert self._dispatcher is not None, "Dispatcher must be initialized when transport starting"

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -35,10 +35,11 @@ class Transport:
     def __init__(
         self,
         ctx: CoreContext,
-        sender: HttpRecordSender,
         upload_callback: Optional[Callable[[int], None]] = None,
         auto_start: bool = True,
     ):
+        self._ctx = ctx
+        self._batch = ctx.config.record_batch
         self._batch_interval = ctx.config.record_interval
         self._upload_callback = upload_callback
 
@@ -50,11 +51,7 @@ class Transport:
         self._throttle = UploadWarningThrottle()
 
         # Transport 持有 sender，负责创建/注入/关闭
-        self._sender = sender
-        self._dispatcher = Dispatch(
-            batch_size=ctx.config.record_batch, sender=self._sender, upload_callback=self._upload_callback
-        )
-
+        self._dispatcher: Optional[Dispatch] = None
         if auto_start:
             self.start()
 
@@ -62,6 +59,18 @@ class Transport:
         """启动守护线程。"""
         if self._started or self._finished:
             return
+        self._dispatcher = Dispatch(
+            batch_size=self._batch,
+            sender=HttpRecordSender(
+                ctx=self._ctx,
+                username=self._ctx.username,
+                project=self._ctx.project,
+                project_id=self._ctx.project_id,
+                experiment_id=self._ctx.experiment_id,
+            ),
+            upload_callback=self._upload_callback,
+        )
+        assert self._dispatcher is not None, "Dispatcher must be initialized when transport starting"
         self._thread = threading.Thread(target=self._loop, name=self.THREAD_NAME, daemon=True)
         self._thread.start()
         self._started = True
@@ -95,6 +104,7 @@ class Transport:
 
     def _loop(self) -> None:
         pending: List[Record] = []
+        assert self._dispatcher is not None, "Dispatcher must be initialized when transport starting"
 
         def refill_pending() -> bool:
             """尝试为 pending 补充数据。

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -67,6 +67,15 @@ def make_start_request(tmp_path, record: StartRecord) -> DeliverRunStartRequest:
     )
 
 
+def set_online_params(core: CorePython) -> None:
+    core._ctx.set_online_params(
+        username="test-user",
+        project="test-project",
+        project_id="test-project-id",
+        experiment_id="test-experiment-id",
+    )
+
+
 # ============================================================
 # TestCorePythonStart
 # ============================================================
@@ -94,10 +103,7 @@ class TestCorePythonStart:
 
         def _report_run_start_and_set_attrs(rec):
             """mock _report_run_start，同时设置 online 模式所需的属性。"""
-            core._username = "test-user"
-            core._project = "test-project"
-            core._project_id = "test-project-id"
-            core._experiment_id = "test-experiment-id"
+            set_online_params(core)
             core._metrics = MagicMock()
             return mock_deliver(rec)
 
@@ -140,10 +146,7 @@ class TestCorePythonFinish:
 
         def _report_run_start_and_set_attrs(rec):
             """mock _report_run_start，同时设置 online 模式所需的属性。"""
-            core._username = "test-user"
-            core._project = "test-project"
-            core._project_id = "test-project-id"
-            core._experiment_id = "test-experiment-id"
+            set_online_params(core)
             core._metrics = MagicMock()
             return mock_start(rec)
 

--- a/tests/unit/sdk/internal/core_python/transport/conftest.py
+++ b/tests/unit/sdk/internal/core_python/transport/conftest.py
@@ -28,7 +28,14 @@ def _build_mock_ctx(**core_overrides):
         save_part=32 * 1024 * 1024,
         save_batch=100,
     )
-    return CoreContext(config=config)
+    ctx = CoreContext(config=config)
+    ctx.set_online_params(
+        username="test-user",
+        project="test-project",
+        project_id="test-project-id",
+        experiment_id="test-experiment-id",
+    )
+    return ctx
 
 
 @pytest.fixture

--- a/tests/unit/sdk/internal/core_python/transport/test_sender.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_sender.py
@@ -21,13 +21,13 @@ def _make_sender(tmp_path: Path, save_batch: int = 100) -> HttpRecordSender:
             save_batch=save_batch,
         )
     )
-    return HttpRecordSender(
-        ctx=ctx,
+    ctx.set_online_params(
         username="alice",
         project="demo",
         project_id="project-id",
         experiment_id="experiment-id",
     )
+    return HttpRecordSender(ctx=ctx)
 
 
 def _make_save_record(source: Path, name: str = "checkpoints/model.txt") -> Record:

--- a/tests/unit/sdk/internal/core_python/transport/test_transport.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_transport.py
@@ -5,7 +5,6 @@ from swanlab.sdk.internal.core_python.transport.thread import Transport
 
 
 def _make_transport(ctx, **kwargs) -> Transport:
-    kwargs.setdefault("sender", MagicMock())
     kwargs.setdefault("auto_start", False)
     return Transport(ctx=ctx, **kwargs)
 
@@ -129,8 +128,8 @@ def test_transport_finish_drains_remaining(make_ctx, make_scalar_record):
 
     ctx = make_ctx(batch_interval=0.01)
     t = _make_transport(ctx)
-    t._dispatcher = FakeDispatch()  # type: ignore
     t.start()
+    t._dispatcher = FakeDispatch()  # type: ignore
     records = [make_scalar_record(step=1), make_scalar_record(step=2)]
     records[0].num = 1
     records[1].num = 2
@@ -141,8 +140,7 @@ def test_transport_finish_drains_remaining(make_ctx, make_scalar_record):
 
 def test_transport_finish_waits_for_thread(mock_ctx):
     """finish() calls join with timeout from class constant."""
-    sender = MagicMock()
-    t = _make_transport(mock_ctx, sender=sender)
+    t = _make_transport(mock_ctx)
     t._thread = MagicMock()
 
     t.finish()
@@ -166,8 +164,8 @@ def test_transport_drains_on_batch_interval(make_ctx, make_scalar_record):
 
     ctx = make_ctx(batch_interval=0.01)
     t = _make_transport(ctx)
-    t._dispatcher = FakeDispatch()  # type: ignore
     t.start()
+    t._dispatcher = FakeDispatch()  # type: ignore
     record = make_scalar_record(step=1)
     record.num = 1
     t.put([record])
@@ -220,8 +218,8 @@ def test_transport_keeps_pending_records_and_warns_after_retry_exhaustion(make_c
 
     ctx = make_ctx(batch_interval=0.01)
     t = _make_transport(ctx)
-    t._dispatcher = FlakyDispatch()  # type: ignore
     t.start()
+    t._dispatcher = FlakyDispatch()  # type: ignore
 
     first = make_scalar_record(step=1)
     second = make_scalar_record(step=2)


### PR DESCRIPTION
## Summary

将在线运行相关的 username/project/project_id/experiment_id 四个字段从 CorePython 迁移到 CoreContext，统一通过 ctx 属性读写；同时将 Transport 与 HttpRecordSender 的解耦推迟到 start() 阶段，简化 CorePython 的初始化流程。

## Changes

- **CoreContext** (context/__init__.py): 新增 set_online_params() 方法及 username/project/project_id/experiment_id 四个 cached_property，访问未初始化字段时会抛出带提示的 AssertionError。
- **CorePython** (__init__.py): 移除冗余的 _username/_project/_project_id/_experiment_id 字段，改为通过 ctx.set_online_params() 写入、ctx 属性读取；_report_run_finish 中 stop_experiment 参数修正为 ctx.project（之前错误传入了 ctx.project_id）。
- **Transport** (transport/thread.py): 构造函数移除 sender 参数，start() 内延迟创建 HttpRecordSender + Dispatch；减少 CorePython 中对 Transport 初始化的耦合。
- **transport/__init__.py**: 缩减公开导出，仅暴露 Transport。
- **单元测试**: 适配新的 CoreContext 在线参数设置方式和 Transport 构造方式。

## Testing

- `uv run pytest tests/unit` → 1322 passed, 21 skipped
- `uv run ruff check` on changed files → All checks passed
- `uv run pyright` → Passed
- 聚焦测试 `tests/unit/sdk/internal/core_python + transport` → 94 passed

## Notes

- 不影响 offline/local/disabled 这三种非在线模式。
- Transport 的 Dispatch 创建时机从 __init__ 移到 start()，测试中如需替换 dispatcher 必须在 start() 之后操作（已同步适配）。