### PR TITLE
feat: add accelerator vendor support and process memory metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,7 @@ repos:
     rev: v0.15.13
     hooks:
       - id: ruff-check
-        args: [--fix]
+        # Avoid auto-fixing during pre-commit: when staged and unstaged changes
+        # touch the same file, pre-commit's stash/restore flow can conflict.
+        # args: [--fix]
       - id: ruff-format

--- a/core/proto/swanlab/metric/column/v1/column.pb.go
+++ b/core/proto/swanlab/metric/column/v1/column.pb.go
@@ -272,8 +272,8 @@ func (SectionType) EnumDescriptor() ([]byte, []int) {
 // YRange Y 轴显示范围
 type YRange struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Min           float64                `protobuf:"fixed64,1,opt,name=min,proto3" json:"min,omitempty"`
-	Max           float64                `protobuf:"fixed64,2,opt,name=max,proto3" json:"max,omitempty"`
+	Min           *float64               `protobuf:"fixed64,1,opt,name=min,proto3,oneof" json:"min,omitempty"`
+	Max           *float64               `protobuf:"fixed64,2,opt,name=max,proto3,oneof" json:"max,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -309,15 +309,15 @@ func (*YRange) Descriptor() ([]byte, []int) {
 }
 
 func (x *YRange) GetMin() float64 {
-	if x != nil {
-		return x.Min
+	if x != nil && x.Min != nil {
+		return *x.Min
 	}
 	return 0
 }
 
 func (x *YRange) GetMax() float64 {
-	if x != nil {
-		return x.Max
+	if x != nil && x.Max != nil {
+		return *x.Max
 	}
 	return 0
 }
@@ -535,10 +535,12 @@ var File_swanlab_metric_column_v1_column_proto protoreflect.FileDescriptor
 
 const file_swanlab_metric_column_v1_column_proto_rawDesc = "" +
 	"\n" +
-	"%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\",\n" +
-	"\x06YRange\x12\x10\n" +
-	"\x03min\x18\x01 \x01(\x01R\x03min\x12\x10\n" +
-	"\x03max\x18\x02 \x01(\x01R\x03max\"8\n" +
+	"%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\"F\n" +
+	"\x06YRange\x12\x15\n" +
+	"\x03min\x18\x01 \x01(\x01H\x00R\x03min\x88\x01\x01\x12\x15\n" +
+	"\x03max\x18\x02 \x01(\x01H\x01R\x03max\x88\x01\x01B\x06\n" +
+	"\x04_minB\x06\n" +
+	"\x04_max\"8\n" +
 	"\fMetricColors\x12\x14\n" +
 	"\x05light\x18\x01 \x01(\tR\x05light\x12\x12\n" +
 	"\x04dark\x18\x02 \x01(\tR\x04dark\"\xf9\x04\n" +
@@ -640,6 +642,7 @@ func file_swanlab_metric_column_v1_column_proto_init() {
 	if File_swanlab_metric_column_v1_column_proto != nil {
 		return
 	}
+	file_swanlab_metric_column_v1_column_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/protos/swanlab/metric/column/v1/column.proto
+++ b/protos/swanlab/metric/column/v1/column.proto
@@ -6,60 +6,60 @@ option go_package = "github.com/swanhubx/swanlab/core/proto/swanlab/metric/colum
 
 // ColumnType 列的数据类型
 enum ColumnType {
-  COLUMN_TYPE_UNSPECIFIED = 0;
-  COLUMN_TYPE_SCALAR      = 1;  // 标量
-  COLUMN_TYPE_IMAGE       = 2;  // 图像
-  COLUMN_TYPE_AUDIO       = 3;  // 音频
-  COLUMN_TYPE_TEXT        = 4;  // 文本
-  COLUMN_TYPE_VIDEO       = 5;  // 视频
-  COLUMN_TYPE_ECHARTS     = 6;  // ECharts 图表
-  COLUMN_TYPE_OBJECT3D    = 7;  // 3D 对象
-  COLUMN_TYPE_MOLECULE    = 8;  // 分子结构
+    COLUMN_TYPE_UNSPECIFIED = 0;
+    COLUMN_TYPE_SCALAR = 1;   // 标量
+    COLUMN_TYPE_IMAGE = 2;    // 图像
+    COLUMN_TYPE_AUDIO = 3;    // 音频
+    COLUMN_TYPE_TEXT = 4;     // 文本
+    COLUMN_TYPE_VIDEO = 5;    // 视频
+    COLUMN_TYPE_ECHARTS = 6;  // ECharts 图表
+    COLUMN_TYPE_OBJECT3D = 7; // 3D 对象
+    COLUMN_TYPE_MOLECULE = 8; // 分子结构
 }
 
 // ColumnClass 列的来源类别
 enum ColumnClass {
-  COLUMN_CLASS_UNSPECIFIED = 0;
-  COLUMN_CLASS_CUSTOM      = 1;  // 用户自定义列（默认）
-  COLUMN_CLASS_SYSTEM      = 2;  // 系统列
+    COLUMN_CLASS_UNSPECIFIED = 0;
+    COLUMN_CLASS_CUSTOM = 1; // 用户自定义列（默认）
+    COLUMN_CLASS_SYSTEM = 2; // 系统列
 }
 
 // ChartType 图表类型
 enum ChartType {
-  CHART_TYPE_UNSPECIFIED = 0;   // 默认情况下，后端根据 column_type 自动推导
-  CHART_TYPE_LINE        = 1;
-  CHART_TYPE_BAR         = 2;
-  CHART_TYPE_SCALAR      = 3;
-  CHART_TYPE_IMAGE       = 4;
-  CHART_TYPE_AUDIO       = 5;
-  CHART_TYPE_TEXT        = 6;
-  CHART_TYPE_VIDEO       = 7;
-  CHART_TYPE_ECHARTS     = 8;
-  CHART_TYPE_OBJECT3D    = 9;
-  CHART_TYPE_MOLECULE    = 10;
+    CHART_TYPE_UNSPECIFIED = 0; // 默认情况下，后端根据 column_type 自动推导
+    CHART_TYPE_LINE = 1;
+    CHART_TYPE_BAR = 2;
+    CHART_TYPE_SCALAR = 3;
+    CHART_TYPE_IMAGE = 4;
+    CHART_TYPE_AUDIO = 5;
+    CHART_TYPE_TEXT = 6;
+    CHART_TYPE_VIDEO = 7;
+    CHART_TYPE_ECHARTS = 8;
+    CHART_TYPE_OBJECT3D = 9;
+    CHART_TYPE_MOLECULE = 10;
 }
 
 // SectionType section 类型
 enum SectionType {
-  SECTION_TYPE_UNSPECIFIED = 0;
-  SECTION_TYPE_PINNED      = 1;  // 固定，仅允许一个同类 section
-  SECTION_TYPE_HIDDEN      = 2;  // 隐藏，仅允许一个同类 section
-  SECTION_TYPE_PUBLIC      = 3;  // 公开，允许多个（默认）
-  SECTION_TYPE_SYSTEM      = 4;  // 系统，允许多个，可自定义 section_name
+    SECTION_TYPE_UNSPECIFIED = 0;
+    SECTION_TYPE_PINNED = 1; // 固定，仅允许一个同类 section
+    SECTION_TYPE_HIDDEN = 2; // 隐藏，仅允许一个同类 section
+    SECTION_TYPE_PUBLIC = 3; // 公开，允许多个（默认）
+    SECTION_TYPE_SYSTEM = 4; // 系统，允许多个，可自定义 section_name
 }
 
 // YRange Y 轴显示范围
 message YRange {
-  double min = 1;
-  double max = 2;
+    optional double min = 1;
+    optional double max = 2;
 }
 
 // MetricColors 指标颜色
 message MetricColors {
-  // light 主题颜色
-  string light = 1;
-  // dark 主题颜色，暂时作为冗余设计存在，前端在深色模式下依旧使用 light 主题颜色
-  string dark = 2;
+    // light 主题颜色
+    string light = 1;
+    // dark 主题颜色，暂时作为冗余设计存在，前端在深色模式下依旧使用 light 主题颜色
+    string dark = 2;
 }
 
 // ColumnRecord 列定义，描述一个 metric key 的显示配置和归类规则。
@@ -73,39 +73,39 @@ message MetricColors {
 //   4. CUSTOM 列未设 section_name 时，归入 MEDIA 或 SCALAR 下；
 //      设了 section_name 则放入 PUBLIC 类型下。
 message ColumnRecord {
-  // 列类别，默认 CUSTOM
-  ColumnClass column_class = 1;
+    // 列类别，默认 CUSTOM
+    ColumnClass column_class = 1;
 
-  // 数据类型，必填
-  ColumnType column_type = 2;
+    // 数据类型，必填
+    ColumnType column_type = 2;
 
-  // 键名，必填，须与 MetricRecord.key 对应
-  string column_key = 3;
+    // 键名，必填，须与 MetricRecord.key 对应
+    string column_key = 3;
 
-  // 显示名称，可选，不填时默认取 key
-  string column_name = 4;
+    // 显示名称，可选，不填时默认取 key
+    string column_name = 4;
 
-  // 自定义 section 名称，优先级高于由 key 推断的 section
-  string section_name = 5;
+    // 自定义 section 名称，优先级高于由 key 推断的 section
+    string section_name = 5;
 
-  // Section 类型，默认 PUBLIC
-  SectionType section_type = 6;
+    // Section 类型，默认 PUBLIC
+    SectionType section_type = 6;
 
-  // Y 轴范围 [min, max]，可选，仅折线图有效
-  YRange y_range = 7;
+    // Y 轴范围 [min, max]，可选，仅折线图有效
+    YRange y_range = 7;
 
-  // 图表索引，相同 chart_index 的列归入同一图表；不填则新建图表
-  string chart_index = 8;
+    // 图表索引，相同 chart_index 的列归入同一图表；不填则新建图表
+    string chart_index = 8;
 
-  // 图表名称，仅对单实验图表生效
-  string chart_name = 9;
+    // 图表名称，仅对单实验图表生效
+    string chart_name = 9;
 
-  // 图表类型，默认根据 column_type 自动推导
-  ChartType chart_type = 10;
+    // 图表类型，默认根据 column_type 自动推导
+    ChartType chart_type = 10;
 
-  // 指标名称，仅对单实验图表生效
-  string metric_name = 11;
+    // 指标名称，仅对单实验图表生效
+    string metric_name = 11;
 
-  // 指标颜色列表，十六进制颜色值，如 "#FF5733"
-  MetricColors metric_colors = 12;
+    // 指标颜色列表，十六进制颜色值，如 "#FF5733"
+    MetricColors metric_colors = 12;
 }

--- a/swanlab/proto/swanlab/metric/column/v1/column_pb2.py
+++ b/swanlab/proto/swanlab/metric/column/v1/column_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\"\"\n\x06YRange\x12\x0b\n\x03min\x18\x01 \x01(\x01\x12\x0b\n\x03max\x18\x02 \x01(\x01\"+\n\x0cMetricColors\x12\r\n\x05light\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61rk\x18\x02 \x01(\t\"\xeb\x03\n\x0c\x43olumnRecord\x12;\n\x0c\x63olumn_class\x18\x01 \x01(\x0e\x32%.swanlab.metric.column.v1.ColumnClass\x12\x39\n\x0b\x63olumn_type\x18\x02 \x01(\x0e\x32$.swanlab.metric.column.v1.ColumnType\x12\x12\n\ncolumn_key\x18\x03 \x01(\t\x12\x13\n\x0b\x63olumn_name\x18\x04 \x01(\t\x12\x14\n\x0csection_name\x18\x05 \x01(\t\x12;\n\x0csection_type\x18\x06 \x01(\x0e\x32%.swanlab.metric.column.v1.SectionType\x12\x31\n\x07y_range\x18\x07 \x01(\x0b\x32 .swanlab.metric.column.v1.YRange\x12\x13\n\x0b\x63hart_index\x18\x08 \x01(\t\x12\x12\n\nchart_name\x18\t \x01(\t\x12\x37\n\nchart_type\x18\n \x01(\x0e\x32#.swanlab.metric.column.v1.ChartType\x12\x13\n\x0bmetric_name\x18\x0b \x01(\t\x12=\n\rmetric_colors\x18\x0c \x01(\x0b\x32&.swanlab.metric.column.v1.MetricColors*\xe9\x01\n\nColumnType\x12\x1b\n\x17\x43OLUMN_TYPE_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_SCALAR\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_IMAGE\x10\x02\x12\x15\n\x11\x43OLUMN_TYPE_AUDIO\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_TEXT\x10\x04\x12\x15\n\x11\x43OLUMN_TYPE_VIDEO\x10\x05\x12\x17\n\x13\x43OLUMN_TYPE_ECHARTS\x10\x06\x12\x18\n\x14\x43OLUMN_TYPE_OBJECT3D\x10\x07\x12\x18\n\x14\x43OLUMN_TYPE_MOLECULE\x10\x08*]\n\x0b\x43olumnClass\x12\x1c\n\x18\x43OLUMN_CLASS_UNSPECIFIED\x10\x00\x12\x17\n\x13\x43OLUMN_CLASS_CUSTOM\x10\x01\x12\x17\n\x13\x43OLUMN_CLASS_SYSTEM\x10\x02*\x88\x02\n\tChartType\x12\x1a\n\x16\x43HART_TYPE_UNSPECIFIED\x10\x00\x12\x13\n\x0f\x43HART_TYPE_LINE\x10\x01\x12\x12\n\x0e\x43HART_TYPE_BAR\x10\x02\x12\x15\n\x11\x43HART_TYPE_SCALAR\x10\x03\x12\x14\n\x10\x43HART_TYPE_IMAGE\x10\x04\x12\x14\n\x10\x43HART_TYPE_AUDIO\x10\x05\x12\x13\n\x0f\x43HART_TYPE_TEXT\x10\x06\x12\x14\n\x10\x43HART_TYPE_VIDEO\x10\x07\x12\x16\n\x12\x43HART_TYPE_ECHARTS\x10\x08\x12\x17\n\x13\x43HART_TYPE_OBJECT3D\x10\t\x12\x17\n\x13\x43HART_TYPE_MOLECULE\x10\n*\x8f\x01\n\x0bSectionType\x12\x1c\n\x18SECTION_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13SECTION_TYPE_PINNED\x10\x01\x12\x17\n\x13SECTION_TYPE_HIDDEN\x10\x02\x12\x17\n\x13SECTION_TYPE_PUBLIC\x10\x03\x12\x17\n\x13SECTION_TYPE_SYSTEM\x10\x04\x42JZHgithub.com/swanhubx/swanlab/core/proto/swanlab/metric/column/v1;columnv1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n%swanlab/metric/column/v1/column.proto\x12\x18swanlab.metric.column.v1\"<\n\x06YRange\x12\x10\n\x03min\x18\x01 \x01(\x01H\x00\x88\x01\x01\x12\x10\n\x03max\x18\x02 \x01(\x01H\x01\x88\x01\x01\x42\x06\n\x04_minB\x06\n\x04_max\"+\n\x0cMetricColors\x12\r\n\x05light\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61rk\x18\x02 \x01(\t\"\xeb\x03\n\x0c\x43olumnRecord\x12;\n\x0c\x63olumn_class\x18\x01 \x01(\x0e\x32%.swanlab.metric.column.v1.ColumnClass\x12\x39\n\x0b\x63olumn_type\x18\x02 \x01(\x0e\x32$.swanlab.metric.column.v1.ColumnType\x12\x12\n\ncolumn_key\x18\x03 \x01(\t\x12\x13\n\x0b\x63olumn_name\x18\x04 \x01(\t\x12\x14\n\x0csection_name\x18\x05 \x01(\t\x12;\n\x0csection_type\x18\x06 \x01(\x0e\x32%.swanlab.metric.column.v1.SectionType\x12\x31\n\x07y_range\x18\x07 \x01(\x0b\x32 .swanlab.metric.column.v1.YRange\x12\x13\n\x0b\x63hart_index\x18\x08 \x01(\t\x12\x12\n\nchart_name\x18\t \x01(\t\x12\x37\n\nchart_type\x18\n \x01(\x0e\x32#.swanlab.metric.column.v1.ChartType\x12\x13\n\x0bmetric_name\x18\x0b \x01(\t\x12=\n\rmetric_colors\x18\x0c \x01(\x0b\x32&.swanlab.metric.column.v1.MetricColors*\xe9\x01\n\nColumnType\x12\x1b\n\x17\x43OLUMN_TYPE_UNSPECIFIED\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_SCALAR\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_IMAGE\x10\x02\x12\x15\n\x11\x43OLUMN_TYPE_AUDIO\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_TEXT\x10\x04\x12\x15\n\x11\x43OLUMN_TYPE_VIDEO\x10\x05\x12\x17\n\x13\x43OLUMN_TYPE_ECHARTS\x10\x06\x12\x18\n\x14\x43OLUMN_TYPE_OBJECT3D\x10\x07\x12\x18\n\x14\x43OLUMN_TYPE_MOLECULE\x10\x08*]\n\x0b\x43olumnClass\x12\x1c\n\x18\x43OLUMN_CLASS_UNSPECIFIED\x10\x00\x12\x17\n\x13\x43OLUMN_CLASS_CUSTOM\x10\x01\x12\x17\n\x13\x43OLUMN_CLASS_SYSTEM\x10\x02*\x88\x02\n\tChartType\x12\x1a\n\x16\x43HART_TYPE_UNSPECIFIED\x10\x00\x12\x13\n\x0f\x43HART_TYPE_LINE\x10\x01\x12\x12\n\x0e\x43HART_TYPE_BAR\x10\x02\x12\x15\n\x11\x43HART_TYPE_SCALAR\x10\x03\x12\x14\n\x10\x43HART_TYPE_IMAGE\x10\x04\x12\x14\n\x10\x43HART_TYPE_AUDIO\x10\x05\x12\x13\n\x0f\x43HART_TYPE_TEXT\x10\x06\x12\x14\n\x10\x43HART_TYPE_VIDEO\x10\x07\x12\x16\n\x12\x43HART_TYPE_ECHARTS\x10\x08\x12\x17\n\x13\x43HART_TYPE_OBJECT3D\x10\t\x12\x17\n\x13\x43HART_TYPE_MOLECULE\x10\n*\x8f\x01\n\x0bSectionType\x12\x1c\n\x18SECTION_TYPE_UNSPECIFIED\x10\x00\x12\x17\n\x13SECTION_TYPE_PINNED\x10\x01\x12\x17\n\x13SECTION_TYPE_HIDDEN\x10\x02\x12\x17\n\x13SECTION_TYPE_PUBLIC\x10\x03\x12\x17\n\x13SECTION_TYPE_SYSTEM\x10\x04\x42JZHgithub.com/swanhubx/swanlab/core/proto/swanlab/metric/column/v1;columnv1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,18 +32,18 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'swanlab.metric.column.v1.co
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'ZHgithub.com/swanhubx/swanlab/core/proto/swanlab/metric/column/v1;columnv1'
-  _globals['_COLUMNTYPE']._serialized_start=643
-  _globals['_COLUMNTYPE']._serialized_end=876
-  _globals['_COLUMNCLASS']._serialized_start=878
-  _globals['_COLUMNCLASS']._serialized_end=971
-  _globals['_CHARTTYPE']._serialized_start=974
-  _globals['_CHARTTYPE']._serialized_end=1238
-  _globals['_SECTIONTYPE']._serialized_start=1241
-  _globals['_SECTIONTYPE']._serialized_end=1384
+  _globals['_COLUMNTYPE']._serialized_start=669
+  _globals['_COLUMNTYPE']._serialized_end=902
+  _globals['_COLUMNCLASS']._serialized_start=904
+  _globals['_COLUMNCLASS']._serialized_end=997
+  _globals['_CHARTTYPE']._serialized_start=1000
+  _globals['_CHARTTYPE']._serialized_end=1264
+  _globals['_SECTIONTYPE']._serialized_start=1267
+  _globals['_SECTIONTYPE']._serialized_end=1410
   _globals['_YRANGE']._serialized_start=67
-  _globals['_YRANGE']._serialized_end=101
-  _globals['_METRICCOLORS']._serialized_start=103
-  _globals['_METRICCOLORS']._serialized_end=146
-  _globals['_COLUMNRECORD']._serialized_start=149
-  _globals['_COLUMNRECORD']._serialized_end=640
+  _globals['_YRANGE']._serialized_end=127
+  _globals['_METRICCOLORS']._serialized_start=129
+  _globals['_METRICCOLORS']._serialized_end=172
+  _globals['_COLUMNRECORD']._serialized_start=175
+  _globals['_COLUMNRECORD']._serialized_end=666
 # @@protoc_insertion_point(module_scope)

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -448,7 +448,10 @@ def encode_column(record: ColumnRecord) -> Optional[UploadColumn]:
     # yRange: 数值列的 y 轴范围
     if record.column_type == ColumnType.COLUMN_TYPE_SCALAR:
         if record.HasField("y_range"):
-            column["yRange"] = (record.y_range.min, record.y_range.max)
+            y_range = record.y_range
+            min_value = y_range.min if y_range.HasField("min") else None
+            max_value = y_range.max if y_range.HasField("max") else None
+            column["yRange"] = (min_value, max_value)
     # chartName: 图表名称
     if record.chart_name:
         column["chartName"] = record.chart_name

--- a/swanlab/sdk/internal/probe_python/__init__.py
+++ b/swanlab/sdk/internal/probe_python/__init__.py
@@ -16,9 +16,7 @@ from swanlab.proto.swanlab.grpc.probe.v1.probe_pb2 import DeliverProbeStartReque
 from swanlab.sdk.internal.pkg import fs
 from swanlab.sdk.internal.probe_python.context import ProbeContext
 from swanlab.sdk.internal.probe_python.environment import conda, git, requirements, runtime, swanlab
-from swanlab.sdk.internal.probe_python.hardware_vendor.apple import Apple
-from swanlab.sdk.internal.probe_python.hardware_vendor.cpu import CPU
-from swanlab.sdk.internal.probe_python.hardware_vendor.memory import Memory
+from swanlab.sdk.internal.probe_python.hardware_vendor import ACCELERATOR_REGISTRY, CPU, Apple, Memory
 from swanlab.sdk.internal.probe_python.monitor import Monitor
 from swanlab.sdk.protocol.core import CoreProtocol
 from swanlab.sdk.protocol.probe import ProbeProtocol
@@ -57,12 +55,18 @@ class ProbePython(ProbeProtocol):
                 cpu_snapshot = CPU.get()
                 memory_snapshot = Memory.get()
             # 2.3 各家加速器厂商
+            accelerators = []
+            for vendor_cls in ACCELERATOR_REGISTRY.values():
+                snapshot = vendor_cls.get()
+                if snapshot is not None:
+                    accelerators.append(snapshot)
 
             # 2.4 组合数据
             hardware_snapshot = HardwareSnapshot(
                 cpu=cpu_snapshot,
                 memory=memory_snapshot,
                 apple_silicon=apple_snapshot,
+                accelerators=accelerators,
             )
         metadata = MetadataSnapshot(
             hardware=hardware_snapshot,

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/README.md
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/README.md
@@ -2,3 +2,15 @@
 
 由于硬件同时包含多维度信息，也同时涉及到信息采集和监控，不同厂家的硬件信息采集和监控方式也不一样，所以单独成一个模块
 模块下每个子模块负责一个厂商的硬件信息采集和监控，模块内提供统一接口供上层调用.
+
+
+## 设计取舍 —— collect() 的两种实现模式：
+
+CollectorProtocol 提供了基于 _handlers 的默认 collect() 实现，子类在 new() 中注册 (key, handler) 元组，
+父类统一遍历执行并做 safe.block 容错。NvidiaGPU 采用此模式，因为 pynvml 是进程内 Python API，
+每个指标可独立封装为 lambda 闭包。
+
+其余加速器（AMD、昇腾、寒武纪等）覆写 collect() 自行实现采集逻辑，未使用 _handlers 机制。
+原因是这些厂商的 CLI 工具（如 npu-smi、cnmon、hy-smi 等）单次调用返回多维度指标，
+拆分为独立 lambda 会增加不必要的进程调用开销，且不利于批量解析。
+覆写的 collect() 方法整体包裹在 safe.block 中，异常时返回空列表，与父类默认实现的安全语义一致。

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/__init__.py
@@ -5,6 +5,17 @@
 @description: 硬件提供商模块
 由于硬件同时包含多维度信息，也同时涉及到信息采集和监控，不同厂家的硬件信息采集和监控方式也不一样，所以单独成一个模块
 模块下每个子模块负责一个厂商的硬件信息采集和监控，模块内提供统一接口供上层调用
+
+设计取舍 —— collect() 的两种实现模式：
+
+CollectorProtocol 提供了基于 _handlers 的默认 collect() 实现，子类在 new() 中注册 (key, handler) 元组，
+父类统一遍历执行并做 safe.block 容错。NvidiaGPU 采用此模式，因为 pynvml 是进程内 Python API，
+每个指标可独立封装为 lambda 闭包。
+
+其余加速器（AMD、昇腾、寒武纪等）覆写 collect() 自行实现采集逻辑，未使用 _handlers 机制。
+原因是这些厂商的 CLI 工具（如 npu-smi、cnmon、hy-smi 等）单次调用返回多维度指标，
+拆分为独立 lambda 会增加不必要的进程调用开销，且不利于批量解析。
+覆写的 collect() 方法整体包裹在 safe.block 中，异常时返回空列表，与父类默认实现的安全语义一致。
 """
 
 from .accelerator import ACCELERATOR_REGISTRY

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/__init__.py
@@ -5,17 +5,6 @@
 @description: 硬件提供商模块
 由于硬件同时包含多维度信息，也同时涉及到信息采集和监控，不同厂家的硬件信息采集和监控方式也不一样，所以单独成一个模块
 模块下每个子模块负责一个厂商的硬件信息采集和监控，模块内提供统一接口供上层调用
-
-设计取舍 —— collect() 的两种实现模式：
-
-CollectorProtocol 提供了基于 _handlers 的默认 collect() 实现，子类在 new() 中注册 (key, handler) 元组，
-父类统一遍历执行并做 safe.block 容错。NvidiaGPU 采用此模式，因为 pynvml 是进程内 Python API，
-每个指标可独立封装为 lambda 闭包。
-
-其余加速器（AMD、昇腾、寒武纪等）覆写 collect() 自行实现采集逻辑，未使用 _handlers 机制。
-原因是这些厂商的 CLI 工具（如 npu-smi、cnmon、hy-smi 等）单次调用返回多维度指标，
-拆分为独立 lambda 会增加不必要的进程调用开销，且不利于批量解析。
-覆写的 collect() 方法整体包裹在 safe.block 中，异常时返回空列表，与父类默认实现的安全语义一致。
 """
 
 from .accelerator import ACCELERATOR_REGISTRY

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/__init__.py
@@ -7,8 +7,9 @@
 模块下每个子模块负责一个厂商的硬件信息采集和监控，模块内提供统一接口供上层调用
 """
 
+from .accelerator import ACCELERATOR_REGISTRY
 from .apple import Apple
 from .cpu import CPU
 from .memory import Memory
 
-__all__ = ["CPU", "Memory", "Apple"]
+__all__ = ["CPU", "Memory", "Apple", "ACCELERATOR_REGISTRY"]

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/__init__.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/__init__.py
@@ -4,3 +4,32 @@
 @time: 2026/3/31 01:49
 @description: 计算加速卡信息模块
 """
+
+from typing import Dict, Type
+
+from swanlab.sdk.typings.probe_python import AcceleratorVendor
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol
+
+from .amd import AMDGPU
+from .cambricon import CambriconMLU
+from .huawei import AscendNPU
+from .hygon import HygonDCU
+from .iluvatar import IluvatarGPU
+from .kunlunxin import KunlunxinXPU
+from .metax import MetaXGPU
+from .moorethreads import MooreThreadsGPU
+from .nvidia import NvidiaGPU
+
+__all__ = ["ACCELERATOR_REGISTRY"]
+
+ACCELERATOR_REGISTRY: Dict[AcceleratorVendor, Type[AcceleratorProtocol]] = {
+    "nvidia": NvidiaGPU,
+    "rocm": AMDGPU,
+    "ascend": AscendNPU,
+    "cambricon": CambriconMLU,
+    "iluvatar": IluvatarGPU,
+    "metax": MetaXGPU,
+    "moorethreads": MooreThreadsGPU,
+    "kunlunxin": KunlunxinXPU,
+    "hygon": HygonDCU,
+}

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/amd.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/amd.py
@@ -116,10 +116,12 @@ class AMDGPU(AcceleratorProtocol):
         return self, scalars
 
     def collect(self) -> List[CollectResult]:
-        if self._system == "Linux":
-            return self._collect_linux_sysfs()
-        else:
-            return self._collect_windows()
+        with safe.block(message="Failed to collect AMD GPU metrics", level="debug"):
+            if self._system == "Linux":
+                return self._collect_linux_sysfs()
+            else:
+                return self._collect_windows()
+        return []
 
     def _collect_linux_sysfs(self) -> List[CollectResult]:
         results: List[CollectResult] = []

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/amd.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/amd.py
@@ -1,6 +1,313 @@
 """
 @author: cunyue
-@file: rocm.py
-@time: 2026/3/31 01:58
-@description: AMD ROCm 计算加速卡信息模块
+@file: amd.py
+@time: 2026/3/31 01:57
+@description: AMD ROCm GPU 信息采集模块
+
+检测原理：
+- Linux 优先读取 amdgpu 驱动暴露的 sysfs 文件，避免 rocm-smi 在部分环境中不稳定。
+- 设备扫描格式：遍历 `/sys/class/drm/card*`，读取 `device/vendor`，AMD vendor id 为 `0x1002`；
+  总显存读取 `device/mem_info_vram_total`（bytes）。驱动版本读取 `/sys/module/amdgpu/version`。
+- Linux 动态指标格式：`gpu_busy_percent` 为 0-100；`mem_info_vram_used/total` 为 bytes；
+  `hwmon/hwmon*/temp1_input` 为 milli-degree Celsius；`power1_average` 或 `power1_input` 为 microwatt。
+- Windows 兜底使用 ROCm `hipinfo` 文本输出，按 `device# <idx>` 分块，解析 `Name:`、
+  `totalGlobalMem: <num> GB`、`memInfo.total/free: <num> GB`。
+- 如果 sysfs 扫描不到设备，会尝试 `rocm-smi --showproductname --json` 的 `cardX -> Card Series` JSON。
 """
+
+import glob
+import json
+import math
+import os
+import platform
+import re
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class AMDGPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        amd_config = next(a for a in shim.accelerators if a.vendor == "rocm")
+        self._indices = amd_config.device_indices
+        self._system = platform.system()
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize AMD monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["AMDGPU", SystemScalars]]:
+        amd_config = next((a for a in shim.accelerators if a.vendor == "rocm"), None)
+        if amd_config is None:
+            console.debug("No AMD monitor config in shim")
+            return None
+        self = cls(shim)
+        max_mem_mb = 0
+        for gpu_id in amd_config.device_indices:
+            if self._system == "Linux":
+                with safe.block(message=f"Failed to read AMD GPU {gpu_id} memory info", level="debug"):
+                    base = f"/sys/class/drm/card{gpu_id}/device"
+                    with open(os.path.join(base, "mem_info_vram_total"), "r") as f:
+                        total_bytes = int(f.read().strip())
+                    total_mb = total_bytes // (1024 * 1024)
+                    if total_mb > max_mem_mb:
+                        max_mem_mb = total_mb
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(amd_config.device_indices):
+            color = generate_color(color_idx)
+
+            util = SystemScalar(
+                key=f"gpu.{idx}.pct",
+                name=f"GPU {idx}",
+                chart_name="GPU Utilization (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(util)
+
+            mem_pct = SystemScalar(
+                key=f"gpu.{idx}.mem.pct",
+                name=f"GPU {idx}",
+                chart_name="GPU Memory Allocated (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(mem_pct)
+
+            mem_value = SystemScalar(
+                key=f"gpu.{idx}.mem.value",
+                name=f"GPU {idx}",
+                chart_name="GPU Memory Allocated (MB)",
+                y_min=0,
+                y_max=max_mem_mb,
+                color=color,
+            )
+            scalars.append(mem_value)
+
+            temp = SystemScalar(
+                key=f"gpu.{idx}.temp",
+                name=f"GPU {idx}",
+                chart_name="GPU Temperature (°C)",
+                color=color,
+            )
+            scalars.append(temp)
+
+            power = SystemScalar(
+                key=f"gpu.{idx}.power",
+                name=f"GPU {idx}",
+                chart_name="GPU Power (W)",
+                color=color,
+            )
+            scalars.append(power)
+
+        console.debug(f"AMD monitor initialized with {len(amd_config.device_indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        if self._system == "Linux":
+            return self._collect_linux_sysfs()
+        else:
+            return self._collect_windows()
+
+    def _collect_linux_sysfs(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            base = f"/sys/class/drm/card{idx}/device"
+
+            results.append((f"gpu.{idx}.pct", math.nan))
+            with safe.block(message=f"Failed to collect AMD GPU {idx} utilization", level="debug"):
+                with open(os.path.join(base, "gpu_busy_percent"), "r") as f:
+                    util = float(f.read().strip())
+                results[-1] = (f"gpu.{idx}.pct", util)
+
+            mem_pct = math.nan
+            mem_used_mb = math.nan
+            with safe.block(message=f"Failed to collect AMD GPU {idx} memory", level="debug"):
+                with open(os.path.join(base, "mem_info_vram_used"), "r") as f:
+                    used_bytes = int(f.read().strip())
+                with open(os.path.join(base, "mem_info_vram_total"), "r") as f:
+                    total_bytes = int(f.read().strip())
+                if total_bytes > 0:
+                    mem_pct = (used_bytes / total_bytes) * 100
+                    mem_used_mb = used_bytes / (1024 * 1024)
+            results.append((f"gpu.{idx}.mem.pct", mem_pct))
+            results.append((f"gpu.{idx}.mem.value", mem_used_mb))
+
+            temp_val = math.nan
+            power_val = math.nan
+            with safe.block(message=f"Failed to collect AMD GPU {idx} temperature/power", level="debug"):
+                hwmons = glob.glob(os.path.join(base, "hwmon", "hwmon*"))
+                if hwmons:
+                    hwmon_path = hwmons[0]
+                    if os.path.exists(os.path.join(hwmon_path, "temp1_input")):
+                        with open(os.path.join(hwmon_path, "temp1_input"), "r") as f:
+                            temp_val = float(f.read().strip()) / 1000.0
+                    p_file = os.path.join(hwmon_path, "power1_average")
+                    if not os.path.exists(p_file):
+                        p_file = os.path.join(hwmon_path, "power1_input")
+                    if os.path.exists(p_file):
+                        with open(p_file, "r") as f:
+                            power_val = float(f.read().strip()) / 1000000.0
+            results.append((f"gpu.{idx}.temp", temp_val))
+            results.append((f"gpu.{idx}.power", power_val))
+
+        return results
+
+    def _collect_windows(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        output = ""
+        with safe.block(message="Failed to run hipinfo for AMD GPU collection", level="debug"):
+            output = subprocess.run(["hipinfo"], capture_output=True, text=True).stdout
+
+        devices_content: Dict[str, str] = {}
+        parts = re.split(r"device#\s+(\d+)", output)
+        if len(parts) >= 2:
+            for i in range(1, len(parts), 2):
+                devices_content[parts[i].strip()] = parts[i + 1]
+        elif output:
+            devices_content["0"] = output
+
+        for idx in self._indices:
+            content = devices_content.get(str(idx), "")
+
+            mem_total = self._extract_float(content, r"memInfo\.total:\s*([\d\.]+)\s*GB")
+            mem_free = self._extract_float(content, r"memInfo\.free:\s*([\d\.]+)\s*GB")
+
+            mem_pct = math.nan
+            mem_used_mb = math.nan
+            if mem_total is not None and mem_free is not None and mem_total > 0:
+                mem_used = mem_total - mem_free
+                mem_used_mb = mem_used * 1024
+                mem_pct = (mem_used / mem_total) * 100
+
+            results.append((f"gpu.{idx}.pct", math.nan))
+            results.append((f"gpu.{idx}.mem.pct", mem_pct))
+            results.append((f"gpu.{idx}.mem.value", mem_used_mb))
+            results.append((f"gpu.{idx}.temp", math.nan))
+            results.append((f"gpu.{idx}.power", math.nan))
+
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to extract float from hipinfo output")
+    def _extract_float(content: str, regex: str) -> Optional[float]:
+        match = re.search(regex, content, re.IGNORECASE)
+        if match:
+            return float(match.group(1))
+        return None
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get AMD GPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        system_name = platform.system()
+        if system_name not in ["Linux", "Windows"]:
+            console.debug(
+                f"AMD GPU detection skipped: only Linux/Windows are supported, current platform is {system_name}"
+            )
+            return None
+
+        if system_name == "Linux":
+            driver, gpu_map = AMDGPU._map_amd_gpu_linux()
+        else:
+            driver, gpu_map = AMDGPU._map_amd_gpu_windows()
+
+        if not gpu_map:
+            console.debug("No AMD GPU detected: sysfs/hipinfo/rocm-smi did not return any AMD devices")
+            return None
+
+        devices = []
+        for gpu_id, info in gpu_map.items():
+            mem_str = info.get("memory", "0GB")
+            digits = re.findall(r"([\d\.]+)", mem_str)
+            mem_val = int(float(digits[0])) if digits else 0
+            unit = "GB" if "GB" in mem_str else "MB"
+            devices.append(
+                DeviceSnapshot(index=int(gpu_id), name=info.get("name", "AMD GPU"), memory=mem_val, memory_unit=unit)
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} AMD GPU(s): {', '.join(names)}")
+        return AcceleratorSnapshot(vendor="rocm", version=driver, devices=devices)
+
+    @staticmethod
+    def _map_amd_gpu_linux() -> Tuple[Optional[str], dict]:
+        driver_version = "Unknown"
+        with safe.block(message="Failed to get AMD GPU driver version", level="debug"):
+            if os.path.exists("/sys/module/amdgpu/version"):
+                with open("/sys/module/amdgpu/version", "r") as f:
+                    driver_version = f.read().strip()
+
+        gpu_map: dict = {}
+        with safe.block(message="Failed to map AMD GPUs via sysfs", level="debug"):
+            cards = glob.glob("/sys/class/drm/card*")
+            amd_cards = []
+            for card_path in cards:
+                if not re.search(r"card\d+$", card_path):
+                    continue
+                vendor_path = os.path.join(card_path, "device/vendor")
+                if os.path.exists(vendor_path):
+                    with open(vendor_path, "r") as f:
+                        vendor = f.read().strip()
+                    if "0x1002" in vendor:
+                        idx = card_path.split("card")[-1]
+                        amd_cards.append(idx)
+            amd_cards.sort(key=lambda x: int(x))
+
+            for idx in amd_cards:
+                mem_str = "0GB"
+                mem_total_path = f"/sys/class/drm/card{idx}/device/mem_info_vram_total"
+                if os.path.exists(mem_total_path):
+                    with open(mem_total_path, "r") as f:
+                        mem_bytes = int(f.read().strip())
+                        mem_gb = round(mem_bytes / (1024**3))
+                        mem_str = f"{mem_gb}GB"
+                gpu_map[idx] = {"name": "AMD GPU", "memory": mem_str}
+
+        if not gpu_map:
+            with safe.block(message="Failed to map AMD GPUs via rocm-smi fallback", level="debug"):
+                data = json.loads(
+                    subprocess.run(["rocm-smi", "--showproductname", "--json"], capture_output=True, text=True).stdout
+                )
+                for k, v in data.items():
+                    idx = k.replace("card", "")
+                    gpu_map[idx] = {"name": v.get("Card Series", "AMD GPU"), "memory": "0GB"}
+        return driver_version, gpu_map
+
+    @staticmethod
+    def _map_amd_gpu_windows() -> Tuple[Optional[str], dict]:
+        driver_version = "Unknown"
+        gpu_map: dict = {}
+        with safe.block(message="Failed to map AMD GPUs via hipinfo on Windows", level="debug"):
+            output = subprocess.run(["hipinfo"], capture_output=True, text=True, check=True).stdout
+            devices = re.split(r"device#\s+(\d+)", output)
+            if len(devices) < 2:
+                gpu_map.update(AMDGPU._parse_hipinfo_text_block("0", output))
+            else:
+                for i in range(1, len(devices), 2):
+                    dev_id = devices[i].strip()
+                    gpu_map.update(AMDGPU._parse_hipinfo_text_block(dev_id, devices[i + 1]))
+        return driver_version, gpu_map
+
+    @staticmethod
+    def _parse_hipinfo_text_block(dev_id: str, content: str) -> dict:
+        name = "AMD GPU"
+        memory = "0GB"
+        name_match = re.search(r"Name:\s*(.+)", content)
+        if name_match:
+            name = name_match.group(1).strip()
+        mem_match = re.search(r"totalGlobalMem:\s*([\d\.]+)\s*GB", content)
+        if mem_match:
+            memory = f"{mem_match.group(1)}GB"
+        return {dev_id: {"name": name, "memory": memory}}

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/amd.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/amd.py
@@ -108,6 +108,7 @@ class AMDGPU(AcceleratorProtocol):
                 key=f"gpu.{idx}.power",
                 name=f"GPU {idx}",
                 chart_name="GPU Power (W)",
+                y_min=0,
                 color=color,
             )
             scalars.append(power)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/cambricon.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/cambricon.py
@@ -1,6 +1,259 @@
 """
 @author: cunyue
 @file: cambricon.py
-@time: 2026/3/31 02:00
-@description: 寒武纪加速卡信息模块
+@time: 2026/3/31 01:58
+@description: 寒武纪 Cambricon MLU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，依赖寒武纪 `cnmon` 命令行工具输出文本。
+- 静态信息使用 `cnmon info -m`，按段落解析：`Card ... <id>` 开启一个设备段，
+  `Product ... <name>` 为型号，`Driver ... <version>` 为驱动版本，`Total ... <MiB>` 为总显存。
+- 利用率使用 `cnmon info -u`，解析包含 `mlu average` 的行，冒号后的百分比为 MLU 使用率。
+- 显存使用使用 `cnmon info -m` 的 `physical memory usage` 段，其后 `used: <MiB>` 行为已用显存。
+- 温度使用 `cnmon info -e` 的 `temperature` 段，解析 `chip: <C>`；功耗使用 `cnmon info -p`
+  的 `power` 段，解析 `usage: <W>`。
 """
+
+import math
+import platform
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class CambriconMLU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        cambricon_config = next(a for a in shim.accelerators if a.vendor == "cambricon")
+        self._indices = cambricon_config.device_indices
+        self._mlu_info = CambriconMLU._map_mlu_raw()[1]
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize Cambricon MLU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["CambriconMLU", SystemScalars]]:
+        cambricon_config = next((a for a in shim.accelerators if a.vendor == "cambricon"), None)
+        if cambricon_config is None:
+            console.debug("No Cambricon MLU monitor config in shim")
+            return None
+        self = cls(shim)
+
+        max_mem_mb = 0
+        for idx in cambricon_config.device_indices:
+            mlu_id = str(idx)
+            if mlu_id in self._mlu_info:
+                mem = int(self._mlu_info[mlu_id].get("memory", 0))
+                if mem * 1024 > max_mem_mb:
+                    max_mem_mb = mem * 1024
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(cambricon_config.device_indices):
+            color = generate_color(color_idx)
+
+            util = SystemScalar(
+                key=f"mlu.{idx}.ptc",
+                name=f"MLU {idx}",
+                chart_name="MLU Utilization (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(util)
+
+            mem_pct = SystemScalar(
+                key=f"mlu.{idx}.mem.ptc",
+                name=f"MLU {idx}",
+                chart_name="MLU Memory Allocated (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(mem_pct)
+
+            mem_value = SystemScalar(
+                key=f"mlu.{idx}.mem.value",
+                name=f"MLU {idx}",
+                chart_name="MLU Memory Allocated (MB)",
+                y_min=0,
+                y_max=max_mem_mb,
+                color=color,
+            )
+            scalars.append(mem_value)
+
+            temp = SystemScalar(
+                key=f"mlu.{idx}.temp",
+                name=f"MLU {idx}",
+                chart_name="MLU Temperature (°C)",
+                color=color,
+            )
+            scalars.append(temp)
+
+            power = SystemScalar(
+                key=f"mlu.{idx}.power",
+                name=f"MLU {idx}",
+                chart_name="MLU Power (W)",
+                color=color,
+            )
+            scalars.append(power)
+
+        console.debug(f"Cambricon MLU monitor initialized with {len(cambricon_config.device_indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        mlu_ids = [str(i) for i in self._indices]
+        results: List[CollectResult] = []
+
+        results.extend(self._collect_utilization(mlu_ids))
+        results.extend(self._collect_memory(mlu_ids))
+        results.extend(self._collect_temperature(mlu_ids))
+        results.extend(self._collect_power(mlu_ids))
+
+        return results
+
+    def _collect_utilization(self, mlu_ids: List[str]) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for mid in mlu_ids:
+            results.append((f"mlu.{mid}.ptc", math.nan))
+        with safe.block(message="Failed to collect MLU utilization", level="debug"):
+            output = subprocess.run(["cnmon", "info", "-u"], capture_output=True, text=True).stdout
+            index = 0
+            for line in output.split("\n"):
+                if "mlu average" in line.lower() and index < len(mlu_ids):
+                    util_str = line.split(":")[-1].replace("%", "").strip()
+                    if util_str.isdigit():
+                        results[index] = (f"mlu.{mlu_ids[index]}.ptc", float(util_str))
+                    index += 1
+        return results
+
+    def _collect_memory(self, mlu_ids: List[str]) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for mid in mlu_ids:
+            results.append((f"mlu.{mid}.mem.ptc", math.nan))
+            results.append((f"mlu.{mid}.mem.value", math.nan))
+        with safe.block(message="Failed to collect MLU memory", level="debug"):
+            output = subprocess.run(["cnmon", "info", "-m"], capture_output=True, text=True).stdout
+            lines = output.split("\n")
+            index = 0
+            for line_idx, line in enumerate(lines):
+                if "physical memory usage" in line.lower() and index < len(mlu_ids):
+                    if line_idx + 2 < len(lines) and "used" in lines[line_idx + 2].lower():
+                        used_line = lines[line_idx + 2]
+                        used_str = used_line.split(":")[-1].replace("MiB", "").strip()
+                        if used_str.isdigit():
+                            used_val = float(used_str)
+                            mlu_id = mlu_ids[index]
+                            total_gb = float(self._mlu_info.get(mlu_id, {}).get("memory", 0))
+                            if total_gb > 0:
+                                pct_idx = index * 2
+                                val_idx = index * 2 + 1
+                                results[pct_idx] = (f"mlu.{mlu_id}.mem.ptc", used_val / (total_gb * 1024) * 100)
+                                results[val_idx] = (f"mlu.{mlu_id}.mem.value", used_val)
+                        index += 1
+        return results
+
+    def _collect_temperature(self, mlu_ids: List[str]) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for mid in mlu_ids:
+            results.append((f"mlu.{mid}.temp", math.nan))
+        with safe.block(message="Failed to collect MLU temperature", level="debug"):
+            output = subprocess.run(["cnmon", "info", "-e"], capture_output=True, text=True).stdout
+            lines = output.split("\n")
+            index = 0
+            for line_idx, line in enumerate(lines):
+                if "temperature" in line.lower() and index < len(mlu_ids):
+                    if line_idx + 2 < len(lines) and "chip" in lines[line_idx + 2].lower():
+                        temp_line = lines[line_idx + 2]
+                        temp_str = temp_line.split(":")[-1].replace("C", "").strip()
+                        if temp_str.isdigit():
+                            results[index] = (f"mlu.{mlu_ids[index]}.temp", float(temp_str))
+                        index += 1
+        return results
+
+    def _collect_power(self, mlu_ids: List[str]) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for mid in mlu_ids:
+            results.append((f"mlu.{mid}.power", math.nan))
+        with safe.block(message="Failed to collect MLU power", level="debug"):
+            output = subprocess.run(["cnmon", "info", "-p"], capture_output=True, text=True).stdout
+            lines = output.split("\n")
+            index = 0
+            for line_idx, line in enumerate(lines):
+                if "power" in line.lower() and index < len(mlu_ids):
+                    if line_idx + 1 < len(lines) and "usage" in lines[line_idx + 1].lower():
+                        power_line = lines[line_idx + 1]
+                        power_str = power_line.split(":")[-1].replace("W", "").strip()
+                        if power_str.isdigit():
+                            results[index] = (f"mlu.{mlu_ids[index]}.power", float(power_str))
+                        index += 1
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Cambricon MLU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"Cambricon MLU detection skipped: cnmon is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+
+        driver, mlu_map = CambriconMLU._map_mlu_raw()
+        if not mlu_map:
+            console.debug("No Cambricon MLU detected: cnmon info -m returned no MLU devices")
+            return None
+
+        devices = []
+        for idx, mlu_id in enumerate(sorted(mlu_map.keys(), key=int)):
+            info = mlu_map[mlu_id]
+            devices.append(
+                DeviceSnapshot(
+                    index=int(mlu_id),
+                    name=f"MLU {mlu_id} {info.get('name', '')}",
+                    memory=int(info.get("memory", 0)),
+                    memory_unit="GB",
+                )
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} Cambricon MLU device(s): {', '.join(names)}")
+        return AcceleratorSnapshot(
+            vendor="cambricon",
+            version=driver,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _map_mlu_raw() -> Tuple[Optional[str], dict]:
+        output = ""
+        with safe.block(message="Failed to run cnmon info for MLU mapping", level="debug"):
+            output = subprocess.run(["cnmon", "info", "-m"], capture_output=True, check=True, text=True).stdout
+        mlu_map: Dict[str, dict] = {}
+        driver = None
+        lines = output.split("\n")[1:]
+
+        mlu_id = None
+        for line in lines:
+            parts = line.split()
+            with safe.block(message="Failed to parse MLU info line", level="debug"):
+                if parts[0] == "Card":
+                    mlu_id = parts[-1]
+                    if mlu_id not in mlu_map:
+                        mlu_map[mlu_id] = {}
+                if mlu_id is None:
+                    continue
+                if parts[0] == "Product":
+                    mlu_map[mlu_id]["name"] = parts[-1]
+                if parts[0] == "Driver" and len(mlu_map[mlu_id]) == 1 and driver is None:
+                    driver = parts[-1]
+                if parts[0] == "Total" and len(mlu_map[mlu_id]) == 1:
+                    mlu_map[mlu_id]["memory"] = str(int(parts[-2]) // 1024)
+
+        return driver, mlu_map

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/cambricon.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/cambricon.py
@@ -60,7 +60,7 @@ class CambriconMLU(AcceleratorProtocol):
             color = generate_color(color_idx)
 
             util = SystemScalar(
-                key=f"mlu.{idx}.ptc",
+                key=f"mlu.{idx}.pct",
                 name=f"MLU {idx}",
                 chart_name="MLU Utilization (%)",
                 y_min=0,
@@ -70,7 +70,7 @@ class CambriconMLU(AcceleratorProtocol):
             scalars.append(util)
 
             mem_pct = SystemScalar(
-                key=f"mlu.{idx}.mem.ptc",
+                key=f"mlu.{idx}.mem.pct",
                 name=f"MLU {idx}",
                 chart_name="MLU Memory Allocated (%)",
                 y_min=0,
@@ -101,6 +101,7 @@ class CambriconMLU(AcceleratorProtocol):
                 key=f"mlu.{idx}.power",
                 name=f"MLU {idx}",
                 chart_name="MLU Power (W)",
+                y_min=0,
                 color=color,
             )
             scalars.append(power)
@@ -122,22 +123,24 @@ class CambriconMLU(AcceleratorProtocol):
     def _collect_utilization(self, mlu_ids: List[str]) -> List[CollectResult]:
         results: List[CollectResult] = []
         for mid in mlu_ids:
-            results.append((f"mlu.{mid}.ptc", math.nan))
+            results.append((f"mlu.{mid}.pct", math.nan))
         with safe.block(message="Failed to collect MLU utilization", level="debug"):
             output = subprocess.run(["cnmon", "info", "-u"], capture_output=True, text=True).stdout
             index = 0
             for line in output.split("\n"):
                 if "mlu average" in line.lower() and index < len(mlu_ids):
                     util_str = line.split(":")[-1].replace("%", "").strip()
-                    if util_str.isdigit():
-                        results[index] = (f"mlu.{mlu_ids[index]}.ptc", float(util_str))
+                    try:
+                        results[index] = (f"mlu.{mlu_ids[index]}.pct", float(util_str))
+                    except ValueError:
+                        pass
                     index += 1
         return results
 
     def _collect_memory(self, mlu_ids: List[str]) -> List[CollectResult]:
         results: List[CollectResult] = []
         for mid in mlu_ids:
-            results.append((f"mlu.{mid}.mem.ptc", math.nan))
+            results.append((f"mlu.{mid}.mem.pct", math.nan))
             results.append((f"mlu.{mid}.mem.value", math.nan))
         with safe.block(message="Failed to collect MLU memory", level="debug"):
             output = subprocess.run(["cnmon", "info", "-m"], capture_output=True, text=True).stdout
@@ -148,15 +151,17 @@ class CambriconMLU(AcceleratorProtocol):
                     if line_idx + 2 < len(lines) and "used" in lines[line_idx + 2].lower():
                         used_line = lines[line_idx + 2]
                         used_str = used_line.split(":")[-1].replace("MiB", "").strip()
-                        if used_str.isdigit():
+                        try:
                             used_val = float(used_str)
                             mlu_id = mlu_ids[index]
                             total_gb = float(self._mlu_info.get(mlu_id, {}).get("memory", 0))
                             if total_gb > 0:
                                 pct_idx = index * 2
                                 val_idx = index * 2 + 1
-                                results[pct_idx] = (f"mlu.{mlu_id}.mem.ptc", used_val / (total_gb * 1024) * 100)
+                                results[pct_idx] = (f"mlu.{mlu_id}.mem.pct", used_val / (total_gb * 1024) * 100)
                                 results[val_idx] = (f"mlu.{mlu_id}.mem.value", used_val)
+                        except ValueError:
+                            pass
                         index += 1
         return results
 
@@ -173,8 +178,10 @@ class CambriconMLU(AcceleratorProtocol):
                     if line_idx + 2 < len(lines) and "chip" in lines[line_idx + 2].lower():
                         temp_line = lines[line_idx + 2]
                         temp_str = temp_line.split(":")[-1].replace("C", "").strip()
-                        if temp_str.isdigit():
+                        try:
                             results[index] = (f"mlu.{mlu_ids[index]}.temp", float(temp_str))
+                        except ValueError:
+                            pass
                         index += 1
         return results
 
@@ -191,8 +198,10 @@ class CambriconMLU(AcceleratorProtocol):
                     if line_idx + 1 < len(lines) and "usage" in lines[line_idx + 1].lower():
                         power_line = lines[line_idx + 1]
                         power_str = power_line.split(":")[-1].replace("W", "").strip()
-                        if power_str.isdigit():
+                        try:
                             results[index] = (f"mlu.{mlu_ids[index]}.power", float(power_str))
+                        except ValueError:
+                            pass
                         index += 1
         return results
 

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/cambricon.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/cambricon.py
@@ -109,13 +109,13 @@ class CambriconMLU(AcceleratorProtocol):
         return self, scalars
 
     def collect(self) -> List[CollectResult]:
-        mlu_ids = [str(i) for i in self._indices]
         results: List[CollectResult] = []
-
-        results.extend(self._collect_utilization(mlu_ids))
-        results.extend(self._collect_memory(mlu_ids))
-        results.extend(self._collect_temperature(mlu_ids))
-        results.extend(self._collect_power(mlu_ids))
+        with safe.block(message="Failed to collect Cambricon MLU metrics", level="debug"):
+            mlu_ids = [str(i) for i in self._indices]
+            results.extend(self._collect_utilization(mlu_ids))
+            results.extend(self._collect_memory(mlu_ids))
+            results.extend(self._collect_temperature(mlu_ids))
+            results.extend(self._collect_power(mlu_ids))
 
         return results
 

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
@@ -134,6 +134,7 @@ class AscendNPU(AcceleratorProtocol):
         util_val = math.nan
         hbm_val = math.nan
         hbm_mb = math.nan
+        hbm_total_mb = math.nan
         with safe.block(message="Failed to collect Ascend NPU usage", level="debug"):
             output = subprocess.run(
                 ["npu-smi", "info", "-t", "usages", "-i", npu_id, "-c", chip_id],
@@ -149,6 +150,12 @@ class AscendNPU(AcceleratorProtocol):
                     hbm_str = line.split(":")[-1].strip()
                     if hbm_str.isdigit():
                         hbm_val = float(hbm_str)
+                if "hbm capacity" in line.lower():
+                    hbm_str = line.split(":")[-1].strip()
+                    if hbm_str.isdigit():
+                        hbm_total_mb = float(hbm_str)
+            if not math.isnan(hbm_val) and not math.isnan(hbm_total_mb):
+                hbm_mb = hbm_val / 100 * hbm_total_mb
         return [
             (f"npu.{label}.ptc", util_val),
             (f"npu.{label}.mem.ptc", hbm_val),

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
@@ -1,6 +1,269 @@
 """
 @author: cunyue
-@file: npu.py
-@time: 2026/3/31 02:00
-@description: 华为昇腾 NPU 相关信息采集和监控
+@file: huawei.py
+@time: 2026/3/31 01:58
+@description: 华为昇腾 Ascend NPU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，先检查 `/dev/davinci*` 设备文件，再调用华为官方 `npu-smi` 工具。
+- 静态映射使用 `npu-smi info -m`，文本表格从第二行开始解析：
+  `NPU ID  Chip ID  Chip Logic ID  Chip Name...`；其中 Chip Logic ID 非数字的 MCU 行会被过滤。
+- 驱动版本使用 `npu-smi -v`，解析冒号后的版本号。
+- CANN 版本读取 `/usr/local/Ascend/ascend-toolkit/latest/{arch}-linux/ascend_toolkit_install.info`
+  中的 `version=<value>`。
+- 动态指标使用 `npu-smi info -t usages/temp/power -i <npu_id> -c <chip_id>`，解析
+  `Aicore Usage Rate`、`HBM Usage Rate`、`HBM Capacity`、温度和功耗冒号后的数值。
 """
+
+import math
+import os
+import platform
+import subprocess
+from typing import List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class AscendNPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        ascend_config = next(a for a in shim.accelerators if a.vendor == "ascend")
+        self._indices = ascend_config.device_indices
+        self._npu_map = AscendNPU._map_npu_raw()
+        self._chips: List[Tuple[str, str]] = []
+        flat_idx = 0
+        for npu_id in sorted(self._npu_map.keys(), key=int):
+            for chip_id in sorted(self._npu_map[npu_id].keys(), key=int):
+                if flat_idx in self._indices:
+                    self._chips.append((npu_id, chip_id))
+                flat_idx += 1
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize Ascend NPU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["AscendNPU", SystemScalars]]:
+        ascend_config = next((a for a in shim.accelerators if a.vendor == "ascend"), None)
+        if ascend_config is None:
+            console.debug("No Ascend NPU monitor config in shim")
+            return None
+        self = cls(shim)
+
+        hbm_value = 0
+        for npu_id, chip_id in self._chips:
+            usage = AscendNPU._get_chip_usage(npu_id, chip_id)
+            if usage:
+                hbm = int(usage.get("hbm", 0))
+                if hbm > hbm_value:
+                    hbm_value = hbm
+        max_hbm_mb = hbm_value * 1024
+
+        scalars: SystemScalars = []
+        for color_idx, (npu_id, chip_id) in enumerate(self._chips):
+            label = f"{npu_id}-{chip_id}"
+            color = generate_color(color_idx)
+
+            util = SystemScalar(
+                key=f"npu.{label}.ptc",
+                name=f"NPU {label}",
+                chart_name="NPU Utilization (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(util)
+
+            hbm_rate = SystemScalar(
+                key=f"npu.{label}.mem.ptc",
+                name=f"NPU {label}",
+                chart_name="NPU Memory Allocated (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(hbm_rate)
+
+            hbm_value_scalar = SystemScalar(
+                key=f"npu.{label}.mem.value",
+                name=f"NPU {label}",
+                chart_name="NPU Memory Allocated (MB)",
+                y_min=0,
+                y_max=max_hbm_mb,
+                color=color,
+            )
+            scalars.append(hbm_value_scalar)
+
+            temp = SystemScalar(
+                key=f"npu.{label}.temp",
+                name=f"NPU {label}",
+                chart_name="NPU Temperature (°C)",
+                color=color,
+            )
+            scalars.append(temp)
+
+            power = SystemScalar(
+                key=f"npu.{label}.power",
+                name=f"NPU {label}",
+                chart_name="NPU Power Usage (W)",
+                color=color,
+            )
+            scalars.append(power)
+
+        console.debug(f"Ascend NPU monitor initialized with {len(self._chips)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for npu_id, chip_id in self._chips:
+            label = f"{npu_id}-{chip_id}"
+            results.extend(self._collect_usage(npu_id, chip_id, label))
+            results.append(self._collect_temp(npu_id, chip_id, label))
+            results.append(self._collect_power(npu_id, chip_id, label))
+        return results
+
+    def _collect_usage(self, npu_id: str, chip_id: str, label: str) -> List[CollectResult]:
+        util_val = math.nan
+        hbm_val = math.nan
+        hbm_mb = math.nan
+        with safe.block(message="Failed to collect Ascend NPU usage", level="debug"):
+            output = subprocess.run(
+                ["npu-smi", "info", "-t", "usages", "-i", npu_id, "-c", chip_id],
+                capture_output=True,
+                text=True,
+            ).stdout
+            for line in output.split("\n"):
+                if "aicore usage rate" in line.lower():
+                    util_str = line.split(":")[-1].strip()
+                    if util_str.isdigit():
+                        util_val = float(util_str)
+                if "hbm usage rate" in line.lower():
+                    hbm_str = line.split(":")[-1].strip()
+                    if hbm_str.isdigit():
+                        hbm_val = float(hbm_str)
+        return [
+            (f"npu.{label}.ptc", util_val),
+            (f"npu.{label}.mem.ptc", hbm_val),
+            (f"npu.{label}.mem.value", hbm_mb),
+        ]
+
+    def _collect_temp(self, npu_id: str, chip_id: str, label: str) -> CollectResult:
+        temp_val = math.nan
+        with safe.block(message="Failed to collect Ascend NPU temperature", level="debug"):
+            output = subprocess.run(
+                ["npu-smi", "info", "-t", "temp", "-i", npu_id, "-c", chip_id],
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            temp_val = float(output.split(":")[-1].strip())
+        return (f"npu.{label}.temp", temp_val)
+
+    def _collect_power(self, npu_id: str, chip_id: str, label: str) -> CollectResult:
+        power_val = math.nan
+        with safe.block(message="Failed to collect Ascend NPU power", level="debug"):
+            output = subprocess.run(
+                ["npu-smi", "info", "-t", "power", "-i", npu_id, "-c", chip_id],
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            power_val = float(output.split(":")[-1].strip())
+        return (f"npu.{label}.power", power_val)
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Ascend NPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"Ascend NPU detection skipped: npu-smi is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+        if not any(f.startswith("davinci") for f in os.listdir("/dev")):
+            console.debug("Ascend NPU detection skipped: no /dev/davinci* device files found")
+            return None
+
+        driver = AscendNPU._get_version()
+        cann = AscendNPU._get_cann_version()
+        npu_map = AscendNPU._map_npu_raw()
+
+        devices = []
+        flat_idx = 0
+        for npu_id in sorted(npu_map.keys(), key=int):
+            for chip_id in sorted(npu_map[npu_id].keys(), key=int):
+                chip_info = npu_map[npu_id][chip_id]
+                usage = AscendNPU._get_chip_usage(npu_id, chip_id)
+                hbm = int(usage.get("hbm", 0)) if usage else 0
+                devices.append(
+                    DeviceSnapshot(
+                        index=flat_idx,
+                        name=f"NPU {npu_id}-{chip_id} {chip_info.get('name', '')}",
+                        memory=hbm,
+                        memory_unit="GB",
+                    )
+                )
+                flat_idx += 1
+
+        if not devices:
+            console.debug("No Ascend NPU detected: npu-smi info -m returned no compute chips")
+            return None
+
+        console.debug(f"Detected {len(devices)} Ascend NPU device(s): {', '.join(d.name for d in devices)}")
+        return AcceleratorSnapshot(
+            vendor="ascend",
+            version=driver,
+            cann_version=cann,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _get_version() -> str:
+        result = subprocess.run(["npu-smi", "-v"], capture_output=True, check=True, text=True)
+        return result.stdout.split(":")[-1].strip()
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get CANN version")
+    def _get_cann_version() -> Optional[str]:
+        arch = platform.machine()
+        if arch not in ("aarch64", "x86_64"):
+            return None
+        path = f"/usr/local/Ascend/ascend-toolkit/latest/{arch}-linux/ascend_toolkit_install.info"
+        cmd = f"grep -m 1 '^version=' {path} | cut -d'=' -f2"
+        proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        return proc.stdout.strip() if proc.returncode == 0 else None
+
+    @staticmethod
+    def _map_npu_raw() -> dict:
+        output = subprocess.run(["npu-smi", "info", "-m"], capture_output=True, check=True, text=True).stdout
+        npu_map: dict = {}
+        for line in output.split("\n")[1:]:
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            npu_id, chip_id, chip_logic_id, *chip_name = parts
+            if not chip_logic_id.isdigit():
+                continue
+            chip_name_str = " ".join(chip_name)
+            if npu_id not in npu_map:
+                npu_map[npu_id] = {}
+            npu_map[npu_id][chip_id] = {"id": chip_logic_id, "name": chip_name_str}
+        return npu_map
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Ascend NPU chip usage")
+    def _get_chip_usage(npu_id: str, chip_id: str) -> Optional[dict]:
+        output = subprocess.run(
+            ["npu-smi", "info", "-t", "usages", "-i", npu_id, "-c", chip_id],
+            capture_output=True,
+            text=True,
+        ).stdout
+        for line in output.split("\n"):
+            if "hbm capacity" in line.lower():
+                hbm = line.split(":")[-1].strip()
+                if hbm.isdigit():
+                    return {"hbm": str(round(int(hbm) / 1024))}
+        return None

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
@@ -120,13 +120,15 @@ class AscendNPU(AcceleratorProtocol):
         return self, scalars
 
     def collect(self) -> List[CollectResult]:
-        results: List[CollectResult] = []
-        for npu_id, chip_id in self._chips:
-            label = f"{npu_id}-{chip_id}"
-            results.extend(self._collect_usage(npu_id, chip_id, label))
-            results.append(self._collect_temp(npu_id, chip_id, label))
-            results.append(self._collect_power(npu_id, chip_id, label))
-        return results
+        with safe.block(message="Failed to collect Ascend NPU metrics", level="debug"):
+            results: List[CollectResult] = []
+            for npu_id, chip_id in self._chips:
+                label = f"{npu_id}-{chip_id}"
+                results.extend(self._collect_usage(npu_id, chip_id, label))
+                results.append(self._collect_temp(npu_id, chip_id, label))
+                results.append(self._collect_power(npu_id, chip_id, label))
+            return results
+        return []
 
     def _collect_usage(self, npu_id: str, chip_id: str, label: str) -> List[CollectResult]:
         util_val = math.nan

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/huawei.py
@@ -71,7 +71,7 @@ class AscendNPU(AcceleratorProtocol):
             color = generate_color(color_idx)
 
             util = SystemScalar(
-                key=f"npu.{label}.ptc",
+                key=f"npu.{label}.pct",
                 name=f"NPU {label}",
                 chart_name="NPU Utilization (%)",
                 y_min=0,
@@ -81,7 +81,7 @@ class AscendNPU(AcceleratorProtocol):
             scalars.append(util)
 
             hbm_rate = SystemScalar(
-                key=f"npu.{label}.mem.ptc",
+                key=f"npu.{label}.mem.pct",
                 name=f"NPU {label}",
                 chart_name="NPU Memory Allocated (%)",
                 y_min=0,
@@ -112,6 +112,7 @@ class AscendNPU(AcceleratorProtocol):
                 key=f"npu.{label}.power",
                 name=f"NPU {label}",
                 chart_name="NPU Power Usage (W)",
+                y_min=0,
                 color=color,
             )
             scalars.append(power)
@@ -144,21 +145,27 @@ class AscendNPU(AcceleratorProtocol):
             for line in output.split("\n"):
                 if "aicore usage rate" in line.lower():
                     util_str = line.split(":")[-1].strip()
-                    if util_str.isdigit():
+                    try:
                         util_val = float(util_str)
+                    except ValueError:
+                        pass
                 if "hbm usage rate" in line.lower():
                     hbm_str = line.split(":")[-1].strip()
-                    if hbm_str.isdigit():
+                    try:
                         hbm_val = float(hbm_str)
+                    except ValueError:
+                        pass
                 if "hbm capacity" in line.lower():
                     hbm_str = line.split(":")[-1].strip()
-                    if hbm_str.isdigit():
+                    try:
                         hbm_total_mb = float(hbm_str)
+                    except ValueError:
+                        pass
             if not math.isnan(hbm_val) and not math.isnan(hbm_total_mb):
                 hbm_mb = hbm_val / 100 * hbm_total_mb
         return [
-            (f"npu.{label}.ptc", util_val),
-            (f"npu.{label}.mem.ptc", hbm_val),
+            (f"npu.{label}.pct", util_val),
+            (f"npu.{label}.mem.pct", hbm_val),
             (f"npu.{label}.mem.value", hbm_mb),
         ]
 
@@ -273,6 +280,8 @@ class AscendNPU(AcceleratorProtocol):
         for line in output.split("\n"):
             if "hbm capacity" in line.lower():
                 hbm = line.split(":")[-1].strip()
-                if hbm.isdigit():
-                    return {"hbm": str(round(int(hbm) / 1024))}
+                try:
+                    return {"hbm": str(round(float(hbm) / 1024))}
+                except ValueError:
+                    pass
         return None

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/hygon.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/hygon.py
@@ -107,6 +107,7 @@ class HygonDCU(AcceleratorProtocol):
                     key=f"dcu.{idx}.power",
                     name=f"DCU {idx}",
                     chart_name="DCU Power (W)",
+                    y_min=0,
                     color=color,
                 )
             )

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/hygon.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/hygon.py
@@ -116,10 +116,11 @@ class HygonDCU(AcceleratorProtocol):
 
     def collect(self) -> List[CollectResult]:
         results: List[CollectResult] = []
-        results.extend(self._get_utilization())
-        results.extend(self._get_memory())
-        results.extend(self._get_temperature())
-        results.extend(self._get_power())
+        with safe.block(message="Failed to collect Hygon DCU metrics", level="debug"):
+            results.extend(self._get_utilization())
+            results.extend(self._get_memory())
+            results.extend(self._get_temperature())
+            results.extend(self._get_power())
         return results
 
     def _get_utilization(self) -> List[CollectResult]:

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/hygon.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/hygon.py
@@ -1,0 +1,257 @@
+"""
+@author: cunyue
+@file: hygon.py
+@time: 2026/3/31 01:58
+@description: 海光 Hygon DCU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，依赖海光 `hy-smi` 命令及其 JSON 输出。
+- 驱动版本使用 `hy-smi --showdriverversion`，解析包含 `Driver Version` 的行。
+- 静态设备信息使用 `hy-smi --showproductname --json` 的 `cardX -> Card Series`，以及
+  `hy-smi --showmemavailable --json` 的 `cardX -> Available memory size (MiB)`；设备索引按 JSON 遍历顺序映射为 0,1,2...
+- 利用率使用 `hy-smi --showuse --json`，解析 `DCU use (%)`。
+- 显存使用率使用 `hy-smi --showmemuse --json`，解析 `DCU memory use (%)`；显存使用量按比例乘以最大显存 MB。
+- 温度使用 `hy-smi --showtemp --json`，解析 `Temperature (Sensor junction) (C)`；功耗使用
+  `hy-smi --showpower --json`，解析 `Average Graphics Package Power (W)`。
+"""
+
+import json
+import math
+import platform
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class HygonDCU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        hygon_config = next(a for a in shim.accelerators if a.vendor == "hygon")
+        self._indices = hygon_config.device_indices
+        driver, dcu_map = HygonDCU._map_hygon_dcu()
+        self._dcu_map = dcu_map
+        max_mem_mb = 0
+        for idx in self._indices:
+            dcu_id = str(idx)
+            if dcu_id in dcu_map:
+                mem_str = dcu_map[dcu_id].get("memory", "0GB")
+                digits = [c for c in mem_str if c.isdigit()]
+                mem_val = int("".join(digits)) if digits else 0
+                if mem_val * 1024 > max_mem_mb:
+                    max_mem_mb = mem_val * 1024
+        self._max_mem_mb = max_mem_mb
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize Hygon DCU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["HygonDCU", SystemScalars]]:
+        hygon_config = next((a for a in shim.accelerators if a.vendor == "hygon"), None)
+        if hygon_config is None:
+            console.debug("No Hygon DCU monitor config in shim")
+            return None
+        self = cls(shim)
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(self._indices):
+            color = generate_color(color_idx)
+
+            scalars.append(
+                SystemScalar(
+                    key=f"dcu.{idx}.pct",
+                    name=f"DCU {idx}",
+                    chart_name="DCU Utilization (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"dcu.{idx}.mem.pct",
+                    name=f"DCU {idx}",
+                    chart_name="DCU Memory Allocated (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"dcu.{idx}.mem.value",
+                    name=f"DCU {idx}",
+                    chart_name="DCU Memory Allocated (MB)",
+                    y_min=0,
+                    y_max=self._max_mem_mb,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"dcu.{idx}.temp",
+                    name=f"DCU {idx}",
+                    chart_name="DCU Temperature (°C)",
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"dcu.{idx}.power",
+                    name=f"DCU {idx}",
+                    chart_name="DCU Power (W)",
+                    color=color,
+                )
+            )
+
+        console.debug(f"Hygon DCU monitor initialized with {len(self._indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        results.extend(self._get_utilization())
+        results.extend(self._get_memory())
+        results.extend(self._get_temperature())
+        results.extend(self._get_power())
+        return results
+
+    def _get_utilization(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"dcu.{idx}.pct", math.nan))
+        with safe.block(message="Failed to collect Hygon DCU utilization data", level="debug"):
+            output = subprocess.run(["hy-smi", "--showuse", "--json"], capture_output=True, text=True).stdout
+            data = json.loads(output)
+            for idx, (dcu_key, dcu_info) in enumerate(data.items()):
+                if idx in self._indices:
+                    results[self._indices.index(idx)] = (
+                        f"dcu.{idx}.pct",
+                        float(dcu_info["DCU use (%)"]),
+                    )
+        return results
+
+    def _get_memory(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"dcu.{idx}.mem.pct", math.nan))
+            results.append((f"dcu.{idx}.mem.value", math.nan))
+        with safe.block(message="Failed to collect Hygon DCU memory data", level="debug"):
+            output = subprocess.run(["hy-smi", "--showmemuse", "--json"], capture_output=True, text=True).stdout
+            data = json.loads(output)
+            for idx, (dcu_key, dcu_info) in enumerate(data.items()):
+                if idx in self._indices:
+                    rate = float(dcu_info["DCU memory use (%)"])
+                    mb = rate * 0.01 * self._max_mem_mb
+                    idx_pos = self._indices.index(idx)
+                    results[idx_pos * 2] = (f"dcu.{idx}.mem.pct", rate)
+                    results[idx_pos * 2 + 1] = (f"dcu.{idx}.mem.value", mb)
+        return results
+
+    def _get_temperature(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"dcu.{idx}.temp", math.nan))
+        with safe.block(message="Failed to collect Hygon DCU temperature data", level="debug"):
+            output = subprocess.run(["hy-smi", "--showtemp", "--json"], capture_output=True, text=True).stdout
+            data = json.loads(output)
+            for idx, (dcu_key, dcu_info) in enumerate(data.items()):
+                if idx in self._indices:
+                    results[self._indices.index(idx)] = (
+                        f"dcu.{idx}.temp",
+                        float(dcu_info["Temperature (Sensor junction) (C)"]),
+                    )
+        return results
+
+    def _get_power(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"dcu.{idx}.power", math.nan))
+        with safe.block(message="Failed to collect Hygon DCU power data", level="debug"):
+            output = subprocess.run(["hy-smi", "--showpower", "--json"], capture_output=True, text=True).stdout
+            data = json.loads(output)
+            for idx, (dcu_key, dcu_info) in enumerate(data.items()):
+                if idx in self._indices:
+                    results[self._indices.index(idx)] = (
+                        f"dcu.{idx}.power",
+                        float(dcu_info["Average Graphics Package Power (W)"]),
+                    )
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Hygon DCU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"Hygon DCU detection skipped: hy-smi is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+
+        driver, dcu_map = HygonDCU._map_hygon_dcu()
+        if not dcu_map:
+            console.debug("No Hygon DCU detected: hy-smi product/memory queries returned no DCU devices")
+            return None
+
+        devices = []
+        for idx, dcu_id in enumerate(sorted(dcu_map.keys(), key=int)):
+            info = dcu_map[dcu_id]
+            mem_str = info.get("memory", "0GB")
+            digits = [c for c in mem_str if c.isdigit()]
+            mem_val = int("".join(digits)) if digits else 0
+            devices.append(
+                DeviceSnapshot(
+                    index=int(dcu_id),
+                    name=info.get("name", "Hygon DCU"),
+                    memory=mem_val,
+                    memory_unit="GB",
+                )
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} Hygon DCU device(s): {', '.join(names)}")
+        return AcceleratorSnapshot(
+            vendor="hygon",
+            version=driver,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _map_hygon_dcu() -> Tuple[Optional[str], dict]:
+        driver_version = None
+        with safe.block(message="Failed to get Hygon DCU driver version", level="debug"):
+            driver_info = subprocess.run(
+                ["hy-smi", "--showdriverversion"], capture_output=True, check=True, text=True
+            ).stdout
+            for line in driver_info.split("\n"):
+                if "Driver Version" in line:
+                    driver_version = line.split(":")[-1].strip()
+                    break
+
+        dcu_map: Dict[str, dict] = {}
+        with safe.block(message="Failed to map Hygon DCU devices", level="debug"):
+            product_map = json.loads(
+                subprocess.run(
+                    ["hy-smi", "--showproductname", "--json"], capture_output=True, check=True, text=True
+                ).stdout
+            )
+            available_mem_map = json.loads(
+                subprocess.run(
+                    ["hy-smi", "--showmemavailable", "--json"], capture_output=True, check=True, text=True
+                ).stdout
+            )
+
+            for idx, device_id in enumerate(product_map.keys()):
+                product_info = product_map.get(device_id, {})
+                device_name = product_info.get("Card Series", "Unknown")
+                available_info = available_mem_map.get(device_id, {})
+                available_mem = available_info.get("Available memory size (MiB)", "0")
+                total_mem_gb = round(int(available_mem) / 1024)
+                dcu_map[str(idx)] = {"name": device_name, "memory": f"{total_mem_gb}GB"}
+
+        return driver_version, dcu_map

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/iluvatar.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/iluvatar.py
@@ -102,6 +102,7 @@ class IluvatarGPU(AcceleratorProtocol):
                     key=f"gpu.{idx}.power",
                     name=f"GPU {idx}",
                     chart_name="GPU Power (W)",
+                    y_min=0,
                     color=color,
                 )
             )

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/iluvatar.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/iluvatar.py
@@ -1,6 +1,265 @@
 """
 @author: cunyue
 @file: iluvatar.py
-@time: 2026/3/31 01:59
-@description: 天数智芯加速卡信息模块
+@time: 2026/3/31 01:58
+@description: Iluvatar GPU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，依赖天数智芯 `ixsmi` 命令的 CSV 查询输出。
+- 静态信息使用 `ixsmi --query-gpu=index,driver_version,name,memory.total --format=csv`，
+  第一行为表头，后续每行格式为 `index, driver_version, name, memory.total`。
+- `memory.total` 可能以 `MiB` 或 `GiB` 结尾，统一转换为 GB。
+- 动态指标分别使用 `--query-gpu=utilization.gpu|utilization.memory|memory.used|temperature.gpu|board.power.draw`，
+  每个 CSV 输出跳过表头，解析第一列并去掉 `%`、`MiB`、`C`、`W` 单位。
 """
+
+import math
+import platform
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class IluvatarGPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        iluvatar_config = next(a for a in shim.accelerators if a.vendor == "iluvatar")
+        self._indices = iluvatar_config.device_indices
+        _, gpu_map = IluvatarGPU._map_iluvatar_gpu()
+        self._gpu_map = gpu_map
+        max_mem_mb = 0
+        for idx in self._indices:
+            gpu_id = str(idx)
+            if gpu_id in gpu_map:
+                mem = int(gpu_map[gpu_id].get("memory", 0))
+                if mem * 1024 > max_mem_mb:
+                    max_mem_mb = mem * 1024
+        self._max_mem_mb = max_mem_mb
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize Iluvatar GPU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["IluvatarGPU", SystemScalars]]:
+        iluvatar_config = next((a for a in shim.accelerators if a.vendor == "iluvatar"), None)
+        if iluvatar_config is None:
+            console.debug("No Iluvatar monitor config in shim")
+            return None
+        self = cls(shim)
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(self._indices):
+            color = generate_color(color_idx)
+
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.pct",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Utilization (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.mem.pct",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Memory Allocated (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.mem.value",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Memory Allocated (MB)",
+                    y_min=0,
+                    y_max=self._max_mem_mb,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.temp",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Temperature (°C)",
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.power",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Power (W)",
+                    color=color,
+                )
+            )
+
+        console.debug(f"Iluvatar monitor initialized with {len(self._indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        indices = [str(i) for i in self._indices]
+
+        for mid in indices:
+            results.append((f"gpu.{mid}.pct", math.nan))
+            results.append((f"gpu.{mid}.mem.pct", math.nan))
+            results.append((f"gpu.{mid}.mem.value", math.nan))
+            results.append((f"gpu.{mid}.temp", math.nan))
+            results.append((f"gpu.{mid}.power", math.nan))
+
+        results = self._collect_utilization(indices, results)
+        results = self._collect_memory(indices, results)
+        results = self._collect_temperature(indices, results)
+        results = self._collect_power(indices, results)
+
+        return results
+
+    def _collect_utilization(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+        with safe.block(message="Failed to collect Iluvatar GPU utilization", level="debug"):
+            gpu_utils = self._run_ixsmi_query("utilization.gpu")
+            for i, val in enumerate(gpu_utils):
+                if i < len(indices):
+                    pos = i * 5
+                    results[pos] = (f"gpu.{indices[i]}.pct", val)
+        return results
+
+    def _collect_memory(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+        with safe.block(message="Failed to collect Iluvatar GPU memory", level="debug"):
+            mem_rates = self._run_ixsmi_query("utilization.memory")
+            mem_used = self._run_ixsmi_query("memory.used")
+            for i in range(min(len(indices), len(mem_rates), len(mem_used))):
+                pos = i * 5 + 1
+                results[pos] = (f"gpu.{indices[i]}.mem.pct", mem_rates[i])
+                results[pos + 1] = (f"gpu.{indices[i]}.mem.value", mem_used[i])
+        return results
+
+    def _collect_temperature(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+        with safe.block(message="Failed to collect Iluvatar GPU temperature", level="debug"):
+            temps = self._run_ixsmi_query("temperature.gpu")
+            for i, val in enumerate(temps):
+                if i < len(indices):
+                    pos = i * 5 + 3
+                    results[pos] = (f"gpu.{indices[i]}.temp", val)
+        return results
+
+    def _collect_power(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+        with safe.block(message="Failed to collect Iluvatar GPU power", level="debug"):
+            powers = self._run_ixsmi_query("board.power.draw")
+            for i, val in enumerate(powers):
+                if i < len(indices):
+                    pos = i * 5 + 4
+                    results[pos] = (f"gpu.{indices[i]}.power", val)
+        return results
+
+    @staticmethod
+    def _run_ixsmi_query(query_type: str) -> List[float]:
+        output = subprocess.run(
+            ["ixsmi", f"--query-gpu={query_type}", "--format=csv"],
+            capture_output=True,
+            check=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout
+        lines = output.strip().split("\n")
+        results: List[float] = []
+        for line in lines[1:]:
+            value_str = line.strip().split(",")[0].strip()
+            if query_type == "utilization.gpu" or query_type == "utilization.memory":
+                value = float(value_str.replace("%", "").strip())
+            elif query_type == "temperature.gpu":
+                value = float(value_str.replace("C", "").strip())
+            elif query_type == "memory.used":
+                value = float(value_str.replace("MiB", "").strip())
+            elif query_type == "board.power.draw":
+                value = float(value_str.replace("W", "").strip())
+            else:
+                value = 0.0
+            results.append(value)
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Iluvatar GPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"Iluvatar GPU detection skipped: ixsmi is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+
+        driver, gpu_map = IluvatarGPU._map_iluvatar_gpu()
+        if not gpu_map:
+            console.debug("No Iluvatar GPU detected: ixsmi query returned no GPU rows")
+            return None
+
+        devices = []
+        for gpu_id in sorted(gpu_map.keys(), key=int):
+            info = gpu_map[gpu_id]
+            devices.append(
+                DeviceSnapshot(
+                    index=int(gpu_id),
+                    name=info.get("name", "Iluvatar GPU"),
+                    memory=int(info.get("memory", 0)),
+                    memory_unit="GB",
+                )
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} Iluvatar GPU(s): {', '.join(names)}")
+        return AcceleratorSnapshot(
+            vendor="iluvatar",
+            version=driver,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _map_iluvatar_gpu() -> Tuple[Optional[str], dict]:
+        output_str = None
+        with safe.block(message="Failed to query Iluvatar GPU info via ixsmi", level="debug"):
+            output_str = subprocess.run(
+                ["ixsmi", "--query-gpu=index,driver_version,name,memory.total", "--format=csv"],
+                capture_output=True,
+                check=True,
+                text=True,
+                encoding="utf-8",
+            ).stdout
+
+        if output_str is None:
+            return None, {}
+
+        lines = output_str.strip().split("\n")
+        if len(lines) < 2:
+            return None, {}
+
+        driver = None
+        gpu_map: Dict[str, dict] = {}
+
+        for line in lines[1:]:
+            parts = [part.strip() for part in line.split(",")]
+            if len(parts) >= 4:
+                gpu_id = parts[0]
+                if driver is None:
+                    driver = parts[1]
+                gpu_name = parts[2]
+                gpu_memory_str = parts[3]
+                if "MiB" in gpu_memory_str:
+                    memory_gb = str(int(gpu_memory_str.replace(" MiB", "").strip()) // 1024)
+                elif "GiB" in gpu_memory_str:
+                    memory_gb = str(int(gpu_memory_str.replace(" GiB", "").strip()))
+                else:
+                    memory_gb = gpu_memory_str
+                gpu_map[gpu_id] = {"name": gpu_name, "memory": memory_gb}
+
+        return driver, gpu_map

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/iluvatar.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/iluvatar.py
@@ -111,57 +111,57 @@ class IluvatarGPU(AcceleratorProtocol):
 
     def collect(self) -> List[CollectResult]:
         results: List[CollectResult] = []
-        indices = [str(i) for i in self._indices]
-
-        for mid in indices:
-            results.append((f"gpu.{mid}.pct", math.nan))
-            results.append((f"gpu.{mid}.mem.pct", math.nan))
-            results.append((f"gpu.{mid}.mem.value", math.nan))
-            results.append((f"gpu.{mid}.temp", math.nan))
-            results.append((f"gpu.{mid}.power", math.nan))
-
-        results = self._collect_utilization(indices, results)
-        results = self._collect_memory(indices, results)
-        results = self._collect_temperature(indices, results)
-        results = self._collect_power(indices, results)
-
+        with safe.block(message="Failed to collect Iluvatar GPU metrics", level="debug"):
+            results.extend(self._collect_utilization())
+            results.extend(self._collect_memory())
+            results.extend(self._collect_temperature())
+            results.extend(self._collect_power())
         return results
 
-    def _collect_utilization(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+    def _collect_utilization(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.pct", math.nan))
         with safe.block(message="Failed to collect Iluvatar GPU utilization", level="debug"):
             gpu_utils = self._run_ixsmi_query("utilization.gpu")
             for i, val in enumerate(gpu_utils):
-                if i < len(indices):
-                    pos = i * 5
-                    results[pos] = (f"gpu.{indices[i]}.pct", val)
+                if i < len(self._indices):
+                    results[i] = (f"gpu.{self._indices[i]}.pct", val)
         return results
 
-    def _collect_memory(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+    def _collect_memory(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.mem.pct", math.nan))
+            results.append((f"gpu.{idx}.mem.value", math.nan))
         with safe.block(message="Failed to collect Iluvatar GPU memory", level="debug"):
             mem_rates = self._run_ixsmi_query("utilization.memory")
             mem_used = self._run_ixsmi_query("memory.used")
-            for i in range(min(len(indices), len(mem_rates), len(mem_used))):
-                pos = i * 5 + 1
-                results[pos] = (f"gpu.{indices[i]}.mem.pct", mem_rates[i])
-                results[pos + 1] = (f"gpu.{indices[i]}.mem.value", mem_used[i])
+            for i in range(min(len(self._indices), len(mem_rates), len(mem_used))):
+                results[i * 2] = (f"gpu.{self._indices[i]}.mem.pct", mem_rates[i])
+                results[i * 2 + 1] = (f"gpu.{self._indices[i]}.mem.value", mem_used[i])
         return results
 
-    def _collect_temperature(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+    def _collect_temperature(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.temp", math.nan))
         with safe.block(message="Failed to collect Iluvatar GPU temperature", level="debug"):
             temps = self._run_ixsmi_query("temperature.gpu")
             for i, val in enumerate(temps):
-                if i < len(indices):
-                    pos = i * 5 + 3
-                    results[pos] = (f"gpu.{indices[i]}.temp", val)
+                if i < len(self._indices):
+                    results[i] = (f"gpu.{self._indices[i]}.temp", val)
         return results
 
-    def _collect_power(self, indices: List[str], results: List[CollectResult]) -> List[CollectResult]:
+    def _collect_power(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.power", math.nan))
         with safe.block(message="Failed to collect Iluvatar GPU power", level="debug"):
             powers = self._run_ixsmi_query("board.power.draw")
             for i, val in enumerate(powers):
-                if i < len(indices):
-                    pos = i * 5 + 4
-                    results[pos] = (f"gpu.{indices[i]}.power", val)
+                if i < len(self._indices):
+                    results[i] = (f"gpu.{self._indices[i]}.power", val)
         return results
 
     @staticmethod

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
@@ -54,7 +54,7 @@ class KunlunxinXPU(AcceleratorProtocol):
 
             scalars.append(
                 SystemScalar(
-                    key=f"xpu.{idx}.ptc",
+                    key=f"xpu.{idx}.pct",
                     name=f"XPU {idx}",
                     chart_name="XPU Utilization (%)",
                     y_min=0,
@@ -64,7 +64,7 @@ class KunlunxinXPU(AcceleratorProtocol):
             )
             scalars.append(
                 SystemScalar(
-                    key=f"xpu.{idx}.mem.ptc",
+                    key=f"xpu.{idx}.mem.pct",
                     name=f"XPU {idx}",
                     chart_name="XPU Memory Allocated (%)",
                     y_min=0,
@@ -85,6 +85,7 @@ class KunlunxinXPU(AcceleratorProtocol):
                     key=f"xpu.{idx}.power",
                     name=f"XPU {idx}",
                     chart_name="XPU Power (W)",
+                    y_min=0,
                     color=color,
                 )
             )
@@ -109,22 +110,31 @@ class KunlunxinXPU(AcceleratorProtocol):
                     mem_used_str = parts[17]
                     temp_str = parts[4]
                     power_str = parts[8]
-                    if util_str.isdigit():
-                        metrics_by_id[xpu_id]["ptc"] = float(util_str)
+                    try:
+                        metrics_by_id[xpu_id]["pct"] = float(util_str)
+                    except ValueError:
+                        pass
                     xpu_info = self._xpu_map.get(xpu_id_str, {})
                     total_mb = int(xpu_info.get("memory", 0)) * 1024
-                    if mem_used_str.isdigit() and total_mb > 0:
-                        metrics_by_id[xpu_id]["mem.ptc"] = float(mem_used_str) / total_mb * 100
-                    if temp_str.isdigit():
+                    try:
+                        if total_mb > 0:
+                            metrics_by_id[xpu_id]["mem.pct"] = float(mem_used_str) / total_mb * 100
+                    except ValueError:
+                        pass
+                    try:
                         metrics_by_id[xpu_id]["temp"] = float(temp_str)
-                    if power_str.isdigit():
+                    except ValueError:
+                        pass
+                    try:
                         metrics_by_id[xpu_id]["power"] = float(power_str)
+                    except ValueError:
+                        pass
 
             results: List[CollectResult] = []
             for idx in self._indices:
                 m = metrics_by_id[idx]
-                results.append((f"xpu.{idx}.ptc", m.get("ptc", math.nan)))
-                results.append((f"xpu.{idx}.mem.ptc", m.get("mem.ptc", math.nan)))
+                results.append((f"xpu.{idx}.pct", m.get("pct", math.nan)))
+                results.append((f"xpu.{idx}.mem.pct", m.get("mem.pct", math.nan)))
                 results.append((f"xpu.{idx}.temp", m.get("temp", math.nan)))
                 results.append((f"xpu.{idx}.power", m.get("power", math.nan)))
             return results
@@ -176,7 +186,7 @@ class KunlunxinXPU(AcceleratorProtocol):
             with safe.block(message="Failed to parse Kunlunxin XPU info row", level="debug"):
                 if len(parts) >= 23:
                     xpu_id = parts[1]
-                    name = (parts[21][1:] + " " + parts[22][:-1]).strip()
+                    name = f"{parts[21]} {parts[22]}".strip().strip("()")
                     memory = int(parts[18]) // 1024
                     xpu_map[xpu_id] = {"name": name, "memory": str(memory)}
 

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
@@ -1,6 +1,195 @@
 """
 @author: cunyue
 @file: kunlunxin.py
-@time: 2026/3/31 02:04
-@description: 昆仑芯加速器相关信息采集和监控
+@time: 2026/3/31 01:58
+@description: 昆仑芯 Kunlunxin XPU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，依赖昆仑芯 `xpu-smi` 文本输出。
+- 驱动版本使用 `xpu-smi -q`，解析包含 `Driver Version` 的行，取冒号后的值。
+- 设备和动态指标均使用 `xpu-smi -m` 的空白分隔表格。当前解析依赖字段位置：
+  第 2 列为 XPU ID（index 1），第 5 列为温度（index 4），第 9 列为功耗（index 8），
+  第 18 列为已用显存 MB（index 17），第 19 列为总显存 MB（index 18），第 20 列为利用率（index 19），
+  第 22/23 列拼接为设备名称（index 21/22）。
+- 显存使用率按 `used_mb / total_mb * 100` 计算；旧版未提供独立显存使用量曲线，当前沿用该行为。
 """
+
+import math
+import platform
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class KunlunxinXPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        kunlun_config = next(a for a in shim.accelerators if a.vendor == "kunlunxin")
+        self._indices = kunlun_config.device_indices
+        driver, xpu_map = KunlunxinXPU._map_xpu()
+        self._xpu_map = xpu_map
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize Kunlunxin XPU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["KunlunxinXPU", SystemScalars]]:
+        kunlun_config = next((a for a in shim.accelerators if a.vendor == "kunlunxin"), None)
+        if kunlun_config is None:
+            console.debug("No Kunlunxin XPU monitor config in shim")
+            return None
+        self = cls(shim)
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(self._indices):
+            color = generate_color(color_idx)
+
+            scalars.append(
+                SystemScalar(
+                    key=f"xpu.{idx}.ptc",
+                    name=f"XPU {idx}",
+                    chart_name="XPU Utilization (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"xpu.{idx}.mem.ptc",
+                    name=f"XPU {idx}",
+                    chart_name="XPU Memory Allocated (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"xpu.{idx}.temp",
+                    name=f"XPU {idx}",
+                    chart_name="XPU Temperature (°C)",
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"xpu.{idx}.power",
+                    name=f"XPU {idx}",
+                    chart_name="XPU Power (W)",
+                    color=color,
+                )
+            )
+
+        console.debug(f"Kunlunxin XPU monitor initialized with {len(self._indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"xpu.{idx}.ptc", math.nan))
+            results.append((f"xpu.{idx}.mem.ptc", math.nan))
+            results.append((f"xpu.{idx}.temp", math.nan))
+            results.append((f"xpu.{idx}.power", math.nan))
+
+        with safe.block(message="Failed to collect Kunlunxin XPU metrics", level="debug"):
+            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
+            index = 0
+            for line in output.split("\n"):
+                parts = line.split()
+                with safe.block(message="Failed to parse Kunlunxin XPU row data", level="debug"):
+                    if len(parts) < 23:
+                        continue
+                    xpu_id_str = parts[1]
+                    if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
+                        continue
+                    util_str = parts[19]
+                    mem_used_str = parts[17]
+                    temp_str = parts[4]
+                    power_str = parts[8]
+                    pos = index * 4
+                    if util_str.isdigit():
+                        results[pos] = (f"xpu.{xpu_id_str}.ptc", float(util_str))
+                    xpu_info = self._xpu_map.get(xpu_id_str, {})
+                    total_mb = int(xpu_info.get("memory", 0)) * 1024
+                    if mem_used_str.isdigit() and total_mb > 0:
+                        results[pos + 1] = (
+                            f"xpu.{xpu_id_str}.mem.ptc",
+                            float(mem_used_str) / total_mb * 100,
+                        )
+                    if temp_str.isdigit():
+                        results[pos + 2] = (f"xpu.{xpu_id_str}.temp", float(temp_str))
+                    if power_str.isdigit():
+                        results[pos + 3] = (f"xpu.{xpu_id_str}.power", float(power_str))
+                    index += 1
+
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Kunlunxin XPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"Kunlunxin XPU detection skipped: xpu-smi is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+
+        driver, xpu_map = KunlunxinXPU._map_xpu()
+        if not xpu_map:
+            console.debug("No Kunlunxin XPU detected: xpu-smi -m returned no parseable XPU rows")
+            return None
+
+        devices = []
+        for xpu_id in sorted(xpu_map.keys(), key=int):
+            info = xpu_map[xpu_id]
+            devices.append(
+                DeviceSnapshot(
+                    index=int(xpu_id),
+                    name=info.get("name", "Kunlunxin XPU"),
+                    memory=int(info.get("memory", 0)),
+                    memory_unit="GB",
+                )
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} Kunlunxin XPU device(s): {', '.join(names)}")
+        return AcceleratorSnapshot(
+            vendor="kunlunxin",
+            version=driver,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _map_xpu() -> Tuple[Optional[str], dict]:
+        output = subprocess.run(["xpu-smi", "-m"], capture_output=True, check=True, text=True).stdout
+
+        driver = KunlunxinXPU._get_xpu_driver()
+        xpu_map: Dict[str, dict] = {}
+
+        for line in output.split("\n"):
+            parts = line.split()
+            with safe.block(message="Failed to parse Kunlunxin XPU info row", level="debug"):
+                if len(parts) >= 23:
+                    xpu_id = parts[1]
+                    name = (parts[21][1:] + " " + parts[22][:-1]).strip()
+                    memory = int(parts[18]) // 1024
+                    xpu_map[xpu_id] = {"name": name, "memory": str(memory)}
+
+        return driver, xpu_map
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get Kunlunxin XPU driver version")
+    def _get_xpu_driver() -> Optional[str]:
+        output = subprocess.run(["xpu-smi", "-q"], capture_output=True, check=True, text=True).stdout
+        for line in output.split("\n"):
+            if "Driver Version" in line:
+                return line.split(":")[-1].strip()
+        return None

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
@@ -93,19 +93,8 @@ class KunlunxinXPU(AcceleratorProtocol):
         return self, scalars
 
     def collect(self) -> List[CollectResult]:
-        results: List[CollectResult] = []
         with safe.block(message="Failed to collect Kunlunxin XPU metrics", level="debug"):
-            results.extend(self._collect_utilization())
-            results.extend(self._collect_memory())
-            results.extend(self._collect_temperature())
-            results.extend(self._collect_power())
-        return results
-
-    def _collect_utilization(self) -> List[CollectResult]:
-        results: List[CollectResult] = []
-        for idx in self._indices:
-            results.append((f"xpu.{idx}.ptc", math.nan))
-        with safe.block(message="Failed to collect Kunlunxin XPU utilization", level="debug"):
+            metrics_by_id: Dict[int, Dict[str, float]] = {idx: {} for idx in self._indices}
             output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
             for line in output.split("\n"):
                 parts = line.split()
@@ -114,70 +103,32 @@ class KunlunxinXPU(AcceleratorProtocol):
                 xpu_id_str = parts[1]
                 if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
                     continue
-                util_str = parts[19]
-                if util_str.isdigit():
-                    idx_pos = self._indices.index(int(xpu_id_str))
-                    results[idx_pos] = (f"xpu.{xpu_id_str}.ptc", float(util_str))
-        return results
+                xpu_id = int(xpu_id_str)
+                with safe.block(message="Failed to parse Kunlunxin XPU row data", level="debug"):
+                    util_str = parts[19]
+                    mem_used_str = parts[17]
+                    temp_str = parts[4]
+                    power_str = parts[8]
+                    if util_str.isdigit():
+                        metrics_by_id[xpu_id]["ptc"] = float(util_str)
+                    xpu_info = self._xpu_map.get(xpu_id_str, {})
+                    total_mb = int(xpu_info.get("memory", 0)) * 1024
+                    if mem_used_str.isdigit() and total_mb > 0:
+                        metrics_by_id[xpu_id]["mem.ptc"] = float(mem_used_str) / total_mb * 100
+                    if temp_str.isdigit():
+                        metrics_by_id[xpu_id]["temp"] = float(temp_str)
+                    if power_str.isdigit():
+                        metrics_by_id[xpu_id]["power"] = float(power_str)
 
-    def _collect_memory(self) -> List[CollectResult]:
-        results: List[CollectResult] = []
-        for idx in self._indices:
-            results.append((f"xpu.{idx}.mem.ptc", math.nan))
-        with safe.block(message="Failed to collect Kunlunxin XPU memory", level="debug"):
-            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
-            for line in output.split("\n"):
-                parts = line.split()
-                if len(parts) < 23:
-                    continue
-                xpu_id_str = parts[1]
-                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
-                    continue
-                mem_used_str = parts[17]
-                xpu_info = self._xpu_map.get(xpu_id_str, {})
-                total_mb = int(xpu_info.get("memory", 0)) * 1024
-                if mem_used_str.isdigit() and total_mb > 0:
-                    idx_pos = self._indices.index(int(xpu_id_str))
-                    results[idx_pos] = (f"xpu.{xpu_id_str}.mem.ptc", float(mem_used_str) / total_mb * 100)
-        return results
-
-    def _collect_temperature(self) -> List[CollectResult]:
-        results: List[CollectResult] = []
-        for idx in self._indices:
-            results.append((f"xpu.{idx}.temp", math.nan))
-        with safe.block(message="Failed to collect Kunlunxin XPU temperature", level="debug"):
-            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
-            for line in output.split("\n"):
-                parts = line.split()
-                if len(parts) < 23:
-                    continue
-                xpu_id_str = parts[1]
-                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
-                    continue
-                temp_str = parts[4]
-                if temp_str.isdigit():
-                    idx_pos = self._indices.index(int(xpu_id_str))
-                    results[idx_pos] = (f"xpu.{xpu_id_str}.temp", float(temp_str))
-        return results
-
-    def _collect_power(self) -> List[CollectResult]:
-        results: List[CollectResult] = []
-        for idx in self._indices:
-            results.append((f"xpu.{idx}.power", math.nan))
-        with safe.block(message="Failed to collect Kunlunxin XPU power", level="debug"):
-            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
-            for line in output.split("\n"):
-                parts = line.split()
-                if len(parts) < 23:
-                    continue
-                xpu_id_str = parts[1]
-                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
-                    continue
-                power_str = parts[8]
-                if power_str.isdigit():
-                    idx_pos = self._indices.index(int(xpu_id_str))
-                    results[idx_pos] = (f"xpu.{xpu_id_str}.power", float(power_str))
-        return results
+            results: List[CollectResult] = []
+            for idx in self._indices:
+                m = metrics_by_id[idx]
+                results.append((f"xpu.{idx}.ptc", m.get("ptc", math.nan)))
+                results.append((f"xpu.{idx}.mem.ptc", m.get("mem.ptc", math.nan)))
+                results.append((f"xpu.{idx}.temp", m.get("temp", math.nan)))
+                results.append((f"xpu.{idx}.power", m.get("power", math.nan)))
+            return results
+        return []
 
     @staticmethod
     @safe.decorator(level="debug", message="Failed to get Kunlunxin XPU info")

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/kunlunxin.py
@@ -94,43 +94,89 @@ class KunlunxinXPU(AcceleratorProtocol):
 
     def collect(self) -> List[CollectResult]:
         results: List[CollectResult] = []
+        with safe.block(message="Failed to collect Kunlunxin XPU metrics", level="debug"):
+            results.extend(self._collect_utilization())
+            results.extend(self._collect_memory())
+            results.extend(self._collect_temperature())
+            results.extend(self._collect_power())
+        return results
+
+    def _collect_utilization(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
         for idx in self._indices:
             results.append((f"xpu.{idx}.ptc", math.nan))
-            results.append((f"xpu.{idx}.mem.ptc", math.nan))
-            results.append((f"xpu.{idx}.temp", math.nan))
-            results.append((f"xpu.{idx}.power", math.nan))
-
-        with safe.block(message="Failed to collect Kunlunxin XPU metrics", level="debug"):
+        with safe.block(message="Failed to collect Kunlunxin XPU utilization", level="debug"):
             output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
-            index = 0
             for line in output.split("\n"):
                 parts = line.split()
-                with safe.block(message="Failed to parse Kunlunxin XPU row data", level="debug"):
-                    if len(parts) < 23:
-                        continue
-                    xpu_id_str = parts[1]
-                    if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
-                        continue
-                    util_str = parts[19]
-                    mem_used_str = parts[17]
-                    temp_str = parts[4]
-                    power_str = parts[8]
-                    pos = index * 4
-                    if util_str.isdigit():
-                        results[pos] = (f"xpu.{xpu_id_str}.ptc", float(util_str))
-                    xpu_info = self._xpu_map.get(xpu_id_str, {})
-                    total_mb = int(xpu_info.get("memory", 0)) * 1024
-                    if mem_used_str.isdigit() and total_mb > 0:
-                        results[pos + 1] = (
-                            f"xpu.{xpu_id_str}.mem.ptc",
-                            float(mem_used_str) / total_mb * 100,
-                        )
-                    if temp_str.isdigit():
-                        results[pos + 2] = (f"xpu.{xpu_id_str}.temp", float(temp_str))
-                    if power_str.isdigit():
-                        results[pos + 3] = (f"xpu.{xpu_id_str}.power", float(power_str))
-                    index += 1
+                if len(parts) < 23:
+                    continue
+                xpu_id_str = parts[1]
+                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
+                    continue
+                util_str = parts[19]
+                if util_str.isdigit():
+                    idx_pos = self._indices.index(int(xpu_id_str))
+                    results[idx_pos] = (f"xpu.{xpu_id_str}.ptc", float(util_str))
+        return results
 
+    def _collect_memory(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"xpu.{idx}.mem.ptc", math.nan))
+        with safe.block(message="Failed to collect Kunlunxin XPU memory", level="debug"):
+            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
+            for line in output.split("\n"):
+                parts = line.split()
+                if len(parts) < 23:
+                    continue
+                xpu_id_str = parts[1]
+                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
+                    continue
+                mem_used_str = parts[17]
+                xpu_info = self._xpu_map.get(xpu_id_str, {})
+                total_mb = int(xpu_info.get("memory", 0)) * 1024
+                if mem_used_str.isdigit() and total_mb > 0:
+                    idx_pos = self._indices.index(int(xpu_id_str))
+                    results[idx_pos] = (f"xpu.{xpu_id_str}.mem.ptc", float(mem_used_str) / total_mb * 100)
+        return results
+
+    def _collect_temperature(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"xpu.{idx}.temp", math.nan))
+        with safe.block(message="Failed to collect Kunlunxin XPU temperature", level="debug"):
+            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
+            for line in output.split("\n"):
+                parts = line.split()
+                if len(parts) < 23:
+                    continue
+                xpu_id_str = parts[1]
+                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
+                    continue
+                temp_str = parts[4]
+                if temp_str.isdigit():
+                    idx_pos = self._indices.index(int(xpu_id_str))
+                    results[idx_pos] = (f"xpu.{xpu_id_str}.temp", float(temp_str))
+        return results
+
+    def _collect_power(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"xpu.{idx}.power", math.nan))
+        with safe.block(message="Failed to collect Kunlunxin XPU power", level="debug"):
+            output = subprocess.run(["xpu-smi", "-m"], capture_output=True, text=True).stdout
+            for line in output.split("\n"):
+                parts = line.split()
+                if len(parts) < 23:
+                    continue
+                xpu_id_str = parts[1]
+                if not xpu_id_str.isdigit() or int(xpu_id_str) not in self._indices:
+                    continue
+                power_str = parts[8]
+                if power_str.isdigit():
+                    idx_pos = self._indices.index(int(xpu_id_str))
+                    results[idx_pos] = (f"xpu.{xpu_id_str}.power", float(power_str))
         return results
 
     @staticmethod

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
@@ -113,10 +113,11 @@ class MetaXGPU(AcceleratorProtocol):
 
     def collect(self) -> List[CollectResult]:
         results: List[CollectResult] = []
-        results.extend(self._get_utilization())
-        results.extend(self._get_memory())
-        results.extend(self._get_temperature())
-        results.extend(self._get_power())
+        with safe.block(message="Failed to collect MetaX GPU metrics", level="debug"):
+            results.extend(self._get_utilization())
+            results.extend(self._get_memory())
+            results.extend(self._get_temperature())
+            results.extend(self._get_power())
         return results
 
     def _get_utilization(self) -> List[CollectResult]:

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
@@ -1,6 +1,253 @@
 """
 @author: cunyue
 @file: metax.py
-@time: 2026/3/31 01:59
-@description: 沐曦计算加速卡信息模块
+@time: 2026/3/31 01:57
+@description: MetaX GPU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，依赖沐曦 `mx-smi` 命令输出文本。
+- 静态信息使用无参数 `mx-smi`：包含 `mx-smi` 的行末为驱动版本；包含 `MACA` 的行为 MACA 版本；
+  包含 `MetaX` 且不含 `Management` 的行为设备型号；包含 `MiB` 的显存行形如 `used/total MiB`，
+  解析 `/` 后的 total 并转换为 GB。
+- 利用率使用 `mx-smi --show-usage`，解析同时包含 `GPU` 和 `%` 的行，倒数第二列为利用率。
+- 显存使用使用 `mx-smi --show-memory`，解析 `vis_vram total` 与 `vis_vram used` 行。
+- 温度使用 `mx-smi --show-temperature` 的 `hotspot` 行；功耗使用 `mx-smi --show-board-power`
+  中同时包含 `Total` 和 `W` 的行，均取倒数第二列数值。
 """
+
+import math
+import platform
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class MetaXGPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        metax_config = next(a for a in shim.accelerators if a.vendor == "metax")
+        self._indices = metax_config.device_indices
+        driver, maca, gpu_map = MetaXGPU._map_metax_gpu()
+        self._gpu_map = gpu_map
+        max_mem_mb = 0
+        for idx in self._indices:
+            mem = gpu_map.get(idx, {}).get("memory", 0)
+            if isinstance(mem, str):
+                mem = int(mem)
+            if mem * 1024 > max_mem_mb:
+                max_mem_mb = mem * 1024
+        self._max_mem_mb = max_mem_mb
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize MetaX GPU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["MetaXGPU", SystemScalars]]:
+        metax_config = next((a for a in shim.accelerators if a.vendor == "metax"), None)
+        if metax_config is None:
+            console.debug("No MetaX monitor config in shim")
+            return None
+        self = cls(shim)
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(self._indices):
+            color = generate_color(color_idx)
+
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.pct",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Utilization (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.mem.pct",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Memory Allocated (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.mem.value",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Memory Allocated (MB)",
+                    y_min=0,
+                    y_max=self._max_mem_mb,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.temp",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Temperature (°C)",
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.power",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Power (W)",
+                    color=color,
+                )
+            )
+
+        console.debug(f"MetaX monitor initialized with {len(self._indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        results.extend(self._get_utilization())
+        results.extend(self._get_memory())
+        results.extend(self._get_temperature())
+        results.extend(self._get_power())
+        return results
+
+    def _get_utilization(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.pct", math.nan))
+        with safe.block(message="Failed to collect MetaX GPU utilization data", level="debug"):
+            output = subprocess.run(["mx-smi", "--show-usage"], capture_output=True, check=True, text=True).stdout
+            index = 0
+            for line in output.split("\n"):
+                if "GPU" in line and "%" in line:
+                    parts = [item for item in line.split(" ") if item != ""]
+                    val = float(parts[-2]) if len(parts) >= 2 else math.nan
+                    if index < len(results):
+                        results[index] = (f"gpu.{self._indices[index]}.pct", val)
+                    index += 1
+        return results
+
+    def _get_memory(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.mem.pct", math.nan))
+            results.append((f"gpu.{idx}.mem.value", math.nan))
+        with safe.block(message="Failed to collect MetaX GPU memory data", level="debug"):
+            output = subprocess.run(["mx-smi", "--show-memory"], capture_output=True, text=True).stdout
+            gpu_mem_total = None
+            index = 0
+            for line in output.split("\n"):
+                if "vis_vram total" in line:
+                    gpu_mem_total = float(line.split(" ")[-2])
+                if "vis_vram used" in line and gpu_mem_total is not None:
+                    gpu_mem_used = float(line.split(" ")[-2])
+                    pct = gpu_mem_used / gpu_mem_total * 100 if gpu_mem_total > 0 else math.nan
+                    mb = gpu_mem_used / 1024
+                    if index < len(self._indices):
+                        pos = index * 2
+                        results[pos] = (f"gpu.{self._indices[index]}.mem.pct", pct)
+                        results[pos + 1] = (f"gpu.{self._indices[index]}.mem.value", mb)
+                    index += 1
+                    gpu_mem_total = None
+        return results
+
+    def _get_temperature(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.temp", math.nan))
+        with safe.block(message="Failed to collect MetaX GPU temperature data", level="debug"):
+            output = subprocess.run(["mx-smi", "--show-temperature"], capture_output=True, check=True, text=True).stdout
+            index = 0
+            for line in output.split("\n"):
+                if "hotspot" in line:
+                    parts = line.split(" ")
+                    val = float(parts[-2]) if len(parts) >= 2 else math.nan
+                    if index < len(results):
+                        results[index] = (f"gpu.{self._indices[index]}.temp", val)
+                    index += 1
+        return results
+
+    def _get_power(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.power", math.nan))
+        with safe.block(message="Failed to collect MetaX GPU power data", level="debug"):
+            output = subprocess.run(["mx-smi", "--show-board-power"], capture_output=True, check=True, text=True).stdout
+            index = 0
+            for line in output.split("\n"):
+                if "Total" in line and "W" in line:
+                    parts = [item for item in line.split(" ") if item != ""]
+                    val = float(parts[-2]) if len(parts) >= 2 else math.nan
+                    if index < len(results):
+                        results[index] = (f"gpu.{self._indices[index]}.power", val)
+                    index += 1
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get MetaX GPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"MetaX GPU detection skipped: mx-smi is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+
+        driver, maca_version, gpu_map = MetaXGPU._map_metax_gpu()
+        if not gpu_map:
+            console.debug("No MetaX GPU detected: mx-smi output did not include MetaX device rows")
+            return None
+
+        devices = []
+        for gpu_id in sorted(gpu_map.keys()):
+            info = gpu_map[gpu_id]
+            devices.append(
+                DeviceSnapshot(
+                    index=int(gpu_id),
+                    name=info.get("name", "MetaX GPU"),
+                    memory=int(info.get("memory", 0)),
+                    memory_unit="GB",
+                )
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} MetaX GPU(s): {', '.join(names)}")
+        return AcceleratorSnapshot(
+            vendor="metax",
+            version=driver,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _map_metax_gpu() -> Tuple[Optional[str], Optional[str], Dict[int, dict]]:
+        output_str = subprocess.run(["mx-smi"], capture_output=True, check=True, text=True).stdout
+
+        driver = None
+        maca_version = None
+        gpu_map: Dict[int, dict] = {}
+        index = 0
+
+        for line in output_str.split("\n"):
+            if "mx-smi" in line:
+                driver = line.split(" ")[-1]
+            if "MACA" in line:
+                maca_version = line.split(" ")[3]
+            elif "MetaX" in line and "Management" not in line:
+                parts = [item for item in line.split(" ") if item != ""]
+                if len(parts) >= 4:
+                    gpu_map[index] = {"name": parts[3]}
+            elif "MiB" in line and index in gpu_map:
+                with safe.block(message="Failed to parse MetaX GPU memory info", level="debug"):
+                    parts = [item for item in line.split(" ") if item != ""]
+                    if len(parts) >= 4:
+                        gpu_map[index]["memory"] = int(parts[-4].split("/")[-1]) // 1024
+                        index += 1
+
+        return driver, maca_version, gpu_map

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
@@ -151,7 +151,7 @@ class MetaXGPU(AcceleratorProtocol):
                 if "vis_vram used" in line and gpu_mem_total is not None:
                     gpu_mem_used = float(line.split(" ")[-2])
                     pct = gpu_mem_used / gpu_mem_total * 100 if gpu_mem_total > 0 else math.nan
-                    mb = gpu_mem_used / 1024
+                    mb = gpu_mem_used
                     if index < len(self._indices):
                         pos = index * 2
                         results[pos] = (f"gpu.{self._indices[index]}.mem.pct", pct)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/metax.py
@@ -104,6 +104,7 @@ class MetaXGPU(AcceleratorProtocol):
                     key=f"gpu.{idx}.power",
                     name=f"GPU {idx}",
                     chart_name="GPU Power (W)",
+                    y_min=0,
                     color=color,
                 )
             )

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/moorethreads.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/moorethreads.py
@@ -111,10 +111,11 @@ class MooreThreadsGPU(AcceleratorProtocol):
 
     def collect(self) -> List[CollectResult]:
         results: List[CollectResult] = []
-        results.extend(self._get_utilization())
-        results.extend(self._get_memory())
-        results.extend(self._get_temperature())
-        results.extend(self._get_power())
+        with safe.block(message="Failed to collect MooreThreads GPU metrics", level="debug"):
+            results.extend(self._get_utilization())
+            results.extend(self._get_memory())
+            results.extend(self._get_temperature())
+            results.extend(self._get_power())
         return results
 
     def _get_utilization(self) -> List[CollectResult]:

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/moorethreads.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/moorethreads.py
@@ -1,6 +1,256 @@
 """
 @author: cunyue
 @file: moorethreads.py
-@time: 2026/3/31 02:00
-@description: 摩尔线程加速卡信息模块
+@time: 2026/3/31 01:57
+@description: Moore Threads GPU 信息采集模块
+
+检测原理：
+- 仅 Linux 支持，依赖摩尔线程 `mthreads-gmi` 的 JSON 输出。
+- 静态信息使用 `mthreads-gmi -q --json`，顶层 `Driver Version` 为驱动版本，`GPU` 数组内每个对象包含
+  `Index`、`Product Name`、`FB Memory Usage.Total`（`MiB` 或 `GiB`）。
+- 利用率使用 `mthreads-gmi -q -d UTILIZATION --json`，解析 `GPU[].Utilization.Gpu`。
+- 显存使用使用 `mthreads-gmi -q -d MEMORY --json`，解析 `GPU[].FB Memory Usage.Total/Used`（MiB）。
+- 温度使用 `mthreads-gmi -q -d TEMPERATURE --json`，解析 `GPU[].Temperature.GPU Current Temp`。
+- 功耗使用 `mthreads-gmi -q -d POWER --json`，解析 `GPU[].Power Readings["Power Draw "]`。
 """
+
+import json
+import math
+import platform
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol, CollectResult
+from swanlab.utils import generate_color
+
+
+class MooreThreadsGPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        mt_config = next(a for a in shim.accelerators if a.vendor == "moorethreads")
+        self._indices = mt_config.device_indices
+        driver, gpu_map = MooreThreadsGPU._map_mt_gpu()
+        self._gpu_map = gpu_map
+        max_mem_mb = 0
+        for idx in self._indices:
+            mem = int(gpu_map.get(str(idx), {}).get("memory", 0))
+            if mem * 1024 > max_mem_mb:
+                max_mem_mb = mem * 1024
+        self._max_mem_mb = max_mem_mb
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize MooreThreads GPU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["MooreThreadsGPU", SystemScalars]]:
+        mt_config = next((a for a in shim.accelerators if a.vendor == "moorethreads"), None)
+        if mt_config is None:
+            console.debug("No MooreThreads monitor config in shim")
+            return None
+        self = cls(shim)
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(self._indices):
+            color = generate_color(color_idx)
+
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.pct",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Utilization (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.mem.pct",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Memory Allocated (%)",
+                    y_min=0,
+                    y_max=100,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.mem.value",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Memory Allocated (MB)",
+                    y_min=0,
+                    y_max=self._max_mem_mb,
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.temp",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Temperature (°C)",
+                    color=color,
+                )
+            )
+            scalars.append(
+                SystemScalar(
+                    key=f"gpu.{idx}.power",
+                    name=f"GPU {idx}",
+                    chart_name="GPU Power (W)",
+                    color=color,
+                )
+            )
+
+        console.debug(f"MooreThreads monitor initialized with {len(self._indices)} device(s)")
+        return self, scalars
+
+    def collect(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        results.extend(self._get_utilization())
+        results.extend(self._get_memory())
+        results.extend(self._get_temperature())
+        results.extend(self._get_power())
+        return results
+
+    def _get_utilization(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.pct", math.nan))
+        with safe.block(message="Failed to collect MooreThreads GPU utilization data", level="debug"):
+            output = subprocess.run(
+                ["mthreads-gmi", "-q", "-d", "UTILIZATION", "--json"],
+                capture_output=True,
+                text=True,
+            ).stdout
+            data = json.loads(output)
+            for gpu_info in data.get("GPU", []):
+                gpu_id = gpu_info["Index"]
+                if gpu_id in self._indices:
+                    gpu_util = gpu_info["Utilization"]["Gpu"]
+                    if isinstance(gpu_util, str) and gpu_util.endswith("%"):
+                        gpu_util = gpu_util[:-1]
+                    idx_pos = self._indices.index(gpu_id)
+                    results[idx_pos] = (f"gpu.{gpu_id}.pct", float(gpu_util))
+        return results
+
+    def _get_memory(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.mem.pct", math.nan))
+            results.append((f"gpu.{idx}.mem.value", math.nan))
+        with safe.block(message="Failed to collect MooreThreads GPU memory data", level="debug"):
+            output = subprocess.run(
+                ["mthreads-gmi", "-q", "-d", "MEMORY", "--json"],
+                capture_output=True,
+                text=True,
+            ).stdout
+            data = json.loads(output)
+            for gpu_info in data.get("GPU", []):
+                gpu_id = gpu_info["Index"]
+                if gpu_id in self._indices:
+                    mem_info = gpu_info["FB Memory Usage"]
+                    mem_total = float(mem_info["Total"].replace("MiB", "").strip())
+                    mem_used = float(mem_info["Used"].replace("MiB", "").strip())
+                    pct = (mem_used / mem_total * 100) if mem_total > 0 else math.nan
+                    idx_pos = self._indices.index(gpu_id)
+                    results[idx_pos * 2] = (f"gpu.{gpu_id}.mem.pct", pct)
+                    results[idx_pos * 2 + 1] = (f"gpu.{gpu_id}.mem.value", mem_used)
+        return results
+
+    def _get_temperature(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.temp", math.nan))
+        with safe.block(message="Failed to collect MooreThreads GPU temperature data", level="debug"):
+            output = subprocess.run(
+                ["mthreads-gmi", "-q", "-d", "TEMPERATURE", "--json"],
+                capture_output=True,
+                text=True,
+            ).stdout
+            data = json.loads(output)
+            for gpu_info in data.get("GPU", []):
+                gpu_id = gpu_info["Index"]
+                if gpu_id in self._indices:
+                    temp_str = gpu_info["Temperature"]["GPU Current Temp"].replace("C", "").strip()
+                    idx_pos = self._indices.index(gpu_id)
+                    results[idx_pos] = (f"gpu.{gpu_id}.temp", float(temp_str))
+        return results
+
+    def _get_power(self) -> List[CollectResult]:
+        results: List[CollectResult] = []
+        for idx in self._indices:
+            results.append((f"gpu.{idx}.power", math.nan))
+        with safe.block(message="Failed to collect MooreThreads GPU power data", level="debug"):
+            output = subprocess.run(
+                ["mthreads-gmi", "-q", "-d", "POWER", "--json"],
+                capture_output=True,
+                text=True,
+            ).stdout
+            data = json.loads(output)
+            for gpu_info in data.get("GPU", []):
+                gpu_id = gpu_info["Index"]
+                if gpu_id in self._indices:
+                    power_str = gpu_info["Power Readings"]["Power Draw "].strip().replace("W", "")
+                    idx_pos = self._indices.index(gpu_id)
+                    results[idx_pos] = (f"gpu.{gpu_id}.power", float(power_str))
+        return results
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get MooreThreads GPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        if platform.system() != "Linux":
+            console.debug(
+                f"MooreThreads GPU detection skipped: mthreads-gmi is only supported on Linux, current platform is {platform.system()}"
+            )
+            return None
+
+        driver, gpu_map = MooreThreadsGPU._map_mt_gpu()
+        if not gpu_map:
+            console.debug("No MooreThreads GPU detected: mthreads-gmi -q --json returned no GPU devices")
+            return None
+
+        devices = []
+        for gpu_id in sorted(gpu_map.keys(), key=int):
+            info = gpu_map[gpu_id]
+            devices.append(
+                DeviceSnapshot(
+                    index=int(gpu_id),
+                    name=info.get("name", "MTT GPU"),
+                    memory=int(info.get("memory", 0)),
+                    memory_unit="GB",
+                )
+            )
+
+        names = [d.name for d in devices]
+        console.debug(f"Detected {len(devices)} MooreThreads GPU(s): {', '.join(names)}")
+        return AcceleratorSnapshot(
+            vendor="moorethreads",
+            version=driver,
+            devices=devices,
+        )
+
+    @staticmethod
+    def _map_mt_gpu() -> Tuple[Optional[str], dict]:
+        output_str = subprocess.run(["mthreads-gmi", "-q", "--json"], capture_output=True, check=True, text=True).stdout
+        output_json = json.loads(output_str)
+        driver = output_json.get("Driver Version")
+        gpu_map: Dict[str, dict] = {}
+
+        for gpu_info in output_json.get("GPU", []):
+            gpu_id = str(gpu_info["Index"])
+            gpu_name = gpu_info["Product Name"]
+            gpu_memory = gpu_info["FB Memory Usage"]["Total"]
+            if gpu_memory.endswith("MiB"):
+                total = int(gpu_memory[:-3]) // 1024
+            elif gpu_memory.endswith("GiB"):
+                total = int(gpu_memory[:-3])
+            else:
+                total = 0
+            gpu_map[gpu_id] = {"name": gpu_name, "memory": str(total)}
+
+        return driver, gpu_map

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/moorethreads.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/moorethreads.py
@@ -102,6 +102,7 @@ class MooreThreadsGPU(AcceleratorProtocol):
                     key=f"gpu.{idx}.power",
                     name=f"GPU {idx}",
                     chart_name="GPU Power (W)",
+                    y_min=0,
                     color=color,
                 )
             )

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/nvidia.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/nvidia.py
@@ -133,6 +133,7 @@ class NvidiaGPU(AcceleratorProtocol):
                 key=f"gpu.{idx}.power",
                 name=f"GPU {idx}",
                 chart_name="GPU Power Usage (W)",
+                y_min=0,
                 color=color,
             )
             scalars.append(power)
@@ -210,6 +211,9 @@ class NvidiaGPU(AcceleratorProtocol):
     @staticmethod
     @safe.decorator(level="debug", message="Failed to get CUDA version via nvidia-smi")
     def _get_cuda_version_from_smi() -> Optional[str]:
-        cmd = "nvidia-smi | grep 'CUDA Version' | awk -F'CUDA Version: ' '{print $2}' | awk '{print $1}'"
-        output = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
-        return output or None
+        output = subprocess.check_output(["nvidia-smi"]).decode("utf-8")
+        marker = "CUDA Version:"
+        for line in output.split("\n"):
+            if marker in line:
+                return line.split(marker, 1)[-1].strip().split()[0]
+        return None

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/nvidia.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/nvidia.py
@@ -1,6 +1,215 @@
 """
 @author: cunyue
-@file: nvml.py
+@file: nvidia.py
 @time: 2026/3/31 01:58
 @description: NVIDIA GPU 信息采集模块
+
+检测原理：
+- 首选 NVIDIA 官方 NVML（Python 包 pynvml）查询设备，NVML 是 nvidia-smi 的底层管理接口之一。
+- 静态信息通过 nvmlSystemGetDriverVersion、nvmlDeviceGetCount、nvmlDeviceGetName、
+  nvmlDeviceGetMemoryInfo 采集。
+- CUDA 版本补充查询先使用 `nvcc --version`，解析形如 `Cuda compilation tools, release 12.4, V...` 的
+  release 字段；失败后使用 `nvidia-smi` 表头中的 `CUDA Version: 12.4` 字段兜底。
+- 动态指标来自 NVML：nvmlDeviceGetUtilizationRates(handle).gpu/memory、
+  nvmlDeviceGetMemoryInfo(handle).used/total、nvmlDeviceGetTemperature、nvmlDeviceGetPowerUsage。
 """
+
+import subprocess
+from typing import Optional, Tuple
+
+import pynvml
+
+from swanlab.sdk.internal.pkg import console, safe
+from swanlab.sdk.typings.probe_python import (
+    AcceleratorSnapshot,
+    DeviceSnapshot,
+    SystemScalar,
+    SystemScalars,
+    SystemShim,
+)
+from swanlab.sdk.typings.probe_python.hardware_vendor import AcceleratorProtocol
+from swanlab.utils import generate_color
+
+
+class NvidiaGPU(AcceleratorProtocol):
+    def __init__(self, shim: SystemShim):
+        super().__init__(shim)
+        pynvml.nvmlInit()
+        nvidia_config = next(a for a in shim.accelerators if a.vendor == "nvidia")
+        self._indices = nvidia_config.device_indices
+        self._handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in self._indices]
+        max_mem_mb = 0
+        for h in self._handles:
+            total = int(pynvml.nvmlDeviceGetMemoryInfo(h).total) >> 20
+            if total > max_mem_mb:
+                max_mem_mb = total
+        self._max_mem_mb = max_mem_mb
+
+    def __del__(self):
+        try:
+            pynvml.nvmlShutdown()
+        except Exception:
+            pass
+
+    @classmethod
+    @safe.decorator(level="debug", message="Failed to initialize NVIDIA GPU monitor")
+    def new(cls, shim: SystemShim) -> Optional[Tuple["NvidiaGPU", SystemScalars]]:
+        nvidia_config = next((a for a in shim.accelerators if a.vendor == "nvidia"), None)
+        if nvidia_config is None:
+            console.debug("No NVIDIA monitor config in shim")
+            return None
+        try:
+            self = cls(shim)
+        except pynvml.NVMLError:
+            console.debug("NVIDIA monitor initialization skipped: pynvml.nvmlInit() failed")
+            return None
+
+        scalars: SystemScalars = []
+        for color_idx, idx in enumerate(self._indices):
+            handle = self._handles[color_idx]
+            color = generate_color(color_idx)
+
+            util = SystemScalar(
+                key=f"gpu.{idx}.pct",
+                name=f"GPU {idx}",
+                chart_name="GPU Utilization (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(util)
+            self._handlers.append(
+                (f"gpu.{idx}.pct", lambda h=handle: float(pynvml.nvmlDeviceGetUtilizationRates(h).gpu))
+            )
+
+            mem_pct = SystemScalar(
+                key=f"gpu.{idx}.mem.pct",
+                name=f"GPU {idx}",
+                chart_name="GPU Memory Allocated (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(mem_pct)
+            self._handlers.append(
+                (
+                    f"gpu.{idx}.mem.pct",
+                    lambda h=handle: (
+                        float(pynvml.nvmlDeviceGetMemoryInfo(h).used)
+                        / float(pynvml.nvmlDeviceGetMemoryInfo(h).total)
+                        * 100
+                    ),
+                )
+            )
+
+            mem_value = SystemScalar(
+                key=f"gpu.{idx}.mem.value",
+                name=f"GPU {idx}",
+                chart_name="GPU Memory Allocated (MB)",
+                y_min=0,
+                y_max=self._max_mem_mb,
+                color=color,
+            )
+            scalars.append(mem_value)
+            self._handlers.append(
+                (f"gpu.{idx}.mem.value", lambda h=handle: int(pynvml.nvmlDeviceGetMemoryInfo(h).used) >> 20)
+            )
+
+            temp = SystemScalar(
+                key=f"gpu.{idx}.temp",
+                name=f"GPU {idx}",
+                chart_name="GPU Temperature (°C)",
+                color=color,
+            )
+            scalars.append(temp)
+            self._handlers.append(
+                (
+                    f"gpu.{idx}.temp",
+                    lambda h=handle: int(pynvml.nvmlDeviceGetTemperature(h, pynvml.NVML_TEMPERATURE_GPU)),
+                )
+            )
+
+            power = SystemScalar(
+                key=f"gpu.{idx}.power",
+                name=f"GPU {idx}",
+                chart_name="GPU Power Usage (W)",
+                color=color,
+            )
+            scalars.append(power)
+            self._handlers.append(
+                (f"gpu.{idx}.power", lambda h=handle: float(pynvml.nvmlDeviceGetPowerUsage(h)) / 1000)
+            )
+
+            mem_time = SystemScalar(
+                key=f"gpu.{idx}.mem.time",
+                name=f"GPU {idx}",
+                chart_name="GPU Time Spent Accessing Memory (%)",
+                y_min=0,
+                y_max=100,
+                color=color,
+            )
+            scalars.append(mem_time)
+            self._handlers.append(
+                (f"gpu.{idx}.mem.time", lambda h=handle: float(pynvml.nvmlDeviceGetUtilizationRates(h).memory))
+            )
+
+        console.debug(f"NVIDIA monitor initialized with {len(self._indices)} device(s)")
+        return self, scalars
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get NVIDIA GPU info")
+    def get() -> Optional[AcceleratorSnapshot]:
+        try:
+            pynvml.nvmlInit()
+        except pynvml.NVMLError:
+            console.debug(
+                "NVIDIA GPU detection skipped: pynvml.nvmlInit() failed; NVIDIA driver/NVML may be unavailable"
+            )
+            return None
+        try:
+            driver = pynvml.nvmlSystemGetDriverVersion()
+            if isinstance(driver, bytes):
+                driver = driver.decode("utf-8")
+            count = pynvml.nvmlDeviceGetCount()
+            if count == 0:
+                console.debug("No NVIDIA GPU detected: NVML initialized but reported 0 devices")
+            cuda_version = NvidiaGPU._get_cuda_version()
+            devices = []
+            for i in range(count):
+                handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                name = pynvml.nvmlDeviceGetName(handle)
+                if isinstance(name, bytes):
+                    name = name.decode("utf-8")
+                mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                mem_gb = round(int(mem_info.total) / 1024**3)
+                devices.append(DeviceSnapshot(index=i, name=name, memory=mem_gb, memory_unit="GB"))
+            names = [d.name for d in devices]
+            console.debug(f"Detected {count} NVIDIA GPU(s): {', '.join(names)}")
+            return AcceleratorSnapshot(
+                vendor="nvidia",
+                version=driver,
+                cuda_version=cuda_version,
+                devices=devices,
+            )
+        finally:
+            pynvml.nvmlShutdown()
+
+    @staticmethod
+    def _get_cuda_version() -> Optional[str]:
+        return NvidiaGPU._get_cuda_version_from_nvcc() or NvidiaGPU._get_cuda_version_from_smi()
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get CUDA version via nvcc")
+    def _get_cuda_version_from_nvcc() -> Optional[str]:
+        output = subprocess.check_output(["nvcc", "--version"]).decode("utf-8")
+        for line in output.split("\n"):
+            if "release" in line:
+                return line.split("release")[-1].strip().split(" ")[0][:-1]
+        return None
+
+    @staticmethod
+    @safe.decorator(level="debug", message="Failed to get CUDA version via nvidia-smi")
+    def _get_cuda_version_from_smi() -> Optional[str]:
+        cmd = "nvidia-smi | grep 'CUDA Version' | awk -F'CUDA Version: ' '{print $2}' | awk '{print $1}'"
+        output = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
+        return output or None

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/apple.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/apple.py
@@ -72,6 +72,22 @@ class Apple(AppleSiliconProtocol):
             )
             scalars.append(mem_proc)
             self._handlers.append(("mem.proc", lambda: psutil.Process().memory_info().rss / 1024 / 1024))
+            mem_proc_pct = SystemScalar(
+                key="mem.proc.pct",
+                name="Process Memory Utilization (%)",
+                chart_name="Process Memory Utilization (%)",
+                color=generate_color(0),
+            )
+            scalars.append(mem_proc_pct)
+            self._handlers.append(("mem.proc.pct", lambda: psutil.Process().memory_percent()))
+            mem_proc_avail = SystemScalar(
+                key="mem.proc.avail",
+                name="Process Memory Available (non-swap) (MB)",
+                chart_name="Process Memory Available (non-swap) (MB)",
+                color=generate_color(0),
+            )
+            scalars.append(mem_proc_avail)
+            self._handlers.append(("mem.proc.avail", lambda: psutil.virtual_memory().available / 1024 / 1024))
         return self, scalars
 
     @staticmethod

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/apple.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/apple.py
@@ -40,6 +40,8 @@ class Apple(AppleSiliconProtocol):
                 key="cpu.pct",
                 name="CPU Utilization (%)",
                 chart_name="CPU Utilization (%)",
+                y_min=0,
+                y_max=100,
                 color=generate_color(0),
             )
             scalars.append(cpu_pct)
@@ -49,6 +51,7 @@ class Apple(AppleSiliconProtocol):
                 key="cpu.thds",
                 name="Process CPU Threads",
                 chart_name="Process CPU Threads",
+                y_min=0,
                 color=generate_color(0),
             )
             scalars.append(cpu_thds)
@@ -59,6 +62,8 @@ class Apple(AppleSiliconProtocol):
                 key="mem.pct",
                 name="System Memory Utilization (%)",
                 chart_name="System Memory Utilization (%)",
+                y_min=0,
+                y_max=100,
                 color=generate_color(0),
             )
             scalars.append(mem_pct)
@@ -68,6 +73,7 @@ class Apple(AppleSiliconProtocol):
                 key="mem.proc",
                 name="Process Memory In Use (non-swap) (MB)",
                 chart_name="Process Memory In Use (non-swap) (MB)",
+                y_min=0,
                 color=generate_color(0),
             )
             scalars.append(mem_proc)
@@ -76,6 +82,8 @@ class Apple(AppleSiliconProtocol):
                 key="mem.proc.pct",
                 name="Process Memory Utilization (%)",
                 chart_name="Process Memory Utilization (%)",
+                y_min=0,
+                y_max=100,
                 color=generate_color(0),
             )
             scalars.append(mem_proc_pct)
@@ -84,6 +92,7 @@ class Apple(AppleSiliconProtocol):
                 key="mem.proc.avail",
                 name="Process Memory Available (non-swap) (MB)",
                 chart_name="Process Memory Available (non-swap) (MB)",
+                y_min=0,
                 color=generate_color(0),
             )
             scalars.append(mem_proc_avail)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/cpu.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/cpu.py
@@ -41,6 +41,8 @@ class CPU(CpuProtocol):
             key="cpu.pct",
             name="CPU Utilization (%)",
             chart_name="CPU Utilization (%)",
+            y_min=0,
+            y_max=100,
             color=generate_color(0),
         )
         scalars.append(usage)
@@ -50,6 +52,7 @@ class CPU(CpuProtocol):
             key="cpu.thds",
             name="Process CPU Threads",
             chart_name="Process CPU Threads",
+            y_min=0,
             color=generate_color(0),
         )
         scalars.append(threads)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/memory.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/memory.py
@@ -49,6 +49,8 @@ class Memory(MemoryProtocol):
             key="mem.pct",
             name="System Memory Utilization (%)",
             chart_name="System Memory Utilization (%)",
+            y_min=0,
+            y_max=100,
             color=generate_color(0),
         )
         scalars.append(mem_pct)
@@ -58,6 +60,7 @@ class Memory(MemoryProtocol):
             key="mem.proc",
             name="Process Memory In Use (non-swap) (MB)",
             chart_name="Process Memory In Use (non-swap) (MB)",
+            y_min=0,
             color=generate_color(0),
         )
         scalars.append(mem_proc)
@@ -66,6 +69,8 @@ class Memory(MemoryProtocol):
             key="mem.proc.pct",
             name="Process Memory Utilization (%)",
             chart_name="Process Memory Utilization (%)",
+            y_min=0,
+            y_max=100,
             color=generate_color(0),
         )
         scalars.append(mem_proc_pct)
@@ -74,6 +79,7 @@ class Memory(MemoryProtocol):
             key="mem.proc.avail",
             name="Process Memory Available (non-swap) (MB)",
             chart_name="Process Memory Available (non-swap) (MB)",
+            y_min=0,
             color=generate_color(0),
         )
         scalars.append(mem_proc_avail)

--- a/swanlab/sdk/internal/probe_python/hardware_vendor/memory.py
+++ b/swanlab/sdk/internal/probe_python/hardware_vendor/memory.py
@@ -62,6 +62,22 @@ class Memory(MemoryProtocol):
         )
         scalars.append(mem_proc)
         self._handlers.append(("mem.proc", lambda: psutil.Process().memory_info().rss / 1024 / 1024))
+        mem_proc_pct = SystemScalar(
+            key="mem.proc.pct",
+            name="Process Memory Utilization (%)",
+            chart_name="Process Memory Utilization (%)",
+            color=generate_color(0),
+        )
+        scalars.append(mem_proc_pct)
+        self._handlers.append(("mem.proc.pct", lambda: psutil.Process().memory_percent()))
+        mem_proc_avail = SystemScalar(
+            key="mem.proc.avail",
+            name="Process Memory Available (non-swap) (MB)",
+            chart_name="Process Memory Available (non-swap) (MB)",
+            color=generate_color(0),
+        )
+        scalars.append(mem_proc_avail)
+        self._handlers.append(("mem.proc.avail", lambda: psutil.virtual_memory().available / 1024 / 1024))
         return self, scalars
 
     @staticmethod

--- a/swanlab/sdk/internal/probe_python/monitor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/monitor/__init__.py
@@ -14,6 +14,7 @@ from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord
 from swanlab.sdk.internal.pkg import console, safe, timer
 from swanlab.sdk.internal.probe_python.context import ProbeContext
+from swanlab.sdk.internal.probe_python.hardware_vendor.accelerator import ACCELERATOR_REGISTRY
 from swanlab.sdk.internal.probe_python.hardware_vendor.apple import Apple
 from swanlab.sdk.internal.probe_python.hardware_vendor.cpu import CPU
 from swanlab.sdk.internal.probe_python.hardware_vendor.memory import Memory
@@ -57,6 +58,13 @@ class Monitor:
             scalars = apple[1] + scalars
 
         # 1.3 加速器信息
+        for acc_config in self._shim.accelerators:
+            vendor_cls = ACCELERATOR_REGISTRY.get(acc_config.vendor)
+            if vendor_cls is None:
+                continue
+            if (instance := vendor_cls.new(self._shim)) is not None:
+                collectors.append(instance[0])
+                scalars = instance[1] + scalars
 
         # 2. 定义指标
         # 有部分指标会聚合到一个图表中，所以需要一个缓存来记录每个指标对应的图表索引

--- a/swanlab/sdk/internal/probe_python/monitor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/monitor/__init__.py
@@ -79,18 +79,23 @@ class Monitor:
         if len(column_records) == 0:
             console.debug("No hardware monitor columns found, skipping creating monitor task")
             return None
-        self._core.upsert_columns(column_records)
         # 3. 定义并启动任务
         all_handlers = [(type(c).__name__, c.collect) for c in collectors]
         if len(all_handlers) == 0:
             console.debug("No hardware monitor collectors found, skipping creating monitor task")
             return None
         # 使用线程池执行任务
+        # 监控任务的执行效率不要求特别高，线程池的方式可以兼容大部分采集器的实现方式，同时也避免了某些采集器在执行过程中可能出现的阻塞问题
+        first_execute = True
         self._executor = ThreadPoolExecutor(max_workers=2)
 
         def task():
-            nonlocal now_step
+            nonlocal now_step, column_records, first_execute
             assert self._executor is not None, "Monitor Executor is not initialized"
+            assert len(column_records) > 0, "No column records to upsert"
+            if first_execute:
+                self._core.upsert_columns(column_records)
+                first_execute = False
             futures = [(n, self._executor.submit(fn)) for n, fn in all_handlers]
             results: List[CollectResult] = []
             for n, f in futures:

--- a/swanlab/sdk/internal/probe_python/monitor/builder.py
+++ b/swanlab/sdk/internal/probe_python/monitor/builder.py
@@ -25,10 +25,16 @@ from swanlab.sdk.typings.probe_python import SystemScalar
 
 def build_probe_column(model: SystemScalar, *, chart_index: str) -> ColumnRecord:
     y_range: Optional[YRange] = None
-    if model.y_min is not None and model.y_max is not None:
-        if model.y_min >= model.y_max:
-            raise ValueError(f"y_min must be less than y_max, but got {model.y_min} >= {model.y_max}")
-        y_range = YRange(min=model.y_min, max=model.y_max)
+    if model.y_min is not None or model.y_max is not None:
+        if model.y_min is not None and model.y_max is not None:
+            if model.y_min >= model.y_max:
+                raise ValueError(f"y_min must be less than y_max, but got {model.y_min} >= {model.y_max}")
+        y_range = YRange()
+        # None 不允许设置在 optional double 上
+        if model.y_min is not None:
+            y_range.min = model.y_min
+        if model.y_max is not None:
+            y_range.max = model.y_max
     metric_colors: Optional[MetricColors] = None
     if model.color is not None:
         metric_colors = MetricColors(light=model.color, dark=model.color)

--- a/swanlab/sdk/typings/core_python/api/upload.py
+++ b/swanlab/sdk/typings/core_python/api/upload.py
@@ -30,7 +30,7 @@ UploadColumn = TypedDict(
         "error": NotRequired[Dict[str, Any]],
         "sectionName": NotRequired[str],
         "sectionType": NotRequired[Literal["PUBLIC", "SYSTEM"]],
-        "yRange": NotRequired[Tuple[float, float]],
+        "yRange": NotRequired[Tuple[Union[float, None], Union[float, None]]],
         "chartName": NotRequired[str],
         "chartIndex": NotRequired[str],
         "metricName": NotRequired[str],

--- a/swanlab/sdk/typings/probe_python/__init__.py
+++ b/swanlab/sdk/typings/probe_python/__init__.py
@@ -323,8 +323,8 @@ class SystemScalar(BaseModel):
     用于在硬件监控线程启动前批量注册系统标量定义。
     """
 
-    key: str = Field(..., pattern=r"^[a-z\.]+$", max_length=512, min_length=1)
-    """标量键名，仅允许小写字母和点号"""
+    key: str = Field(..., pattern=r"^[a-z0-9\.\-]+$", max_length=512, min_length=1)
+    """标量键名，允许小写字母、数字、点号和连字符"""
     name: Optional[str] = Field(default=None, max_length=512, min_length=1)
     """显示名称"""
     color: Optional[str] = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")

--- a/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_apple.py
+++ b/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_apple.py
@@ -95,7 +95,7 @@ class TestAppleNew:
         collector, scalars = result
         assert isinstance(collector, Apple)
         assert isinstance(scalars, list)
-        assert len(scalars) == 4
+        assert len(scalars) == 6
 
     def test_scalar_keys(self):
         """验证采集器注册了正确的 scalar key"""
@@ -104,7 +104,7 @@ class TestAppleNew:
         assert result is not None
         _, scalars = result
         keys = [s.key for s in scalars]
-        assert keys == ["cpu.pct", "cpu.thds", "mem.pct", "mem.proc"]
+        assert keys == ["cpu.pct", "cpu.thds", "mem.pct", "mem.proc", "mem.proc.pct", "mem.proc.avail"]
 
     def test_scalar_chart_names(self):
         """验证 scalar 的 chart_name 分组正确"""
@@ -118,19 +118,22 @@ class TestAppleNew:
             "Process CPU Threads",
             "System Memory Utilization (%)",
             "Process Memory In Use (non-swap) (MB)",
+            "Process Memory Utilization (%)",
+            "Process Memory Available (non-swap) (MB)",
         ]
 
