### PR TITLE
chore: add sync edge case tests and fix column upload overlap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ exclude = [
     "**/build",
     "**/*.egg-info",
 ]
+extraPaths = ["."]
 
 [tool.ruff]
 exclude = [

--- a/swanlab/sdk/internal/core_python/store/__init__.py
+++ b/swanlab/sdk/internal/core_python/store/__init__.py
@@ -175,16 +175,19 @@ class DataStoreReader:
         return self
 
     def __next__(self) -> bytes:
-        with safe.block(message="Failed to scan record, stopping iteration"):
-            # record 需要定义在外层，保证 scan 异常被 safe.block 吞掉后，下面仍能统一按迭代结束处理。
-            record: Optional[bytes] = None
-            try:
-                record = self.scan()
-            except DataStoreError as e:
-                # 单条记录损坏通常意味着后续文件内容也不再可信；迭代器在最后一条有效记录处停止。
-                console.debug(f"Failed to scan record, stopping iteration: {e}")
-                raise StopIteration
-        # scan 返回 None 表示正常 EOF；异常路径中 record 也会保持 None，因此这里统一转换为迭代器协议。
+        try:
+            record = self.scan()
+        except DataStoreError as e:
+            # 单条记录损坏通常意味着后续文件内容也不再可信；迭代器在最后一条有效记录处停止。
+            console.debug(f"Failed to scan record, stopping iteration: {e}")
+            raise StopIteration from e
+        except Exception as e:
+            # 未预期异常仍记录 trace，但不要把 StopIteration 这种迭代控制流放进 safe.block。
+            with safe.block(message="Failed to scan record, stopping iteration"):
+                raise
+            raise StopIteration from e
+
+        # scan 返回 None 表示正常 EOF，统一转换为迭代器协议。
         if record is None:
             raise StopIteration
         return record

--- a/swanlab/sdk/internal/core_python/store/__init__.py
+++ b/swanlab/sdk/internal/core_python/store/__init__.py
@@ -18,6 +18,7 @@ from typing import IO, Any, Optional, Tuple
 from typing_extensions import Union
 
 from swanlab.exceptions import DataStoreError
+from swanlab.sdk.internal.pkg import console, safe
 
 __all__ = ["DataStoreWriter", "DataStoreReader", "DataStoreError"]
 
@@ -174,7 +175,16 @@ class DataStoreReader:
         return self
 
     def __next__(self) -> bytes:
-        record = self.scan()
+        with safe.block(message="Failed to scan record, stopping iteration"):
+            # record 需要定义在外层，保证 scan 异常被 safe.block 吞掉后，下面仍能统一按迭代结束处理。
+            record: Optional[bytes] = None
+            try:
+                record = self.scan()
+            except DataStoreError as e:
+                # 单条记录损坏通常意味着后续文件内容也不再可信；迭代器在最后一条有效记录处停止。
+                console.debug(f"Failed to scan record, stopping iteration: {e}")
+                raise StopIteration
+        # scan 返回 None 表示正常 EOF；异常路径中 record 也会保持 None，因此这里统一转换为迭代器协议。
         if record is None:
             raise StopIteration
         return record

--- a/swanlab/sdk/internal/core_python/sync.py
+++ b/swanlab/sdk/internal/core_python/sync.py
@@ -110,6 +110,8 @@ class CoreSyncPython(CoreSyncProtocol):
                 start_record.id = self._start_request.id
             # sync 实验统一开启宽松resume限制，resume设置为allow，后端自动创建新实验
             start_record.resume = ResumeMode.RESUME_MODE_ALLOW
+            # sync的实验不同步实验颜色，否则会给用户一些奇怪的感觉：https://github.com/SwanHubX/SwanLab/issues/1434
+            start_record.color = ""
             result = prepare_experiment_start(start_record)
             self._ctx.set_online_params(
                 username=result.username,
@@ -164,9 +166,12 @@ class CoreSyncPython(CoreSyncProtocol):
                         self._transport.put([record])
                     else:
                         console.debug(f"Log at epoch {record.log.epoch} was skipped syncing because it is too old.")
-                elif record.HasField("column") and self._metrics.get(record.column.column_key) is None:
+                elif record.HasField("column"):
                     # 如果 column 不存在于 _metrics 中则上传，并且定义此column
                     column = record.column
+                    if self._metrics.get(column.column_key) is not None:
+                        console.debug(f"Column '{column.column_key}' was skipped syncing because it already exists.")
+                        continue
                     if column.column_type == ColumnType.COLUMN_TYPE_SCALAR:
                         self._metrics.define_scalar(key=column.column_key, column=column)
                     else:

--- a/tests/unit/sdk/cmd/sync/test_sync_e2e.py
+++ b/tests/unit/sdk/cmd/sync/test_sync_e2e.py
@@ -2,9 +2,12 @@ from pathlib import Path
 from typing import Iterable
 
 import swanlab
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnType
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord, ScalarValue
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
+from swanlab.proto.swanlab.run.v1.run_pb2 import RunState, StartRecord
 from swanlab.sdk.cmd import sync as sync_cmd
-from swanlab.sdk.internal.core_python.store import DataStoreReader
+from swanlab.sdk.internal.core_python.store import LEVELDBLOG_HEADER_LEN, DataStoreReader, DataStoreWriter
 from swanlab.sdk.internal.core_python.sync import CoreSyncPython
 from swanlab.sdk.internal.core_python.utils import PrepareExperimentStartResult
 from swanlab.sdk.internal.settings import Settings
@@ -55,7 +58,7 @@ def column_signatures(records: Iterable[Record]) -> set[str]:
     return {record.column.column_key for record in records if record.HasField("column")}
 
 
-def make_prepare_result() -> PrepareExperimentStartResult:
+def make_prepare_result(new_experiment: bool = True) -> PrepareExperimentStartResult:
     return PrepareExperimentStartResult(
         username="alice",
         project="demo",
@@ -68,7 +71,7 @@ def make_prepare_result() -> PrepareExperimentStartResult:
             "_count": {"experiments": 0, "contributors": 0, "collaborators": 0, "clones": 0},
         },
         experiment={"cuid": "experiment-id", "slug": "sync-e2e-run", "name": "sync-e2e-run"},
-        new_experiment=True,
+        new_experiment=new_experiment,
         name="sync-e2e-run",
         color="#abcdef",
     )
@@ -81,6 +84,43 @@ def create_offline_run() -> Path:
     swanlab.log({"loss": 0.1, "acc": 0.9}, step=2)
     swanlab.finish()
     return run_dir
+
+
+def make_start_record() -> StartRecord:
+    return StartRecord(id="sync-e2e-run", workspace="alice", project="demo")
+
+
+def make_scalar_record(step: int, value: float) -> Record:
+    return Record(
+        scalar=ScalarRecord(
+            key="loss",
+            step=step,
+            type=ColumnType.COLUMN_TYPE_SCALAR,
+            value=ScalarValue(number=value),
+        )
+    )
+
+
+def write_raw_run(run_dir: Path, records: list[Record]) -> Path:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    run_file = run_dir / "run-sync-e2e-run.swanlab"
+    writer = DataStoreWriter()
+    writer.open(run_file)
+    for record in records:
+        writer.write(record.SerializeToString())
+    writer.close()
+    return run_file
+
+
+def corrupt_record_payload(run_file: Path, payloads: list[bytes], record_index: int) -> None:
+    offset = LEVELDBLOG_HEADER_LEN
+    for payload in payloads[:record_index]:
+        offset += LEVELDBLOG_HEADER_LEN + len(payload)
+    offset += LEVELDBLOG_HEADER_LEN
+
+    data = bytearray(run_file.read_bytes())
+    data[offset] ^= 0xFF
+    run_file.write_bytes(bytes(data))
 
 
 class FakeTransport:
@@ -179,3 +219,126 @@ def test_e2e_sync_uploads_records_from_generated_swanlab_file(monkeypatch):
     assert scalar_signatures(source_records) <= scalar_signatures(uploaded_records)
     assert stopped
     assert stopped[0][0:3] == ("alice", "demo", "experiment-id")
+
+
+def test_e2e_sync_skips_records_already_in_remote_summary(monkeypatch):
+    run_dir = create_offline_run()
+    transports: list[FakeTransport] = []
+
+    core = CoreSyncPython()
+    core._read_executor = ImmediateExecutor()  # type: ignore[assignment]
+
+    def make_transport(ctx) -> FakeTransport:
+        transport = FakeTransport(ctx)
+        transports.append(transport)
+        return transport
+
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: True)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: core)
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.prepare_experiment_start",
+        lambda record: make_prepare_result(new_experiment=False),
+    )
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.get_experiment_summary",
+        lambda project_id, experiment_id: {
+            "log": None,
+            "media": None,
+            "scalar": [{"key": "loss", "step": 1}, {"key": "acc", "step": 1}],
+        },
+    )
+    monkeypatch.setattr("swanlab.sdk.internal.core_python.sync.Transport", make_transport)
+    monkeypatch.setattr("swanlab.sdk.internal.core_python.sync.stop_experiment", lambda *args, **kwargs: None)
+
+    sync_cmd.sync(
+        run_dir,
+        settings=Settings(
+            api_key="test-api-key",
+            project=Settings.Project(workspace="alice", name="demo"),
+            run=Settings.Run(id="sync-e2e-run"),
+        ),
+    )
+
+    assert len(transports) == 1
+    assert scalar_signatures(transports[0].records) == {("loss", 2), ("acc", 2)}
+
+
+def test_e2e_sync_stops_uploading_after_corrupted_record(tmp_path: Path, monkeypatch):
+    records = [
+        Record(start=make_start_record()),
+        make_scalar_record(step=1, value=0.3),
+        make_scalar_record(step=2, value=0.2),
+        make_scalar_record(step=3, value=0.1),
+    ]
+    payloads = [record.SerializeToString() for record in records]
+    run_file = write_raw_run(tmp_path, records)
+    corrupt_record_payload(run_file, payloads, record_index=2)
+    transports: list[FakeTransport] = []
+
+    core = CoreSyncPython()
+    core._read_executor = ImmediateExecutor()  # type: ignore[assignment]
+
+    def make_transport(ctx) -> FakeTransport:
+        transport = FakeTransport(ctx)
+        transports.append(transport)
+        return transport
+
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: True)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: core)
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.prepare_experiment_start", lambda record: make_prepare_result()
+    )
+    monkeypatch.setattr("swanlab.sdk.internal.core_python.sync.Transport", make_transport)
+    monkeypatch.setattr("swanlab.sdk.internal.core_python.sync.stop_experiment", lambda *args, **kwargs: None)
+
+    sync_cmd.sync(
+        tmp_path,
+        settings=Settings(
+            api_key="test-api-key",
+            project=Settings.Project(workspace="alice", name="demo"),
+            run=Settings.Run(id="sync-e2e-run"),
+        ),
+    )
+
+    assert len(transports) == 1
+    assert scalar_signatures(transports[0].records) == {("loss", 1)}
+
+
+def test_e2e_sync_marks_missing_finish_record_as_crashed(tmp_path: Path, monkeypatch):
+    write_raw_run(tmp_path, [Record(start=make_start_record()), make_scalar_record(step=1, value=0.3)])
+    transports: list[FakeTransport] = []
+    stopped = []
+
+    core = CoreSyncPython()
+    core._read_executor = ImmediateExecutor()  # type: ignore[assignment]
+
+    def make_transport(ctx) -> FakeTransport:
+        transport = FakeTransport(ctx)
+        transports.append(transport)
+        return transport
+
+    def fake_stop_experiment(username, project, experiment_id, *, state, finished_at):
+        stopped.append((username, project, experiment_id, state, finished_at))
+
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: True)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: core)
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.prepare_experiment_start", lambda record: make_prepare_result()
+    )
+    monkeypatch.setattr("swanlab.sdk.internal.core_python.sync.Transport", make_transport)
+    monkeypatch.setattr("swanlab.sdk.internal.core_python.sync.stop_experiment", fake_stop_experiment)
+
+    sync_cmd.sync(
+        tmp_path,
+        settings=Settings(
+            api_key="test-api-key",
+            project=Settings.Project(workspace="alice", name="demo"),
+            run=Settings.Run(id="sync-e2e-run"),
+        ),
+    )
+
+    assert len(transports) == 1
+    assert stopped[0][0:4] == ("alice", "demo", "experiment-id", RunState.RUN_STATE_CRASHED)
+    assert "log" in record_kinds(transports[0].records)
+    error_logs = [record.log.line for record in transports[0].records if record.HasField("log")]
+    assert any("before writing a finish record" in line for line in error_logs)

