### PR TITLE
fix: initialize _global_step to -1 for correct first step value

### DIFF
--- a/swanlab/sdk/internal/context/__init__.py
+++ b/swanlab/sdk/internal/context/__init__.py
@@ -41,7 +41,7 @@ class RunConfig:
 # 上下文宿主
 class RunContext:
     def __init__(self, config: RunConfig, callbacks: Optional[CallbacksType] = None):
-        self._global_step: int = 0
+        self._global_step: int = -1
         self._global_system_step: Optional[int] = None
         self.config: RunConfig = config
         self.callbacker = create_callback_manager(callbacks=callbacks)


### PR DESCRIPTION
## Summary
修复 `RunContext._global_step` 初始化值为 0 导致的 off-by-one 问题。当用户未指定 step 时，`next_step()` 会先自增再返回，初始值为 0 导致首次调用返回 1 而非 0。改为 -1 后首次自增即为 0，符合零起始的预期行为。

## Changes
- `swanlab/sdk/internal/context/__init__.py:44`: 将 `_global_step` 初始值从 `0` 改为 `-1`

## Testing
未运行测试。

## Notes
- 该变更影响所有使用 `RunContext.next_step()` 自动步进（不传 `user_step`）的场景：首次调用返回值由原来的 `1` 变为 `0`
- 对显式传入 `user_step` 的场景无影响；对初始化后 `_global_step` 已被覆盖的场景（如从系统恢复 step）无影响