-    def test_collect_returns_four_metrics(self):
-        """collect() 返回 4 个 (key, value) 采集结果"""
+    def test_collect_returns_six_metrics(self):
+        """collect() 返回 6 个 (key, value) 采集结果"""
         mock_proc = MagicMock()
         mock_proc.num_threads.return_value = 8
         mock_proc.memory_info.return_value = MagicMock(rss=1024 * 1024 * 256)  # 256 MB
+        mock_proc.memory_percent.return_value = 12.5
         with (
             patch("psutil.cpu_percent", return_value=42.5),
             patch("psutil.Process", return_value=mock_proc),
             patch("psutil.virtual_memory") as mock_vm,
         ):
-            mock_vm.return_value = MagicMock(percent=67.3)
+            mock_vm.return_value = MagicMock(percent=67.3, available=1024 * 1024 * 1024 * 4)
             shim = self._make_shim(slug="macos-arm")
             result = Apple.new(shim)
 
@@ -139,12 +142,14 @@ class TestAppleNew:
         with (
             patch("psutil.cpu_percent", return_value=42.5),
             patch("psutil.Process", return_value=mock_proc),
-            patch("psutil.virtual_memory", return_value=MagicMock(percent=67.3)),
+            patch("psutil.virtual_memory", return_value=MagicMock(percent=67.3, available=1024 * 1024 * 1024 * 4)),
         ):
             metrics = collector.collect()
 
