### PR TITLE
test: add offline mode auto-step starts-from-zero assertion

### DIFF
--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -441,16 +441,15 @@ class TestInitOfflineMode:
 
     def test_auto_step_starts_from_zero(self):
         """offline 模式下，未显式传入 step 时首次 run.log() 应从 step=0 开始自增"""
-        run = init(mode="offline")
-        run._components.emitter.emit = MagicMock(wraps=run._components.emitter.emit)
+        with init(mode="offline") as run:
+            run._components.emitter.emit = MagicMock(wraps=run._components.emitter.emit)
 
-        run.log({"loss": 0.5})
-        run.log({"loss": 0.4})
+            run.log({"loss": 0.5})
+            run.log({"loss": 0.4})
 
-        events = [call.args[0] for call in run._components.emitter.emit.call_args_list]
-        assert all(isinstance(event, MetricLogEvent) for event in events)
-        assert [event.step for event in events] == [0, 1]
-        run.finish()
+            events = [call.args[0] for call in run._components.emitter.emit.call_args_list]
+            assert all(isinstance(event, MetricLogEvent) for event in events)
+            assert [event.step for event in events] == [0, 1]
 
 
 # ============================================================

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -19,6 +19,7 @@
 import json
 import multiprocessing
 from typing import cast
+from unittest.mock import MagicMock
 
 import pytest
 import responses as responses_lib
@@ -27,7 +28,7 @@ import yaml
 from swanlab.sdk.cmd.init import init
 from swanlab.sdk.cmd.login import login_cli
 from swanlab.sdk.cmd.merge_settings import merge_settings
-from swanlab.sdk.internal.bus import RunEmitter
+from swanlab.sdk.internal.bus import MetricLogEvent, RunEmitter
 from swanlab.sdk.internal.pkg import fork
 from swanlab.sdk.internal.run import Run, get_run, has_run
 from swanlab.sdk.internal.run.components import BackgroundConsumer, NullConsumer, NullEmitter
@@ -437,6 +438,19 @@ class TestInitOfflineMode:
         run = init(mode="offline", workspace="my-org")
 
         assert run._ctx.config.settings.project.workspace == "my-org"
+
+    def test_auto_step_starts_from_zero(self):
+        """offline 模式下，未显式传入 step 时首次 run.log() 应从 step=0 开始自增"""
+        run = init(mode="offline")
+        run._components.emitter.emit = MagicMock(wraps=run._components.emitter.emit)
+
+        run.log({"loss": 0.5})
+        run.log({"loss": 0.4})
+
+        events = [call.args[0] for call in run._components.emitter.emit.call_args_list]
+        assert all(isinstance(event, MetricLogEvent) for event in events)
+        assert [event.step for event in events] == [0, 1]
+        run.finish()
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

为 offline 模式下 run.log() 的自动递增 step 行为补充单元测试，验证首次调用 run.log() 时 step 从 0 开始自增。

该测试是对 #1653（`fix: initialize _global_step to -1`）的回归覆盖。

## Changes

| 文件 | 变更 |
|------|------|
| `tests/unit/sdk/cmd/init/test_init_e2e.py` | 新增 `test_auto_step_starts_from_zero` 测试用例，使用 `unittest.mock.MagicMock` 捕获 emit 事件，断言连续两次 `run.log()` 的 step 值分别为 0 和 1 |

此外导入了 `MagicMock` 和 `MetricLogEvent`，将 `RunEmitter` 的导入路径从单独一行合并到 `MetricLogEvent` 所在行。

## Testing

- [x] `test_auto_step_starts_from_zero` 本地通过

## Notes

- 仅新增测试，无破坏性变更
- 依赖 #1653 中 `_global_step` 初始化为 `-1` 的修复