--- a/tests/unit/sdk/cmd/sync/test_sync_helper.py
+++ b/tests/unit/sdk/cmd/sync/test_sync_helper.py
@@ -8,7 +8,10 @@
 import pytest
 from pydantic import ValidationError
 
-from swanlab.sdk.cmd.sync import ensure_run_dir
+from swanlab.exceptions import AuthenticationError
+from swanlab.proto.swanlab.grpc.core.v1.sync_pb2 import DeliverSyncFlushResponse, DeliverSyncStartResponse
+from swanlab.sdk.cmd.sync import ensure_run_dir, sync
+from swanlab.sdk.internal.settings import Settings
 
 
 def test_ensure_run_dir_ok(tmp_path):
@@ -28,3 +31,84 @@ def test_ensure_run_dir_requires_readable(tmp_path, monkeypatch):
 
     with pytest.raises(PermissionError):
         ensure_run_dir(tmp_path)
+
+
+def test_sync_requires_api_key_when_client_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: False)
+
+    with pytest.raises(AuthenticationError, match="Please login first"):
+        sync(tmp_path, settings=Settings())
+
+
+def test_sync_logs_in_when_api_key_provided(tmp_path, monkeypatch):
+    logged_in = False
+    login_calls = []
+
+    def client_exists():
+        return logged_in
+
+    def login_raw(api_key, *, host, print_welcome):
+        nonlocal logged_in
+        login_calls.append((api_key, host, print_welcome))
+        logged_in = True
+
+    class FakeCoreSync:
+        def confirm_sync_finish(self):
+            return type("Response", (), {"success": True, "message": "OK"})()
+
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", client_exists)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.login_raw", login_raw)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: FakeCoreSync())
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._deliver_sync_start", lambda *args, **kwargs: None)
+
+    sync(tmp_path, settings=Settings(api_key="test-api-key", api_host="https://api.example.com"))
+
+    assert login_calls == [("test-api-key", "https://api.example.com", False)]
+
+
+def test_sync_raises_when_deliver_sync_start_fails(tmp_path, monkeypatch):
+    class FakeCoreSync:
+        confirmed = False
+
+        def deliver_sync_start(self, request):
+            return DeliverSyncStartResponse(success=False, message="start failed")
+
+        def deliver_sync_flush(self):
+            raise AssertionError("flush should not be called")
+
+        def confirm_sync_finish(self):
+            self.confirmed = True
+            return type("Response", (), {"success": True, "message": "OK"})()
+
+    core = FakeCoreSync()
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: True)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: core)
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        sync(tmp_path, settings=Settings())
+
+    assert core.confirmed is False
+
+
+def test_sync_raises_when_deliver_sync_flush_fails(tmp_path, monkeypatch):
+    class FakeCoreSync:
+        confirmed = False
+
+        def deliver_sync_start(self, request):
+            return DeliverSyncStartResponse(success=True, message="success")
+
+        def deliver_sync_flush(self):
+            return DeliverSyncFlushResponse(success=False, message="flush failed")
+
+        def confirm_sync_finish(self):
+            self.confirmed = True
+            return type("Response", (), {"success": True, "message": "OK"})()
+
+    core = FakeCoreSync()
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: True)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: core)
+
+    with pytest.raises(RuntimeError, match="flush failed"):
+        sync(tmp_path, settings=Settings())
+
+    assert core.confirmed is False