-        assert len(metrics) == 4
+        assert len(metrics) == 6
         assert metrics[0] == ("cpu.pct", 42.5)
         assert metrics[1] == ("cpu.thds", 8)
         assert metrics[2] == ("mem.pct", 67.3)
         assert metrics[3] == ("mem.proc", 256.0)
+        assert metrics[4] == ("mem.proc.pct", 12.5)
+        assert metrics[5] == ("mem.proc.avail", 4096.0)

--- a/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_memory.py
+++ b/tests/unit/sdk/internal/probe_python/hardware_vendor/test_hardware_memory.py
@@ -294,7 +294,7 @@ class TestMemoryNew:
         collector, scalars = result
         assert isinstance(collector, Memory)
         assert isinstance(scalars, list)
-        assert len(scalars) == 2
+        assert len(scalars) == 4
 
     def test_returns_tuple_on_macos_intel(self):
         """macOS Intel 平台返回 (Memory, SystemScalars) 元组"""
@@ -303,7 +303,7 @@ class TestMemoryNew:
         assert result is not None
         collector, scalars = result
         assert isinstance(collector, Memory)
-        assert len(scalars) == 2
+        assert len(scalars) == 4
 
     def test_returns_tuple_on_windows(self):
         """Windows 平台返回 (Memory, SystemScalars) 元组"""
