### PR TITLE
chore(ci): add ruff lint check to PR workflow

### DIFF
--- a/.github/workflows/test-python-pr.yml
+++ b/.github/workflows/test-python-pr.yml
@@ -20,6 +20,8 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: uv sync --all-extras --group dev
+      - name: Run ruff
+        run: uv run ruff check .
       - name: Run basedpyright
         run: uv run basedpyright
   test:


### PR DESCRIPTION
## Summary
在 PR workflow 的 type-check job 中新增 ruff 代码风格检查，确保每次 PR 自动验证代码符合项目 lint 规范。

## Changes
- `.github/workflows/test-python-pr.yml`: 在 `type-check` job 的 `Run basedpyright` 步骤前添加 `Run ruff` 步骤，执行 `uv run ruff check .`

## Testing
- ruff 配置已在 `pyproject.toml` 中定义，包含 `E4/E7/E9/F/I` 规则
- 未运行测试（本 PR 仅修改 CI 配置）

## Notes
- ruff 作为 dev 依赖已随 `uv sync --all-extras --group dev` 安装，无需额外依赖
- 该步骤与 basedpyright 共享同一 job，不影响 test 矩阵的运行时间