--- a/tests/unit/sdk/internal/core_python/store/test_datastore.py
+++ b/tests/unit/sdk/internal/core_python/store/test_datastore.py
@@ -200,6 +200,23 @@ class TestChecksumValidation:
             r.scan()
         r.close()
 
+    def test_iteration_stops_at_corrupted_record(self, tmp_path: Path):
+        p = tmp_path / "test.swanlab"
+        first = b"first"
+        second = b"second"
+        third = b"third"
+        write_records(p, first, second, third)
+
+        second_data_offset = LEVELDBLOG_HEADER_LEN + LEVELDBLOG_HEADER_LEN + len(first) + LEVELDBLOG_HEADER_LEN
+        data = bytearray(p.read_bytes())
+        data[second_data_offset] ^= 0xFF
+        p.write_bytes(bytes(data))
+
+        r = DataStoreReader()
+        r.open(str(p))
+        assert list(r) == [first]
+        r.close()
+
 
 # ---------------------------------------------------------------------------
 # 文件管理

--- a/tests/unit/sdk/internal/core_python/test_core_sync.py
+++ b/tests/unit/sdk/internal/core_python/test_core_sync.py
@@ -8,7 +8,8 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 from swanlab.proto.swanlab.config.v1.config_pb2 import ConfigRecord, UpdateType
 from swanlab.proto.swanlab.grpc.core.v1.sync_pb2 import DeliverSyncStartRequest
