### PR TITLE
refactor: bump DataStore header version to 2 and improve sync error message

### DIFF
--- a/swanlab/sdk/internal/core_python/store/__init__.py
+++ b/swanlab/sdk/internal/core_python/store/__init__.py
@@ -206,7 +206,7 @@ class DataStoreReader:
         if version != LEVELDBLOG_HEADER_VERSION:
             raise DataStoreError(
                 f"Invalid run version: {version} (expected {LEVELDBLOG_HEADER_VERSION}). "
-                "This file was created by an older version of SwanLab SDK. "
+                "This file was created by an incompatible version of SwanLab SDK. "
                 "Please use a matching SDK version to sync this run. "
                 "For supported versions, see: https://docs.swanlab.cn/api/cli-swanlab-sync.html"
             )

--- a/swanlab/sdk/internal/core_python/store/__init__.py
+++ b/swanlab/sdk/internal/core_python/store/__init__.py
@@ -33,7 +33,7 @@ LEVELDBLOG_LAST = 4
 
 LEVELDBLOG_HEADER_IDENT = b":SWL"
 LEVELDBLOG_HEADER_MAGIC = 0xE1D6  # zlib.crc32(bytes("SwanLab", 'utf-8')) & 0xffff
-LEVELDBLOG_HEADER_VERSION = 1
+LEVELDBLOG_HEADER_VERSION = 2
 
 # 模块级 CRC 预计算，构造一次，读写两侧共用
 _CRC = [0] * (LEVELDBLOG_LAST + 1)
@@ -205,7 +205,10 @@ class DataStoreReader:
             raise DataStoreError("Invalid header magic")
         if version != LEVELDBLOG_HEADER_VERSION:
             raise DataStoreError(
-                f"Invalid run version: {version}. For supported versions, see: https://docs.swanlab.cn/api/cli-swanlab-sync.html"
+                f"Invalid run version: {version} (expected {LEVELDBLOG_HEADER_VERSION}). "
+                "This file was created by an older version of SwanLab SDK. "
+                "Please use a matching SDK version to sync this run. "
+                "For supported versions, see: https://docs.swanlab.cn/api/cli-swanlab-sync.html"
             )
         self._index += len(header)
 

--- a/tests/unit/sdk/cmd/sync/test_sync_e2e.py
+++ b/tests/unit/sdk/cmd/sync/test_sync_e2e.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Iterable
 
+import pytest
+
 import swanlab
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnType
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord, ScalarValue
@@ -342,3 +344,29 @@ def test_e2e_sync_marks_missing_finish_record_as_crashed(tmp_path: Path, monkeyp
     assert "log" in record_kinds(transports[0].records)
     error_logs = [record.log.line for record in transports[0].records if record.HasField("log")]
     assert any("before writing a finish record" in line for line in error_logs)
+
+
+def test_e2e_sync_fails_with_legacy_version_file(tmp_path: Path, monkeypatch):
+    """sync 遇到旧版本（v1）文件时应失败并给出版本错误提示。"""
+    import struct
+
+    from swanlab.sdk.internal.core_python.store import LEVELDBLOG_HEADER_IDENT, LEVELDBLOG_HEADER_MAGIC
+
+    run_file = tmp_path / "run-legacy-run.swanlab"
+    with open(run_file, "wb") as f:
+        f.write(struct.pack("<4sHB", LEVELDBLOG_HEADER_IDENT, LEVELDBLOG_HEADER_MAGIC, 1))
+
+    core = CoreSyncPython()
+
+    monkeypatch.setattr("swanlab.sdk.cmd.sync.client.exists", lambda: True)
+    monkeypatch.setattr("swanlab.sdk.cmd.sync._create_core_sync", lambda: core)
+
+    with pytest.raises(RuntimeError, match="version"):
+        sync_cmd.sync(
+            tmp_path,
+            settings=Settings(
+                api_key="test-api-key",
+                project=Settings.Project(workspace="alice", name="demo"),
+                run=Settings.Run(id="legacy-run"),
+            ),
+        )

--- a/tests/unit/sdk/internal/core_python/store/test_datastore.py
+++ b/tests/unit/sdk/internal/core_python/store/test_datastore.py
@@ -177,6 +177,14 @@ class TestHeaderValidation:
         with pytest.raises(DataStoreError, match="version"):
             r.open(str(p))
 
+    def test_legacy_version_rejected(self, tmp_path: Path):
+        """旧 SDK（v1）生成的文件应被拒绝，并提示版本不匹配。"""
+        p = tmp_path / "legacy.swanlab"
+        _write_raw_header(p, LEVELDBLOG_HEADER_IDENT, LEVELDBLOG_HEADER_MAGIC, 1)
+        r = DataStoreReader()
+        with pytest.raises(DataStoreError, match="version"):
+            r.open(str(p))
+
 
 # ---------------------------------------------------------------------------
 # CRC 校验


### PR DESCRIPTION
## Summary

将 DataStore 文件头版本号从 1 提升至 2，以反映底层数据格式从 utf-8 字符串到原始 protobuf bytes 的变更。同时优化了版本不匹配时的错误提示信息，使其更具可操作性。

## Changes

- **swanlab/sdk/internal/core_python/store/\_\_init\_\_.py**
  - `LEVELDBLOG_HEADER_VERSION` 从 1 改为 2
  - 优化 `_read_header()` 中的版本不匹配错误消息，加入期望版本号和明确的操作指引

- **tests/unit/sdk/internal/core_python/store/test_datastore.py**
  - 新增 `test_legacy_version_rejected`：验证 DataStoreReader 拒绝打开 v1 版本文件

- **tests/unit/sdk/cmd/sync/test_sync_e2e.py**
  - 补充缺失的 `import pytest`
  - 新增 `test_e2e_sync_fails_with_legacy_version_file`：验证端到端 sync 遇到 v1 文件时正确失败

## Testing

- 26 个相关测试全部通过（含 2 个新增用例）
- ruff lint 通过
- basedpyright 类型检查通过

## Notes

- 旧版 SDK (v1) 与新 SDK (v2) 的 on-disk 格式不兼容（v1 使用 utf-8 字符串，v2 使用 protobuf bytes），此变更是预期行为
- 用户使用新 SDK 同步 v1 文件时会看到清晰的错误提示，引导其使用匹配版本的 SDK