@@ -312,7 +312,7 @@ class TestMemoryNew:
         assert result is not None
         collector, scalars = result
         assert isinstance(collector, Memory)
-        assert len(scalars) == 2
+        assert len(scalars) == 4
 
     def test_scalar_keys(self):
         """验证采集器注册了正确的 scalar key"""
@@ -321,7 +321,7 @@ class TestMemoryNew:
         assert result is not None
         _, scalars = result
         keys = [s.key for s in scalars]
-        assert keys == ["mem.pct", "mem.proc"]
+        assert keys == ["mem.pct", "mem.proc", "mem.proc.pct", "mem.proc.avail"]
 
     def test_scalar_chart_names(self):
         """验证 scalar 的 chart_name 分组正确"""
@@ -330,28 +330,36 @@ class TestMemoryNew:
         assert result is not None
         _, scalars = result
         chart_names = [s.chart_name for s in scalars]
-        assert chart_names == ["System Memory Utilization (%)", "Process Memory In Use (non-swap) (MB)"]
+        assert chart_names == [
+            "System Memory Utilization (%)",
+            "Process Memory In Use (non-swap) (MB)",
+            "Process Memory Utilization (%)",
+            "Process Memory Available (non-swap) (MB)",
+        ]
 
-    def test_collect_returns_two_metrics(self):
-        """collect() 返回 2 个 (key, value) 采集结果"""
+    def test_collect_returns_four_metrics(self):
+        """collect() 返回 4 个 (key, value) 采集结果"""
         mock_proc = MagicMock()
         mock_proc.memory_info.return_value = MagicMock(rss=1024 * 1024 * 512)  # 512 MB