-from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnType
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaRecord, ScalarRecord, ScalarValue
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.proto.swanlab.run.v1.run_pb2 import FinishRecord, ResumeMode, RunState, StartRecord
 from swanlab.proto.swanlab.settings.core.v1.core_pb2 import CoreSettings
@@ -169,6 +170,18 @@ class FakeReader:
         self.closed = True
 
 
+class FakeRawReader:
+    def __init__(self, payloads: list[bytes]):
+        self._payloads = payloads
+        self.closed = False
+
+    def __iter__(self):
+        return iter(self._payloads)
+
+    def close(self):
+        self.closed = True
+
+
 class FakeMetric:
     def __init__(self):
         self.updated = []
@@ -213,6 +226,15 @@ def test_sync_context_run_file_missing_raises(tmp_path: Path):
     ctx = CoreContext(config=make_core_config(tmp_path, run_id=""), mode="sync")
 
     with pytest.raises(FileNotFoundError, match=r"No run-\*\.swanlab"):
+        _ = ctx.run_file
+
+
+def test_sync_context_run_file_multiple_raises(tmp_path: Path):
+    (tmp_path / "run-a.swanlab").touch()
+    (tmp_path / "run-b.swanlab").touch()
+    ctx = CoreContext(config=make_core_config(tmp_path, run_id=""), mode="sync")
+
+    with pytest.raises(RuntimeError, match=r"Multiple run-\*\.swanlab"):
         _ = ctx.run_file
 
 