+        mock_proc.memory_percent.return_value = 12.5
         with (
             patch("psutil.virtual_memory") as mock_vm,
             patch("psutil.Process", return_value=mock_proc),
         ):
-            mock_vm.return_value = MagicMock(percent=55.8)
+            mock_vm.return_value = MagicMock(percent=55.8, available=1024 * 1024 * 1024 * 2)
             shim = self._make_shim(slug="linux")
             result = Memory.new(shim)
 
         assert result is not None
         collector, _ = result
         with (
-            patch("psutil.virtual_memory", return_value=MagicMock(percent=55.8)),
+            patch("psutil.virtual_memory", return_value=MagicMock(percent=55.8, available=1024 * 1024 * 1024 * 2)),
             patch("psutil.Process", return_value=mock_proc),
         ):
             metrics = collector.collect()
 
-        assert len(metrics) == 2
+        assert len(metrics) == 4
         assert metrics[0] == ("mem.pct", 55.8)
         assert metrics[1] == ("mem.proc", 512.0)
+        assert metrics[2] == ("mem.proc.pct", 12.5)
+        assert metrics[3] == ("mem.proc.avail", 2048.0)


### PR DESCRIPTION
## Summary

新增多种硬件加速器厂商的监控采集支持（NVIDIA、AMD、昇腾 NPU、寒武纪 MLU、Iluvatar GPU、MetaX GPU、摩尔线程 GPU、昆仑芯 XPU、海光 DCU），并为 Apple Silicon 和标准内存监控器添加进程内存利用率和可用内存指标。