@@ -273,6 +295,7 @@ def test_deliver_sync_flush_prepares_experiment_with_overrides(tmp_path: Path, m
     assert prepared_record.project == "override-project"
     assert prepared_record.id == "override-run-id"
     assert prepared_record.resume == ResumeMode.RESUME_MODE_ALLOW
+    assert prepared_record.color == ""
     assert core._ctx.username == "alice"
     assert core._ctx.project == "demo"
     assert core._ctx.project_id == "project-id"
@@ -304,6 +327,42 @@ def test_deliver_sync_flush_fetches_summary_for_existing_experiment(tmp_path: Pa
     get_summary.assert_called_once_with("project-id", "experiment-id")
 
 
+def test_deliver_sync_flush_returns_failure_when_prepare_fails(tmp_path: Path, monkeypatch):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._start_record = make_start_record()
+    core._start_request = make_start_request(tmp_path)
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.prepare_experiment_start",
+        MagicMock(side_effect=RuntimeError("backend failed")),
+    )
+
+    resp = core.deliver_sync_flush()
+
+    assert resp.success is False
+    assert resp.message == "Failed to prepare sync experiment"
+
+
+def test_deliver_sync_flush_returns_failure_when_metrics_init_fails(tmp_path: Path, monkeypatch):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._start_record = make_start_record()
+    core._start_request = make_start_request(tmp_path)
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.prepare_experiment_start",
+        MagicMock(return_value=make_prepare_result(new_experiment=True)),
+    )
+    monkeypatch.setattr(
+        "swanlab.sdk.internal.core_python.sync.RunMetrics.new",
+        MagicMock(side_effect=RuntimeError("metrics failed")),
+    )
+
+    resp = core.deliver_sync_flush()
+
+    assert resp.success is False
+    assert resp.message == "Failed to initialize sync metrics"
+
+
 def test_read_uploads_newer_logs_and_captures_finish_record(tmp_path: Path):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
@@ -323,6 +382,101 @@ def test_read_uploads_newer_logs_and_captures_finish_record(tmp_path: Path):
     assert core._finish_record.state == RunState.RUN_STATE_FINISHED
     assert [record.log.line for record in transport.records] == ["new"]
     assert core._epoch == 3