## Changes

### 新增加速器采集模块

`swanlab/sdk/internal/probe_python/hardware_vendor/accelerator/` 目录下新增：

- **nvidia.py**：基于 nvidia-smi 采集 GPU 使用率、显存、温度、功耗等指标
- **amd.py**：基于 rocm-smi 采集 AMD GPU 相关指标
- **huawei.py**：昇腾 NPU 采集支持（npu-smi）
- **cambricon.py**：寒武纪 MLU 采集支持
- **iluvatar.py**：Iluvatar GPU 采集支持
- **metax.py**：MetaX GPU 采集支持
- **moorethreads.py**：摩尔线程 GPU 采集支持
- **kunlunxin.py**：昆仑芯 XPU 采集支持
- **hygon.py**：海光 DCU 采集支持（rocminfo）
- **__init__.py**：新增硬件加速器注册表，按平台自动选择合适的采集器

### 内存监控增强

`apple.py`、`memory.py`：

- 新增 `mem.proc.pct`（进程内存利用率百分比）
- 新增 `mem.proc.avail`（系统可用内存 MB）
- 现有指标 `mem.pct` 和 `mem.proc` 保持不变

### 其他变更

- 更新 monitor 模块注册新增指标
- 更新类型定义 `swanlab/sdk/typings/probe_python/__init__.py`
- 修复 pre-commit ruff 排除配置

### 测试更新

`tests/unit/.../hardware_vendor/` 下：

- `test_hardware_apple.py`：更新 Apple 采集器测试以适配新增的 2 个指标（4 → 6 scalars）
- `test_hardware_memory.py`：更新 Memory 采集器测试以适配新增的 2 个指标（2 → 4 scalars）

## Testing

- 单元测试已同步更新以覆盖新增指标
- 未运行完整测试套件

## Notes

- 各加速器采集模块依赖对应厂商的 CLI 工具（如 nvidia-smi、rocm-smi、npu-smi 等），在无硬件的环境下会静默跳过采集
- 新增指标向后兼容，不影响现有用户的指标数据