+
+
+def test_read_skips_columns_already_in_metrics(tmp_path: Path):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._reader = FakeReader(  # type: ignore[assignment]
+        [Record(column=ColumnRecord(column_key="loss", column_type=ColumnType.COLUMN_TYPE_SCALAR))]
+    )
+    transport = FakeTransport(core._ctx)
+    core._transport = transport  # type: ignore[assignment]
+    metrics = FakeMetrics()
+    metrics.metrics["loss"] = FakeMetric()
+    core._metrics = metrics  # type: ignore[assignment]
+
+    asyncio.run(core.read())
+
+    assert transport.records == []
+
+
+def test_read_auto_defines_scalar_column_when_metric_is_missing(tmp_path: Path):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    scalar = ScalarRecord(
+        key="loss",
+        step=1,
+        type=ColumnType.COLUMN_TYPE_SCALAR,
+        value=ScalarValue(number=0.3),
+    )
+    core._reader = FakeReader([Record(scalar=scalar)])  # type: ignore[assignment]
+    transport = FakeTransport(core._ctx)
+    core._transport = transport  # type: ignore[assignment]
+    metrics = FakeMetrics()
+    core._metrics = metrics  # type: ignore[assignment]
+
+    asyncio.run(core.read())
+
+    assert [record_kind(record) for record in transport.records] == ["column", "scalar"]
+    assert transport.records[0].column.column_key == "loss"
+    assert transport.records[0].column.column_type == ColumnType.COLUMN_TYPE_SCALAR
+    assert metrics.get("loss") is not None
+
+
+def test_read_auto_defines_media_column_when_metric_is_missing(tmp_path: Path):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    media = MediaRecord(key="images/sample", step=1, type=ColumnType.COLUMN_TYPE_IMAGE)
+    core._reader = FakeReader([Record(media=media)])  # type: ignore[assignment]
+    transport = FakeTransport(core._ctx)
+    core._transport = transport  # type: ignore[assignment]
+    metrics = FakeMetrics()
+    core._metrics = metrics  # type: ignore[assignment]
+
+    asyncio.run(core.read())
+
+    assert [record_kind(record) for record in transport.records] == ["column", "media"]
+    assert transport.records[0].column.column_key == "images/sample"
+    assert transport.records[0].column.column_type == ColumnType.COLUMN_TYPE_IMAGE
+    assert metrics.get("images/sample") is not None
+
+
+def test_read_skips_invalid_protobuf_payload_and_continues(tmp_path: Path):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    first = Record(
+        scalar=ScalarRecord(
+            key="loss",
+            step=1,
+            type=ColumnType.COLUMN_TYPE_SCALAR,
+            value=ScalarValue(number=0.3),
+        )
+    )
+    second = Record(
+        scalar=ScalarRecord(
+            key="loss",
+            step=2,
+            type=ColumnType.COLUMN_TYPE_SCALAR,
+            value=ScalarValue(number=0.2),
+        )
+    )
+    core._reader = FakeRawReader([first.SerializeToString(), b"\x80", second.SerializeToString()])  # type: ignore[assignment]
+    transport = FakeTransport(core._ctx)
+    core._transport = transport  # type: ignore[assignment]
+    core._metrics = FakeMetrics()  # type: ignore[assignment]
+
+    asyncio.run(core.read())
+
+    assert [record_kind(record) for record in transport.records] == ["column", "scalar", "scalar"]
+    assert [(record.scalar.key, record.scalar.step) for record in transport.records if record.HasField("scalar")] == [
+        ("loss", 1),
+        ("loss", 2),
+    ]
 
 
 def test_confirm_sync_finish_marks_missing_finish_record_as_crashed(tmp_path: Path, monkeypatch):
@@ -345,3 +499,54 @@ def test_confirm_sync_finish_marks_missing_finish_record_as_crashed(tmp_path: Pa
     assert transport.finished is True
     assert [record_kind(record) for record in transport.records] == ["log"]
     assert "before writing a finish record" in transport.records[0].log.line
+
+
+def test_confirm_sync_finish_uploads_error_log_for_failed_finish_record(tmp_path: Path, monkeypatch):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    transport = FakeTransport(core._ctx)
+    core._transport = transport  # type: ignore[assignment]
+    core._read_executor = FakeExecutor()  # type: ignore[assignment]
+    core._reader = FakeReader([])  # type: ignore[assignment]
+    finished_at = make_timestamp()
+    core._finish_record = FinishRecord(
+        state=RunState.RUN_STATE_ABORTED,
+        error="user aborted run",
+        finished_at=finished_at,
+    )
+    report = MagicMock(return_value=MagicMock(success=True, message="OK"))
+    monkeypatch.setattr(core, "_report_run_finish", report)
+
+    resp = core.confirm_sync_finish()
+
+    assert resp.success is True
+    report_record = report.call_args.args[0]
+    assert report_record.state == RunState.RUN_STATE_ABORTED
+    assert transport.finished is True
+    assert [record_kind(record) for record in transport.records] == ["log"]
+    assert transport.records[0].log.level == LogLevel.LOG_LEVEL_ERROR
+    assert transport.records[0].log.line == "user aborted run"
+
+
+def test_confirm_sync_finish_uses_existing_finish_record(tmp_path: Path, monkeypatch):
+    core = CoreSyncPython()
+    core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
+    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    transport = FakeTransport(core._ctx)
+    core._transport = transport  # type: ignore[assignment]
+    core._read_executor = FakeExecutor()  # type: ignore[assignment]
+    core._reader = FakeReader([])  # type: ignore[assignment]
+    finished_at = make_timestamp()
+    core._finish_record = FinishRecord(state=RunState.RUN_STATE_FINISHED, finished_at=finished_at)
+    report = MagicMock(return_value=MagicMock(success=True, message="OK"))
+    monkeypatch.setattr(core, "_report_run_finish", report)
+
+    resp = core.confirm_sync_finish()
+
+    assert resp.success is True
+    report_record = report.call_args.args[0]
+    assert report_record.state == RunState.RUN_STATE_FINISHED
+    assert report_record.finished_at == finished_at
+    assert transport.records == []
+    assert transport.finished is True


### PR DESCRIPTION
## Summary

补充 sync 功能的边界测试覆盖，修复 column 上传路径的一个遗漏，强化损坏记录的容错处理。

## Changes

### 生产代码

- **`swanlab/sdk/internal/core_python/store/__init__.py`**  
  `DataStoreReader.__next__` 增加 `safe.block` 包装，在 `scan()` 遇到 `DataStoreError` 时优雅转为 `StopIteration` 而非直接崩溃。

- **`swanlab/sdk/internal/core_python/sync.py`**  
  1. `deliver_sync_flush` 中清空 `start_record.color`，避免 sync 实验继承离线实验颜色（fix #1434）。  
  2. column 上传路径：已存在于 metrics 中的 column 记录改为直接跳过（`continue`），不再落入通用上传分支。

### 测试

- **`tests/unit/sdk/internal/core_python/test_core_sync.py`**（+10 个测试）  
  颜色清空断言、多个 run 文件 check、flush prepare/metrics 失败返回、已存在 column 不重复上传、scalar/media 自动补 column、非法 protobuf payload 跳过继续、finish 失败态 error log 上传、已有正常 finish record 直接使用。

- **`tests/unit/sdk/cmd/sync/test_sync_helper.py`**（+4 个测试）  
  缺少 client 抛 `AuthenticationError`、API key 触发登录、`_deliver_sync_start` 失败 raise、`deliver_sync_flush` 失败 raise。

- **`tests/unit/sdk/cmd/sync/test_sync_e2e.py`**（+4 个测试）  
  resume 跳过远程已有 scalar、损坏 datastore 记录停止读取、缺失 finish record 标记 crashed。

- **`tests/unit/sdk/internal/core_python/store/test_datastore.py`**（+1 个测试）  
  迭代器在损坏记录处停止在最后一条有效记录。

## Testing

```bash
uv run pytest tests/unit/sdk/internal/core_python/test_core_sync.py \
  tests/unit/sdk/cmd/sync/test_sync_helper.py \
  tests/unit/sdk/cmd/sync/test_sync_e2e.py \
  tests/unit/sdk/internal/core_python/store/test_datastore.py -v
```

已验证 48 个测试全部通过。

## Notes

- `pyproject.toml` 新增 `extraPaths = ["."]` 用于 basedpyright。
- column 上传路径的行为变更为：已存在列不再上传（此前会无差别上传）。该修正确保与 scalar/media 的分支逻辑一致。

closes: #1268 
closes: #1279 