### PR TITLE
feat: add parallel execution support with shared run directory naming

### DIFF
--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -30,7 +30,7 @@ from .sdk import (
 )
 from .sdk.typings.cmd import ConfigLike, LoginType
 from .sdk.typings.context import CallbacksType
-from .sdk.typings.run import AsyncLogType, FinishType, ModeType, ResumeType, SaveType
+from .sdk.typings.run import AsyncLogType, FinishType, ModeType, ParallelType, ResumeType, SaveType
 from .sdk.typings.run.column import ScalarXAxisType
 from .sdk.typings.run.transforms import CaptionsType
 from .sdk.typings.run.transforms.audio import AudioDatasType, AudioRatesType
@@ -105,6 +105,7 @@ def init(
     tags: Optional[List[str]] = None,
     id: Optional[str] = None,
     resume: Optional[Union[ResumeType, bool]] = None,
+    parallel: Optional[ParallelType] = None,
     config: Optional[ConfigLike] = None,
     settings: Optional[Settings] = None,
     callbacks: Optional[CallbacksType] = None,
@@ -132,6 +133,7 @@ def init(
     :param id: Run ID for resuming a previous run (online mode only).
     :param resume: Resume behavior. Options: "must" (must resume), "allow" (resume if exists),
         "never" (always create new). Defaults to "never".
+    :param parallel: Parallel execution policy. Options: "none", "shared".
     :param config: Experiment configuration dict or path to config file (JSON/YAML).
     :param settings: Custom Settings object for advanced configuration.
     :param callbacks: List of callback functions triggered on run events.

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -10,7 +10,6 @@ init函数执行时被视为init之前
 
 import json
 import os
-import re
 import socket
 import time
 from datetime import datetime
@@ -31,7 +30,7 @@ from swanlab.sdk.internal.context import (
     use_context,
 )
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.internal.pkg import adapter, console, constraints, fork, fs, helper, safe
+from swanlab.sdk.internal.pkg import adapter, console, fork, fs, helper, safe
 from swanlab.sdk.typings.cmd import ConfigLike
 from swanlab.sdk.typings.context import CallbacksType
 from swanlab.utils.experiment import generate_color, generate_id, generate_name
@@ -462,49 +461,6 @@ def ensure_run_dir(
     raise RuntimeError(f"Failed to create a unique run directory after {max_retries} attempts")
 
 
-def _fmt_safe_dirname(
-    dirname: str,
-    fallback: str = "unknown",
-    _os_safe_re=re.compile(constraints.OS_SAFE_PATTERN),
-) -> str:
-    """
-    格式化目录名，将不安全字符、"." 以及 "-" 替换为 "_"
-
-    :param dirname: 原始目录名
-    :param fallback: 格式化后为空时的兜底值
-    :param _os_safe_re: 用于判断安全字符的正则表达式，一般不改动，这里主要是为了在函数参数中预编译正则表达式，避免每次调用都编译一次
-
-    :return: 格式化后的目录名
-    """
-    # 允许的安全字符直接保留，不允许的字符替换为 "_"
-    dirname = "".join(c if _os_safe_re.match(c) else "_" for c in dirname)
-    dirname = dirname.replace(".", "_").replace("-", "_")
-    dirname = re.sub(r"_{2,}", "_", dirname)
-    dirname = dirname.strip().strip("_")
-    return dirname or fallback
-
-
-def _truncate_dirname(name: str, max_length: int) -> Tuple[str, bool]:
-    """
-    截断目录名，保留前3和后部分字符，中间用 "..." 连接，确保结果不超过 max_length。
-    例如： "abcdefghijklmnopqrstuvwxyz" 截断为 "abc...yz"（max_length >= 8 时）
-
-    :param name: 原始目录名
-    :param max_length: 目录名最大长度，必须 >= 7 以容纳 "abc...yz" 格式
-    :return: 截断后的目录名和是否发生了截断
-    """
-    if len(name) <= max_length:
-        return name, False
-    if max_length < 7:
-        raise ValueError(
-            f"Failed to generate run directory name: max_length ({max_length}) is too small. "
-            f"Consider increasing `dir_max_length` (SWANLAB_RUN_DIR_MAX_LENGTH) or specifying a custom `run.dir` (SWANLAB_RUN_DIR)."
-        )
-    tail_len = max_length - 6  # 3 (head) + 3 (...) + tail
-    truncated_name = f"{name[:3]}...{name[-tail_len:]}"
-    return truncated_name, True
-
-
 def _generate_run_dir_name(
     run_id: str,
     max_length: int,
@@ -517,9 +473,9 @@ def _generate_run_dir_name(
     语义为 "某一时刻、某个运行id、某个主机、某个进程开启的运行"。
 
     :param run_id: 当前运行的唯一标识符
-    :param max_length: 目录名最大长度
+    :param max_length: 目录名最大字节长度
     :param parallel: 并行策略
-    :param hostname_max_len: 主机名最大长度，仅在共享模式或者分布式时使用，hostname_max_len 有可能会被进一步缩减以适应 max_length
+    :param hostname_max_len: 主机名最大字节长度，仅在共享模式或者分布式时使用，hostname_max_len 有可能会被进一步缩减以适应 max_length
 
     :return: run_dir 目录名（非完整路径）和是否截断
     """
@@ -532,7 +488,7 @@ def _generate_run_dir_name(
         hostname = socket.gethostname() or "unknown_hostname"
         suffix = f"-{fork.current_pid()}"
     # 2. 计算中间部分的可用长度（算上"-"分隔符），并确定 hostname 的最大长度
-    reserved_length = len(prefix) + len(suffix or "")
+    reserved_length = len(prefix.encode("utf-8")) + len((suffix or "").encode("utf-8"))
     available_length = max_length - reserved_length
     if available_length <= 0:
         # 由于 settings 中 dir_max_length 的约束，理论上不会出现 available_length <= 0 的情况，但这里做一个兜底，避免出现负数导致后续逻辑混乱
@@ -546,11 +502,23 @@ def _generate_run_dir_name(
     # 3. 开始截断和格式化中间部分的长度，hostname 和 run_id 共享 available_length 的长度，优先保证 hostname 的完整性
     hostname_truncated = False
     if hostname is not None:
-        hostname = _fmt_safe_dirname(hostname, fallback="unknown_host")
-        hostname, hostname_truncated = _truncate_dirname(hostname, hostname_max_len)
-        available_length -= len(hostname) + 1  # 减去 hostname 的长度和一个 "-" 分隔符
-    run_id = _fmt_safe_dirname(run_id, fallback="unknown_run")
-    run_id, run_id_truncated = _truncate_dirname(run_id, available_length)
+        hostname = fs.safe_fmt(hostname, fallback="unknown_host")
+        try:
+            hostname, hostname_truncated = fs.safe_truncate(hostname, hostname_max_len)
+        except ValueError:
+            raise ValueError(
+                f"Failed to generate run directory name: max_length ({max_length}) is too small to truncate hostname. "
+                f"Consider increasing `dir_max_length` (SWANLAB_RUN_DIR_MAX_LENGTH) or specifying a custom `run.dir` (SWANLAB_RUN_DIR)."
+            ) from None
+        available_length -= len(hostname.encode("utf-8")) + 1  # 减去 hostname 的字节长度和一个 "-" 分隔符
+    run_id = fs.safe_fmt(run_id, fallback="unknown_run")
+    try:
+        run_id, run_id_truncated = fs.safe_truncate(run_id, available_length)
+    except ValueError:
+        raise ValueError(
+            f"Failed to generate run directory name: max_length ({max_length}) is too small to truncate run_id. "
+            f"Consider increasing `dir_max_length` (SWANLAB_RUN_DIR_MAX_LENGTH) or specifying a custom `run.dir` (SWANLAB_RUN_DIR)."
+        ) from None
     # 4. 组合最终的目录名
     dir_name = prefix + run_id
     if hostname is not None:

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -490,13 +490,16 @@ def _truncate_dirname(name: str, max_length: int) -> Tuple[str, bool]:
     例如： "abcdefghijklmnopqrstuvwxyz" 截断为 "abc...yz"（max_length >= 8 时）
 
     :param name: 原始目录名
-    :param max_length: 目录名最大长度
+    :param max_length: 目录名最大长度，必须 >= 7 以容纳 "abc...yz" 格式
     :return: 截断后的目录名和是否发生了截断
     """
     if len(name) <= max_length:
         return name, False
     if max_length < 7:
-        return name[:max_length], True
+        raise ValueError(
+            f"Failed to generate run directory name: max_length ({max_length}) is too small. "
+            f"Consider increasing `dir_max_length` (SWANLAB_RUN_DIR_MAX_LENGTH) or specifying a custom `run.dir` (SWANLAB_RUN_DIR)."
+        )
     tail_len = max_length - 6  # 3 (head) + 3 (...) + tail
     truncated_name = f"{name[:3]}...{name[-tail_len:]}"
     return truncated_name, True
@@ -534,7 +537,8 @@ def _generate_run_dir_name(
     if available_length <= 0:
         # 由于 settings 中 dir_max_length 的约束，理论上不会出现 available_length <= 0 的情况，但这里做一个兜底，避免出现负数导致后续逻辑混乱
         raise ValueError(
-            f"Failed to generate run directory name: max_length {max_length} is too small to accommodate prefix and suffix."
+            f"Failed to generate run directory name: max_length ({max_length}) is too small to accommodate prefix and suffix. "
+            f"Consider increasing `dir_max_length` (SWANLAB_RUN_DIR_MAX_LENGTH) or specifying a custom `run.dir` (SWANLAB_RUN_DIR)."
         )
     # run id 最小会被截断为 "a...b" 样式，长度为 5，并且 run id 和 hostname 之间存在一个 "-" 分隔符，所以至少需要 6 个字符的长度才能保证 run id 的完整性
     if hostname is not None:

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -462,10 +462,7 @@ def ensure_run_dir(
 
 
 def _generate_run_dir_name(
-    run_id: str,
-    max_length: int,
-    parallel: ParallelType = "none",
-    hostname_max_len: int = 64,
+    run_id: str, max_length: int, parallel: ParallelType = "none", hostname_max_len: int = 64
 ) -> Tuple[str, bool]:
     """
     生成 run_dir 的目录名，格式为 ``run-{timestamp}-{run_id}``，超长时截断。
@@ -485,7 +482,17 @@ def _generate_run_dir_name(
     hostname: Optional[str] = None
     # 并行模式添加hostname和pid到目录名
     if parallel != "none":
-        hostname = socket.gethostname() or "unknown_hostname"
+        with safe.block(level="debug", message="Failed to get hostname for run directory name, using fallback."):
+            hostname = socket.gethostname() or "unknown_hostname"
+        if not hostname:
+            # 虽然console.warning有可能会造成大量重复日志刷屏，但这种情况确实很罕见，且通常意味着系统环境有问题，
+            # 用户应该被告知这个潜在风险，所以我们选择在这里打warning而不是silent fail
+            console.warning(
+                "Failed to get hostname for run directory name, swanlab will use a fallback name.",
+                "This may cause issues when running multiple processes on the same machine.",
+                "Consider setting a custom run directory name (SWANLAB_RUN_DIR).",
+            )
+            hostname = "unknown_hostname"
         suffix = f"-{fork.current_pid()}"
     # 2. 计算中间部分的可用长度（算上"-"分隔符），并确定 hostname 的最大长度
     reserved_length = len(prefix.encode("utf-8")) + len((suffix or "").encode("utf-8"))

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -503,9 +503,9 @@ def _generate_run_dir_name(
             f"Failed to generate run directory name: max_length ({max_length}) is too small to accommodate prefix and suffix. "
             f"Consider increasing `dir_max_length` (SWANLAB_RUN_DIR_MAX_LENGTH) or specifying a custom `run.dir` (SWANLAB_RUN_DIR)."
         )
-    # run id 最小会被截断为 "a...b" 样式，长度为 5，并且 run id 和 hostname 之间存在一个 "-" 分隔符，所以至少需要 6 个字符的长度才能保证 run id 的完整性
+    # run id 最小会被截断为 "abc...yz" 样式，长度为 7，并且 run id 和 hostname 之间存在一个 "-" 分隔符，所以至少需要 8 个字符的长度才能保证 run id 的完整性
     if hostname is not None:
-        hostname_max_len = min(hostname_max_len, available_length - 5 - 1)
+        hostname_max_len = min(hostname_max_len, available_length - 7 - 1)
     # 3. 开始截断和格式化中间部分的长度，hostname 和 run_id 共享 available_length 的长度，优先保证 hostname 的完整性
     hostname_truncated = False
     if hostname is not None:

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -462,11 +462,16 @@ def ensure_run_dir(
     raise RuntimeError(f"Failed to create a unique run directory after {max_retries} attempts")
 
 
-def _fmt_safe_dirname(dirname: str, _os_safe_re=re.compile(constraints.OS_SAFE_PATTERN)) -> str:
+def _fmt_safe_dirname(
+    dirname: str,
+    fallback: str = "unknown",
+    _os_safe_re=re.compile(constraints.OS_SAFE_PATTERN),
+) -> str:
     """
     格式化目录名，将不安全字符、"." 以及 "-" 替换为 "_"
 
     :param dirname: 原始目录名
+    :param fallback: 格式化后为空时的兜底值
     :param _os_safe_re: 用于判断安全字符的正则表达式，一般不改动，这里主要是为了在函数参数中预编译正则表达式，避免每次调用都编译一次
 
     :return: 格式化后的目录名
@@ -476,13 +481,13 @@ def _fmt_safe_dirname(dirname: str, _os_safe_re=re.compile(constraints.OS_SAFE_P
     dirname = dirname.replace(".", "_").replace("-", "_")
     dirname = re.sub(r"_{2,}", "_", dirname)
     dirname = dirname.strip().strip("_")
-    return dirname or "unknown_host"
+    return dirname or fallback
 
 
 def _truncate_dirname(name: str, max_length: int) -> Tuple[str, bool]:
     """
-    截断目录名，保留前3和后2个字符，中间用 "..." 连接
-    例如： "abcdefghijklmnopqrstuvwxyz" 截断为 "abc...yz"
+    截断目录名，保留前3和后部分字符，中间用 "..." 连接，确保结果不超过 max_length。
+    例如： "abcdefghijklmnopqrstuvwxyz" 截断为 "abc...yz"（max_length >= 8 时）
 
     :param name: 原始目录名
     :param max_length: 目录名最大长度
@@ -490,11 +495,10 @@ def _truncate_dirname(name: str, max_length: int) -> Tuple[str, bool]:
     """
     if len(name) <= max_length:
         return name, False
-    if max_length <= 5:
-        raise ValueError(
-            "Failed to generate run directory name: max_length must be greater than 5 to allow truncation."
-        )
-    truncated_name = f"{name[:3]}...{name[-2:]}"
+    if max_length < 7:
+        return name[:max_length], True
+    tail_len = max_length - 6  # 3 (head) + 3 (...) + tail
+    truncated_name = f"{name[:3]}...{name[-tail_len:]}"
     return truncated_name, True
 
 
@@ -538,10 +542,10 @@ def _generate_run_dir_name(
     # 3. 开始截断和格式化中间部分的长度，hostname 和 run_id 共享 available_length 的长度，优先保证 hostname 的完整性
     hostname_truncated = False
     if hostname is not None:
-        hostname = _fmt_safe_dirname(hostname)
+        hostname = _fmt_safe_dirname(hostname, fallback="unknown_host")
         hostname, hostname_truncated = _truncate_dirname(hostname, hostname_max_len)
         available_length -= len(hostname) + 1  # 减去 hostname 的长度和一个 "-" 分隔符
-    run_id = _fmt_safe_dirname(run_id)
+    run_id = _fmt_safe_dirname(run_id, fallback="unknown_run")
     run_id, run_id_truncated = _truncate_dirname(run_id, available_length)
     # 4. 组合最终的目录名
     dir_name = prefix + run_id

--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -10,10 +10,11 @@ init函数执行时被视为init之前
 
 import json
 import os
+import re
+import socket
 import time
 from datetime import datetime
 from functools import partial
-from hashlib import sha256
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -30,7 +31,7 @@ from swanlab.sdk.internal.context import (
     use_context,
 )
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.internal.pkg import adapter, console, fs, helper, safe
+from swanlab.sdk.internal.pkg import adapter, console, constraints, fork, fs, helper, safe
 from swanlab.sdk.typings.cmd import ConfigLike
 from swanlab.sdk.typings.context import CallbacksType
 from swanlab.utils.experiment import generate_color, generate_id, generate_name
@@ -38,7 +39,7 @@ from swanlab.utils.experiment import generate_color, generate_id, generate_name
 from ..internal.run import Run, get_run, has_run
 from ..internal.settings import Settings
 from ..internal.settings import settings as global_settings
-from ..typings.run import ModeType, ResumeType
+from ..typings.run import ModeType, ParallelType, ResumeType
 from . import utils
 from .login import login_cli, login_raw
 
@@ -103,6 +104,7 @@ def init(
     tags: Optional[List[str]] = None,
     id: Optional[str] = None,
     resume: Optional[Union[ResumeType, bool]] = None,
+    parallel: Optional[ParallelType] = None,
     config: Optional[ConfigLike] = None,
     settings: Optional[Settings] = None,
     callbacks: Optional[CallbacksType] = None,
@@ -143,6 +145,8 @@ def init(
 
     :param resume: Resume behavior. Options: "must" (must resume), "allow" (resume if exists),
         "never" (always create new). Defaults to "never".
+
+    :param parallel: Parallel execution strategy. Options: "none" (default), "shared".
 
     :param config: Experiment configuration dict or path to config file (JSON/YAML).
 
@@ -219,6 +223,7 @@ def init(
         "run.resume": resume,
         "run.id": id,
         "run.config": Path(config) if isinstance(config, (str, os.PathLike)) else None,
+        "run.parallel": parallel,
     }.items():
         set_nested_value(args_dict, key, value)
     run_settings.merge_settings(args_dict)
@@ -417,6 +422,7 @@ def ensure_run_dir(
     retry_interval: float = 1.0,
     dir_max_length: int = 255,
     dir_name: Optional[str] = None,
+    parallel: ParallelType = "none",
 ) -> Path:
     """
     原子化地创建一个不与已有目录冲突的 run_dir。
@@ -441,7 +447,7 @@ def ensure_run_dir(
         fs.safe_mkdir(run_dir, ensure_clean=True)
         return run_dir
     for i in range(max_retries):
-        run_dir_name, truncated = _generate_run_dir_name(run_id, dir_max_length)
+        run_dir_name, truncated = _generate_run_dir_name(run_id, dir_max_length, parallel)
         run_dir = log_dir / run_dir_name
         try:
             fs.safe_mkdir(run_dir, ensure_clean=True)
@@ -456,26 +462,94 @@ def ensure_run_dir(
     raise RuntimeError(f"Failed to create a unique run directory after {max_retries} attempts")
 
 
-def _generate_run_dir_name(run_id: str, max_length: int) -> Tuple[str, bool]:
+def _fmt_safe_dirname(dirname: str, _os_safe_re=re.compile(constraints.OS_SAFE_PATTERN)) -> str:
+    """
+    格式化目录名，将不安全字符、"." 以及 "-" 替换为 "_"
+
+    :param dirname: 原始目录名
+    :param _os_safe_re: 用于判断安全字符的正则表达式，一般不改动，这里主要是为了在函数参数中预编译正则表达式，避免每次调用都编译一次
+
+    :return: 格式化后的目录名
+    """
+    # 允许的安全字符直接保留，不允许的字符替换为 "_"
+    dirname = "".join(c if _os_safe_re.match(c) else "_" for c in dirname)
+    dirname = dirname.replace(".", "_").replace("-", "_")
+    dirname = re.sub(r"_{2,}", "_", dirname)
+    dirname = dirname.strip().strip("_")
+    return dirname or "unknown_host"
+
+
+def _truncate_dirname(name: str, max_length: int) -> Tuple[str, bool]:
+    """
+    截断目录名，保留前3和后2个字符，中间用 "..." 连接
+    例如： "abcdefghijklmnopqrstuvwxyz" 截断为 "abc...yz"
+
+    :param name: 原始目录名
+    :param max_length: 目录名最大长度
+    :return: 截断后的目录名和是否发生了截断
+    """
+    if len(name) <= max_length:
+        return name, False
+    if max_length <= 5:
+        raise ValueError(
+            "Failed to generate run directory name: max_length must be greater than 5 to allow truncation."
+        )
+    truncated_name = f"{name[:3]}...{name[-2:]}"
+    return truncated_name, True
+
+
+def _generate_run_dir_name(
+    run_id: str,
+    max_length: int,
+    parallel: ParallelType = "none",
+    hostname_max_len: int = 64,
+) -> Tuple[str, bool]:
     """
     生成 run_dir 的目录名，格式为 ``run-{timestamp}-{run_id}``，超长时截断。
+    如果为共享模式或者分布式训练，增加hostname和pid两个参数，格式为 ``run-{timestamp}-{run_id}-{hostname}-{pid}``，
+    语义为 "某一时刻、某个运行id、某个主机、某个进程开启的运行"。
 
     :param run_id: 当前运行的唯一标识符
     :param max_length: 目录名最大长度
+    :param parallel: 并行策略
+    :param hostname_max_len: 主机名最大长度，仅在共享模式或者分布式时使用，hostname_max_len 有可能会被进一步缩减以适应 max_length
+
     :return: run_dir 目录名（非完整路径）和是否截断
     """
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    name = f"run-{timestamp}-{run_id}"
-    if len(name) <= max_length:
-        return name, False
-
-    digest = sha256(run_id.encode("utf-8")).hexdigest()[:8]
-    prefix = f"run-{timestamp}-truncated-"
-    suffix = f"-{digest}"
-    run_id_max_length = max_length - len(prefix) - len(suffix)
-    truncated_run_id = run_id[: max(0, run_id_max_length)]
-    truncated_name = f"{prefix}{truncated_run_id}{suffix}"
-    return truncated_name, True
+    # 1. 先准备前后缀，因为只有run_id和hostname有可能被截断
+    prefix = "-".join(["run", datetime.now().strftime("%Y%m%d_%H%M%S")]) + "-"
+    suffix: Optional[str] = None
+    hostname: Optional[str] = None
+    # 并行模式添加hostname和pid到目录名
+    if parallel != "none":
+        hostname = socket.gethostname() or "unknown_hostname"
+        suffix = f"-{fork.current_pid()}"
+    # 2. 计算中间部分的可用长度（算上"-"分隔符），并确定 hostname 的最大长度
+    reserved_length = len(prefix) + len(suffix or "")
+    available_length = max_length - reserved_length
+    if available_length <= 0:
+        # 由于 settings 中 dir_max_length 的约束，理论上不会出现 available_length <= 0 的情况，但这里做一个兜底，避免出现负数导致后续逻辑混乱
+        raise ValueError(
+            f"Failed to generate run directory name: max_length {max_length} is too small to accommodate prefix and suffix."
+        )
+    # run id 最小会被截断为 "a...b" 样式，长度为 5，并且 run id 和 hostname 之间存在一个 "-" 分隔符，所以至少需要 6 个字符的长度才能保证 run id 的完整性
+    if hostname is not None:
+        hostname_max_len = min(hostname_max_len, available_length - 5 - 1)
+    # 3. 开始截断和格式化中间部分的长度，hostname 和 run_id 共享 available_length 的长度，优先保证 hostname 的完整性
+    hostname_truncated = False
+    if hostname is not None:
+        hostname = _fmt_safe_dirname(hostname)
+        hostname, hostname_truncated = _truncate_dirname(hostname, hostname_max_len)
+        available_length -= len(hostname) + 1  # 减去 hostname 的长度和一个 "-" 分隔符
+    run_id = _fmt_safe_dirname(run_id)
+    run_id, run_id_truncated = _truncate_dirname(run_id, available_length)
+    # 4. 组合最终的目录名
+    dir_name = prefix + run_id
+    if hostname is not None:
+        dir_name += f"-{hostname}"
+    if suffix is not None:
+        dir_name += suffix
+    return dir_name, hostname_truncated or run_id_truncated
 
 
 def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[RunContext, Optional[str]]:
@@ -502,13 +576,14 @@ def _init(run_settings: Settings, callbacks: Optional[CallbacksType]) -> Tuple[R
             max_retries=run_settings.run.dir_create_retries,
             dir_max_length=run_settings.run.dir_max_length,
             dir_name=run_settings.run.dir,
+            parallel=run_settings.run.parallel,
         )
     else:
         # 禁用模式下的run_dir为一个示例目录，仅用于满足上下文类型限制
         if run_settings.run.dir:
             run_dir = run_settings.log_dir / run_settings.run.dir
         else:
-            run_dir_name, _ = _generate_run_dir_name(run_id, run_settings.run.dir_max_length)
+            run_dir_name, _ = _generate_run_dir_name(run_id, run_settings.run.dir_max_length, run_settings.run.parallel)
             run_dir = run_settings.log_dir / run_dir_name
     # 3. 创建一个临时的上下文，避免出现任何问题导致上下文残留
     with use_context(RunContext(config=RunConfig(settings=run_settings, run_dir=run_dir), callbacks=callbacks)) as ctx:

--- a/swanlab/sdk/internal/core_python/context/__init__.py
+++ b/swanlab/sdk/internal/core_python/context/__init__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Literal, Optional
 
 from swanlab.proto.swanlab.settings.core.v1.core_pb2 import CoreSettings
+from swanlab.sdk.internal.pkg import fs
 
 __all__ = ["CoreContext", "CoreConfig"]
 
@@ -133,11 +134,16 @@ class CoreContext:
     @cached_property
     def run_file(self) -> Path:
         if self._mode == "core":
-            assert self.config.run_id, "Run ID is not set."
-            # core 模式下，根据run id创建run file
-            return self.config.run_dir / f"run-{self.config.run_id}.swanlab"
+            # 1. core 模式下，根据run id创建run file
+            run_id = self.config.run_id
+            assert run_id, "Run ID is not set."
+            # 确保 run_id 中的特殊字符被安全替换，避免文件系统不兼容
+            run_id = fs.safe_fmt(run_id, fallback="unknown_run_id")
+            # 避免过长的 run_id 导致文件系统不兼容
+            run_id = fs.safe_truncate(run_id, max_length=100)[0]
+            return self.config.run_dir / f"run-{run_id}.swanlab"
         elif self._mode == "sync":
-            # sync 模式下，查询目录下 run-*.swanlab 文件作为run file
+            # 2. sync 模式下，查询目录下 run-*.swanlab 文件作为run file
             files = sorted(self.config.run_dir.glob("run-*.swanlab"))
             if len(files) == 0:
                 raise FileNotFoundError(f"No run-*.swanlab file found in {self.config.run_dir}")

--- a/swanlab/sdk/internal/pkg/fs/__init__.py
+++ b/swanlab/sdk/internal/pkg/fs/__init__.py
@@ -61,10 +61,17 @@ def safe_truncate(name: str, max_length: int = 255) -> Tuple[str, bool]:
     if len(name.encode("utf-8")) <= max_length:
         return name, False
     if max_length < 7:
-        raise ValueError(f"max_length ({max_length}) is too small for truncate_dirname, must be >= 7.")
+        raise ValueError(f"max_length ({max_length}) is too small for safe_truncate, must be >= 7.")
     tail_len = max_length - 6
     truncated_name = f"{name[:3]}...{name[-tail_len:]}"
-    while len(truncated_name.encode("utf-8")) > max_length and tail_len > 0:
+    # 当 tail_len=0 时，truncated_name 为 "abc...{整个name}"，此时再比较没什么意义，所以到了 tail_len=1 就停止循环，确保至少保留一个字符
+    while len(truncated_name.encode("utf-8")) > max_length and tail_len > 1:
         tail_len -= 1
-        truncated_name = f"{name[:3]}...{name[-tail_len:]}" if tail_len > 0 else f"{name[:3]}..."
+        truncated_name = f"{name[:3]}...{name[-tail_len:]}"
+    # 在极端情况下（例如所有字符都是多字节的），即使 tail_len=1 也可能超过 max_length，因此需要最后再检查一次
+    if len(truncated_name.encode("utf-8")) > max_length:
+        raise ValueError(
+            f"max_length ({max_length}) is too small for safe_truncate: "
+            f"the first 3 characters of the name already exceed {max_length - 3} bytes."
+        )
     return truncated_name, True

--- a/swanlab/sdk/internal/pkg/fs/__init__.py
+++ b/swanlab/sdk/internal/pkg/fs/__init__.py
@@ -65,6 +65,7 @@ def safe_truncate(name: str, max_length: int = 255) -> Tuple[str, bool]:
     tail_len = max_length - 6
     truncated_name = f"{name[:3]}...{name[-tail_len:]}"
     # 当 tail_len=0 时，truncated_name 为 "abc...{整个name}"，此时再比较没什么意义，所以到了 tail_len=1 就停止循环，确保至少保留一个字符
+    # tail_len=0 和 tail_len=1 实际上是等价的
     while len(truncated_name.encode("utf-8")) > max_length and tail_len > 1:
         tail_len -= 1
         truncated_name = f"{name[:3]}...{name[-tail_len:]}"

--- a/swanlab/sdk/internal/pkg/fs/__init__.py
+++ b/swanlab/sdk/internal/pkg/fs/__init__.py
@@ -7,14 +7,16 @@
 """
 
 import os
+import re
 import shutil
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
+from .. import constraints
 from .dir import safe_mkdir, safe_mkdirs
 from .write import safe_write
 
-__all__ = ["safe_mkdir", "safe_mkdirs", "safe_link", "safe_write"]
+__all__ = ["safe_fmt", "safe_mkdir", "safe_mkdirs", "safe_link", "safe_truncate", "safe_write"]
 
 
 def safe_link(source: Union[str, Path], target: Union[str, Path]) -> Path:
@@ -27,3 +29,42 @@ def safe_link(source: Union[str, Path], target: Union[str, Path]) -> Path:
         except OSError:
             shutil.copy2(str(source), str(target))
     return target
+
+
+_OS_SAFE_RE = re.compile(constraints.OS_SAFE_PATTERN)
+
+
+def safe_fmt(dirname: str, fallback: str = "unknown") -> str:
+    """
+    格式化目录名，将不安全字符、"." 以及 "-" 替换为 "_"
+
+    :param dirname: 原始目录名
+    :param fallback: 格式化后为空时的兜底值
+    :return: 格式化后的目录名
+    """
+    dirname = "".join(c if _OS_SAFE_RE.match(c) else "_" for c in dirname)
+    dirname = dirname.replace(".", "_").replace("-", "_")
+    dirname = re.sub(r"_{2,}", "_", dirname)
+    dirname = dirname.strip().strip("_")
+    return dirname or fallback
+
+
+def safe_truncate(name: str, max_length: int = 255) -> Tuple[str, bool]:
+    """
+    截断目录名，保留前3和后部分字符，中间用 "..." 连接，确保结果的 UTF-8 字节长度不超过 max_length。
+    例如： "abcdefghijklmnopqrstuvwxyz" 截断为 "abc...yz"（max_length >= 8 时）
+
+    :param name: 原始目录名
+    :param max_length: 目录名最大字节长度，必须 >= 7 以容纳 "abc...yz" 格式，一般文件系统的限制是不超过255字节
+    :return: 截断后的目录名和是否发生了截断
+    """
+    if len(name.encode("utf-8")) <= max_length:
+        return name, False
+    if max_length < 7:
+        raise ValueError(f"max_length ({max_length}) is too small for truncate_dirname, must be >= 7.")
+    tail_len = max_length - 6
+    truncated_name = f"{name[:3]}...{name[-tail_len:]}"
+    while len(truncated_name.encode("utf-8")) > max_length and tail_len > 0:
+        tail_len -= 1
+        truncated_name = f"{name[:3]}...{name[-tail_len:]}" if tail_len > 0 else f"{name[:3]}..."
+    return truncated_name, True

--- a/swanlab/sdk/internal/run/greeting.py
+++ b/swanlab/sdk/internal/run/greeting.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from rich.text import Text
 
 from swanlab.sdk.internal.context import RunContext
-from swanlab.sdk.internal.pkg import console
+from swanlab.sdk.internal.pkg import console, fs
 from swanlab.sdk.internal.pkg.helper.version import get_swanlab_version
 
 if TYPE_CHECKING:
@@ -28,35 +28,13 @@ def _print_save_dir(ctx: RunContext):
     console.info("💾 Run data saved at", Text(str(ctx.config.run_dir), "magenta bold"))
 
 
-def _truncate_middle(text: object, max_len: int = 45, placeholder: str = "...") -> str:
-    """
-    Truncate text in the middle if it exceeds max_len.
-
-    Examples:
-        abcdefghijklmnopqrstuvwxyz, max_len=10 -> abcd...xyz
-    """
-    text = str(text)
-    if max_len <= 0:
-        return placeholder
-    if len(text) <= max_len:
-        return text
-    if len(placeholder) >= max_len:
-        return placeholder[:max_len]
-    remain = max_len - len(placeholder)
-    left_len = (remain + 1) // 2
-    right_len = remain // 2
-    left = text[:left_len]
-    right = text[-right_len:] if right_len > 0 else ""
-    return left + placeholder + right
-
-
 def _print_online_tip(run: "Run"):
     project_url = run.url.split("/runs/")[0]
     console.info("📁 View project at", Text(project_url, style=f"link {project_url} blue underline"))
     # 截断 run.name，超过 name_truncate_len 时，前后保留 20 个字符，中间显示 ...
     console.info(
         "🚀 View run",
-        Text(_truncate_middle(run.name), "yellow"),
+        Text(fs.safe_truncate(run.name, max_length=45)[0], "yellow"),
         "at",
         Text(run.url, style=f"link {run.url} blue underline"),
     )

--- a/swanlab/sdk/internal/run/greeting.py
+++ b/swanlab/sdk/internal/run/greeting.py
@@ -72,7 +72,7 @@ def _print_local_tip(ctx: RunContext):
 
 def _print_offline_tip(ctx: RunContext):
     console.info(
-        "☁️ Run ",
+        "⚡️ Run",
         Text(f"`swanlab sync {str(ctx.config.run_dir)}`", "bold"),
         "to sync this run",
     )

--- a/swanlab/sdk/internal/settings/experiment.py
+++ b/swanlab/sdk/internal/settings/experiment.py
@@ -9,13 +9,15 @@
 import json
 import os
 from pathlib import Path
-from typing import Annotated, Any, List, Literal, Optional, cast
+from typing import Annotated, Any, List, Optional, cast, get_args
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic.config import ConfigDict
 from pydantic_settings import NoDecode
 
+from swanlab.sdk.internal.pkg import console
 from swanlab.sdk.internal.pkg import constraints as const
-from swanlab.sdk.typings.run import ResumeType
+from swanlab.sdk.typings.run import ParallelType, ResumeType
 
 
 def project_name_factory() -> Optional[str]:
@@ -54,6 +56,8 @@ class ProjectSettings(BaseModel):
     """
     Whether this SwanLab run is public.
     """
+
+    model_config = ConfigDict(frozen=True)
 
 
 def experiment_name_factory() -> Optional[str]:
@@ -153,6 +157,8 @@ class ExperimentSettings(BaseModel):
     Job type for this SwanLab run.
     """
 
+    model_config = ConfigDict(frozen=True)
+
 
 def run_id_factory() -> Optional[str]:
     # 向下兼容旧版本环境变量
@@ -190,7 +196,7 @@ def map_resume_value(value: Any) -> ResumeType:
             return "allow"
         if value_lower == "0":
             return "never"
-        if value_lower in ["must", "allow", "never"]:
+        if value_lower in get_args(ResumeType):
             return cast(ResumeType, value_lower)
         raise ValueError(f"Invalid resume value: {value_lower}, must be one of ['must', 'allow', 'never']")
     raise ValueError(f"Invalid resume value type: {type(value).__name__}, must be one of ['must', 'allow', 'never']")
@@ -202,19 +208,24 @@ class RunSettings(BaseModel):
     Run ID for this SwanLab run.
     """
 
-    resume: Literal["must", "allow", "never"] = Field(default_factory=run_resume_factory)
+    resume: ResumeType = Field(default_factory=run_resume_factory)
     """
     Resume policy for this SwanLab run.
+    """
+
+    @field_validator("resume", mode="before")
+    def validate_resume(cls, v: Any) -> Any:
+        return map_resume_value(v)
+
+    parallel: ParallelType = Field(default="none")
+    """
+    Parallel execution policy for this SwanLab run.
     """
 
     history: Optional[Path] = Field(default=None)
     """
     History path for this SwanLab run, useful for resuming from a previous run.
     """
-
-    @field_validator("resume", mode="before")
-    def validate_resume(cls, v: Any) -> Any:
-        return map_resume_value(v)
 
     config: Optional[Path] = Field(default=None)
     """
@@ -238,8 +249,18 @@ class RunSettings(BaseModel):
     If the generated directory name conflicts with an existing one, a new name will be generated after a short delay, up to this many times.
     """
 
+    @model_validator(mode="before")
+    @classmethod
+    def force_resume_for_parallel(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("parallel", "none") != "none":
+            console.debug("Parallel execution detected, forcing resume policy to 'allow'")
+            return {**data, "resume": "allow"}
+        return data
+
     @model_validator(mode="after")
     def validate_dir_length(self) -> "RunSettings":
         if self.dir is not None and len(self.dir) > self.dir_max_length:
             raise ValueError(f"run.dir length ({len(self.dir)}) exceeds run.dir_max_length ({self.dir_max_length})")
         return self
+
+    model_config = ConfigDict(frozen=True)

--- a/swanlab/sdk/internal/settings/integration.py
+++ b/swanlab/sdk/internal/settings/integration.py
@@ -9,6 +9,7 @@ import os
 from typing import ClassVar, Type
 
 from pydantic import BaseModel, Field, model_validator
+from pydantic.config import ConfigDict
 
 
 def webhook_url_factory() -> str:
@@ -51,6 +52,7 @@ class WebhookSettings(BaseModel):
     """
     Webhook timeout for SwanLab notifications.
     """
+    model_config = ConfigDict(frozen=True)
 
 
 class DashBoardSettings(BaseModel):
@@ -63,6 +65,7 @@ class DashBoardSettings(BaseModel):
     """
     Dashboard server port.
     """
+    model_config = ConfigDict(frozen=True)
 
 
 class IntegrationSettings(BaseModel):
@@ -107,3 +110,5 @@ class IntegrationSettings(BaseModel):
                     data["dashboard"] = dashboard_data
 
         return data
+
+    model_config = ConfigDict(frozen=True)

--- a/swanlab/sdk/typings/run/__init__.py
+++ b/swanlab/sdk/typings/run/__init__.py
@@ -12,6 +12,11 @@ ResumeType = Literal["must", "allow", "never"]
 Run 恢复策略
 """
 
+ParallelType = Literal["none", "shared"]
+"""
+Run 并行策略
+"""
+
 ModeType = Literal["disabled", "online", "local", "offline"]
 """
 Run 运行策略

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -444,3 +444,11 @@ class TestEnsureRunDirShared:
         parts = name.split("-")
         # none 模式: run-{timestamp}-{run_id}，只有3段
         assert len(parts) == 3
+
+    def test_small_dir_max_length_truncation(self, tmp_path, monkeypatch):
+        """较小的 dir_max_length 时目录名仍不超限"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
+
+        run_dir = ensure_run_dir(tmp_path, "a" * 512, retry_interval=0.01, dir_max_length=50)
+
+        assert len(run_dir.name) <= 50

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -290,7 +290,7 @@ class TestEnsureRunDir:
 
         run_dir = ensure_run_dir(tmp_path, "a" * 512, retry_interval=0.01, dir_max_length=80)
 
-        assert len(run_dir.name) <= 80
+        assert len(run_dir.name.encode("utf-8")) <= 80
         assert "..." in run_dir.name
 
     def test_truncation_same_prefix(self, tmp_path, monkeypatch):
@@ -305,8 +305,8 @@ class TestEnsureRunDir:
 
         assert "..." in run_dir1.name
         assert "..." in run_dir2.name
-        assert len(run_dir1.name) <= 80
-        assert len(run_dir2.name) <= 80
+        assert len(run_dir1.name.encode("utf-8")) <= 80
+        assert len(run_dir2.name.encode("utf-8")) <= 80
 
     def test_warns_only_for_created_truncated_name(self, tmp_path, monkeypatch):
         """重试创建目录时，只对最终创建成功的截断目录告警"""
@@ -421,7 +421,7 @@ class TestEnsureRunDirShared:
 
         name = run_dir.name
         assert "..." in name
-        assert len(name) <= 255
+        assert len(name.encode("utf-8")) <= 255
 
     def test_shared_truncates_long_run_id(self, tmp_path, monkeypatch):
         """shared 模式下长 run_id 截断后不超限"""
@@ -431,7 +431,7 @@ class TestEnsureRunDirShared:
 
         run_dir = ensure_run_dir(tmp_path, "a" * 512, parallel="shared", retry_interval=0.01, dir_max_length=80)
 
-        assert len(run_dir.name) <= 80
+        assert len(run_dir.name.encode("utf-8")) <= 80
         assert "myhost" in run_dir.name
         assert "12345" in run_dir.name
 
@@ -446,9 +446,26 @@ class TestEnsureRunDirShared:
         assert len(parts) == 3
 
     def test_small_dir_max_length_truncation(self, tmp_path, monkeypatch):
-        """较小的 dir_max_length 时目录名仍不超限"""
+        """较小的 dir_max_length 时目录名字节长度仍不超限"""
         monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
 
         run_dir = ensure_run_dir(tmp_path, "a" * 512, retry_interval=0.01, dir_max_length=50)
 
-        assert len(run_dir.name) <= 50
+        assert len(run_dir.name.encode("utf-8")) <= 50
+
+    def test_chinese_hostname_byte_length_within_limit(self, tmp_path, monkeypatch):
+        """中文 hostname 的目录名 UTF-8 字节长度不超限"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: "我的电脑" * 20)
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01, dir_max_length=80)
+
+        assert len(run_dir.name.encode("utf-8")) <= 80
+
+    def test_chinese_run_id_byte_length_within_limit(self, tmp_path, monkeypatch):
+        """包含中文的 run_id 截断后字节长度不超限"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
+
+        run_dir = ensure_run_dir(tmp_path, "测试" * 100, retry_interval=0.01, dir_max_length=80)
+
+        assert len(run_dir.name.encode("utf-8")) <= 80

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -6,13 +6,11 @@
 """
 
 import json
-from hashlib import sha256
 from unittest.mock import MagicMock
 
 import pytest
 
 from swanlab.sdk.cmd.init import (
-    _generate_run_dir_name,
     compatible_kwargs,
     ensure_run_dir,
     load_config,
@@ -223,13 +221,12 @@ class TestEnsureRunDir:
         )._generate_run_dir_name
         this_run_dir = ""
 
-        def mock_generate(run_id, max_length):
+        def mock_generate(run_id, max_length, parallel="none", hostname_max_len=64):
             nonlocal call_count, this_run_dir
             call_count += 1
-            # 第一次生成一个已被占用的名字，第二次正常生成
             if call_count == 1:
                 return "run-20260101_000000-conflict", False
-            this_run_dir, truncated = original_generate(run_id, max_length)
+            this_run_dir, truncated = original_generate(run_id, max_length, parallel, hostname_max_len)
             return this_run_dir, truncated
 
         monkeypatch.setattr("swanlab.sdk.cmd.init._generate_run_dir_name", mock_generate)
@@ -255,8 +252,7 @@ class TestEnsureRunDir:
 
         name = run_dir.name
         assert name.startswith("run-")
-        assert name.endswith("-myrun42")
-        # 中间部分应为 YYYYMMDD_HHMMSS 格式
+        assert "myrun42" in name
         parts = name.split("-", 2)  # ["run", "20260418_123456", "myrun42"]
         assert len(parts) == 3
         timestamp = parts[1]
@@ -267,7 +263,10 @@ class TestEnsureRunDir:
         """超过最大重试次数仍无法创建唯一目录时，应抛出 RuntimeError"""
         monkeypatch.setattr(
             "swanlab.sdk.cmd.init._generate_run_dir_name",
-            lambda _run_id, _max_length: ("run-20260101_000000-conflict", False),
+            lambda _run_id, _max_length, _parallel="none", _hostname_max_len=64: (
+                "run-20260101_000000-conflict",
+                False,
+            ),
         )
 
         # 预先创建冲突目录
@@ -276,66 +275,45 @@ class TestEnsureRunDir:
         with pytest.raises(RuntimeError, match="Failed to create a unique run directory after 2 attempts"):
             ensure_run_dir(tmp_path, "abc123", max_retries=2, retry_interval=0.01)
 
-    def test_generate_run_dir_name_keeps_short_name(self, monkeypatch):
-        """未超过长度限制时，应保持原始格式且不告警"""
-        warning = MagicMock()
-        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
+    def test_keeps_short_name(self, tmp_path):
+        """未超过长度限制时，应保持原始格式"""
+        run_dir = ensure_run_dir(tmp_path, "myrun42", retry_interval=0.01)
 
-        name, truncated = _generate_run_dir_name("myrun42", 255)
-
+        name = run_dir.name
         assert name.startswith("run-")
-        assert name.endswith("-myrun42")
-        assert "truncated" not in name
-        assert truncated is False
-        warning.assert_not_called()
+        assert "myrun42" in name
+        assert "..." not in name
 
-    def test_generate_run_dir_name_truncates_long_name(self, monkeypatch):
-        """超过长度限制时，应截断并在目录名中体现 truncated 语义"""
-        warning = MagicMock()
-        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
-
-        name, truncated = _generate_run_dir_name("a" * 512, 80)
-
-        assert len(name) <= 80
-        assert "truncated" in name
-        assert truncated is True
-        warning.assert_not_called()
-
-    def test_generate_run_dir_name_uses_hash_to_reduce_conflicts(self, monkeypatch):
-        """相同长前缀但不同内容的 run_id 截断后仍应生成不同名称"""
+    def test_truncates_long_name(self, tmp_path, monkeypatch):
+        """超过长度限制时，应截断并在目录名中体现 ... 省略"""
         monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
 
-        name1, _ = _generate_run_dir_name("a" * 511 + "1", 80)
-        name2, _ = _generate_run_dir_name("a" * 511 + "2", 80)
+        run_dir = ensure_run_dir(tmp_path, "a" * 512, retry_interval=0.01, dir_max_length=80)
 
-        assert name1 != name2
+        assert len(run_dir.name) <= 80
+        assert "..." in run_dir.name
 
-    def test_generate_run_dir_name_zero_id_space(self, monkeypatch):
-        """max_length 刚好等于 prefix + suffix 长度时，run_id 被完全截去，结果不超限"""
+    def test_truncation_same_prefix(self, tmp_path, monkeypatch):
+        """不同 run_id 截断后前缀相同时，... 省略格式可能相同"""
         monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
-        timestamp = "20260101_000000"
-        monkeypatch.setattr(
-            "swanlab.sdk.cmd.init.datetime", MagicMock(now=lambda: MagicMock(strftime=lambda _: timestamp))
-        )
 
-        run_id = "a" * 512
-        prefix = f"run-{timestamp}-truncated-"
-        digest = sha256(run_id.encode("utf-8")).hexdigest()[:8]
-        suffix = f"-{digest}"
-        max_length = len(prefix) + len(suffix)
+        run_dir1 = ensure_run_dir(tmp_path, "a" * 511 + "1", retry_interval=0.01, dir_max_length=80)
+        # 用不同的 log_dir 避免冲突
+        log_dir2 = tmp_path / "second"
+        log_dir2.mkdir()
+        run_dir2 = ensure_run_dir(log_dir2, "a" * 511 + "2", retry_interval=0.01, dir_max_length=80)
 
-        name, truncated = _generate_run_dir_name(run_id, max_length)
+        assert "..." in run_dir1.name
+        assert "..." in run_dir2.name
+        assert len(run_dir1.name) <= 80
+        assert len(run_dir2.name) <= 80
 
-        assert len(name) == max_length
-        assert name == prefix + suffix
-        assert truncated is True
-
-    def test_ensure_run_dir_warns_only_for_created_truncated_name(self, tmp_path, monkeypatch):
+    def test_warns_only_for_created_truncated_name(self, tmp_path, monkeypatch):
         """重试创建目录时，只对最终创建成功的截断目录告警"""
         warning = MagicMock()
         call_count = 0
 
-        def mock_generate(_run_id, _max_length):
+        def mock_generate(_run_id, _max_length, _parallel="none", _hostname_max_len=64):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -352,13 +330,16 @@ class TestEnsureRunDir:
         warning.assert_called_once()
         assert "run-20260101_000001-success" in warning.call_args.args[0]
 
-    def test_ensure_run_dir_does_not_warn_when_truncated_name_never_created(self, tmp_path, monkeypatch):
+    def test_does_not_warn_when_truncated_name_never_created(self, tmp_path, monkeypatch):
         """全部重试失败时，不应对未使用的截断目录告警"""
         warning = MagicMock()
         monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
         monkeypatch.setattr(
             "swanlab.sdk.cmd.init._generate_run_dir_name",
-            lambda _run_id, _max_length: ("run-20260101_000000-conflict", True),
+            lambda _run_id, _max_length, _parallel="none", _hostname_max_len=64: (
+                "run-20260101_000000-conflict",
+                True,
+            ),
         )
         (tmp_path / "run-20260101_000000-conflict").mkdir()
 
@@ -367,16 +348,99 @@ class TestEnsureRunDir:
 
         warning.assert_not_called()
 
-    def test_ensure_run_dir_with_dir_name_creates_once(self, tmp_path):
+    def test_with_dir_name_creates_once(self, tmp_path):
         """指定 dir_name 时直接使用，仅创建一次"""
         run_dir = ensure_run_dir(tmp_path, "abc123", dir_name="my-custom-dir")
 
         assert run_dir.exists()
         assert run_dir.name == "my-custom-dir"
 
-    def test_ensure_run_dir_with_dir_name_conflict_raises(self, tmp_path):
+    def test_with_dir_name_conflict_raises(self, tmp_path):
         """指定 dir_name 时目录已存在，直接抛错"""
         (tmp_path / "my-custom-dir").mkdir()
 
         with pytest.raises(FileExistsError):
             ensure_run_dir(tmp_path, "abc123", dir_name="my-custom-dir")
+
+
+class TestEnsureRunDirShared:
+    """测试 ensure_run_dir 在 shared 模式下的行为"""
+
+    def test_shared_name_contains_hostname_and_pid(self, tmp_path, monkeypatch):
+        """shared 模式目录名应包含 hostname 和 pid"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: "myhost")
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 99999)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01)
+
+        name = run_dir.name
+        assert name.startswith("run-")
+        assert "myhost" in name
+        assert "99999" in name
+        assert "run42" in name
+
+    def test_shared_hostname_sanitize(self, tmp_path, monkeypatch):
+        """hostname 中的非法字符应被替换为 _"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: "node:01.cluster/local")
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01)
+
+        name = run_dir.name
+        assert ":" not in name
+        assert "/" not in name
+        assert "node_01_cluster_local" in name
+
+    def test_shared_hostname_preserves_chinese(self, tmp_path, monkeypatch):
+        """中文 hostname 应被保留"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: "我的电脑")
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01)
+
+        name = run_dir.name
+        assert "我的电脑" in name
+
+    def test_shared_hostname_all_illegal_fallback(self, tmp_path, monkeypatch):
+        """全非法字符 hostname 应回退为 unknown_host"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: "<>:|?*#%")
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01)
+
+        name = run_dir.name
+        assert "unknown_host" in name
+
+    def test_shared_hostname_truncation(self, tmp_path, monkeypatch):
+        """超长 hostname 应被截断为 abc...yz 格式"""
+        long_hostname = "a" * 100
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: long_hostname)
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01)
+
+        name = run_dir.name
+        assert "..." in name
+        assert len(name) <= 255
+
+    def test_shared_truncates_long_run_id(self, tmp_path, monkeypatch):
+        """shared 模式下长 run_id 截断后不超限"""
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", lambda: "myhost")
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", MagicMock())
+
+        run_dir = ensure_run_dir(tmp_path, "a" * 512, parallel="shared", retry_interval=0.01, dir_max_length=80)
+
+        assert len(run_dir.name) <= 80
+        assert "myhost" in run_dir.name
+        assert "12345" in run_dir.name
+
+    def test_none_mode_no_hostname(self, tmp_path):
+        """parallel="none" 时目录名不应包含 hostname"""
+        run_dir = ensure_run_dir(tmp_path, "run42", retry_interval=0.01)
+
+        name = run_dir.name
+        assert name.startswith("run-")
+        parts = name.split("-")
+        # none 模式: run-{timestamp}-{run_id}，只有3段
+        assert len(parts) == 3

--- a/tests/unit/sdk/cmd/init/test_init_helper.py
+++ b/tests/unit/sdk/cmd/init/test_init_helper.py
@@ -469,3 +469,19 @@ class TestEnsureRunDirShared:
         run_dir = ensure_run_dir(tmp_path, "测试" * 100, retry_interval=0.01, dir_max_length=80)
 
         assert len(run_dir.name.encode("utf-8")) <= 80
+
+    def test_empty_hostname_uses_fallback_and_warns(self, tmp_path, monkeypatch):
+        """socket.gethostname() 抛异常时应使用 unknown_hostname 并告警"""
+
+        def _raise_os_error():
+            raise OSError("hostname lookup failed")
+
+        monkeypatch.setattr("swanlab.sdk.cmd.init.socket.gethostname", _raise_os_error)
+        monkeypatch.setattr("swanlab.sdk.cmd.init.fork.current_pid", lambda: 12345)
+        warning = MagicMock()
+        monkeypatch.setattr("swanlab.sdk.cmd.init.console.warning", warning)
+
+        run_dir = ensure_run_dir(tmp_path, "run42", parallel="shared", retry_interval=0.01)
+
+        assert "unknown_hostname" in run_dir.name
+        warning.assert_called_once()

--- a/tests/unit/sdk/internal/pkg/fs/test_pkg_fs_init.py
+++ b/tests/unit/sdk/internal/pkg/fs/test_pkg_fs_init.py
@@ -117,3 +117,24 @@ class TestSafeTruncate:
         result, truncated = safe_truncate(name)
         assert truncated is True
         assert len(result.encode("utf-8")) <= 255
+
+    def test_tail_shrinks_from_two_to_one(self):
+        """tail_len=2 时超限，应减到 1 再检查；tail_len > 2 会错误跳过缩减导致 raise"""
+        # name[:3]="abc" (3B) + "..." (3B) + name[-2:]="试测" (6B) = 12B > 8
+        # 减到 tail_len=1: name[-1:]="测" (3B) → "abc...测" = 9B > 8，仍超限，最终 raise
+        # 但关键是循环必须执行 tail_len 2→1 的缩减，而非跳过
+        name = "abc测试测试测试"
+        with pytest.raises(ValueError):
+            safe_truncate(name, 8)
+
+    def test_tail_shrinks_from_two_to_one_succeeds(self):
+        """tail_len=2 时超限，减到 1 后恰好满足 max_length，应返回而非 raise"""
+        # name[:3]="abc" (3B) + "..." (3B) + name[-2:]="de" (2B) = 8B == 8，恰好不超
+        # 所以这个 case 初始就不超限，换一个：需要 tail 是多字节字符
+        # name[:3]="abc" (3B) + "..." (3B) + name[-2:]="测x" (4B) = 10B > 9
+        # 减到 tail_len=1: name[-1:]="x" (1B) → "abc...x" = 7B <= 9，满足
+        name = "abc测试测x"
+        result, truncated = safe_truncate(name, 9)
+        assert truncated is True
+        assert "..." in result
+        assert len(result.encode("utf-8")) <= 9

--- a/tests/unit/sdk/internal/pkg/fs/test_pkg_fs_init.py
+++ b/tests/unit/sdk/internal/pkg/fs/test_pkg_fs_init.py
@@ -1,0 +1,119 @@
+"""
+@author: cunyue
+@file: test_pkg_fs_init.py
+@time: 2026/5/23
+@description: 测试 fs.__init__ 中的 safe_fmt 和 safe_truncate
+"""
+
+import pytest
+
+from swanlab.sdk.internal.pkg.fs import safe_fmt, safe_truncate
+
+
+class TestSafeFmt:
+    def test_ascii_passthrough(self):
+        assert safe_fmt("hello") == "hello"
+
+    def test_illegal_chars_replaced(self):
+        result = safe_fmt("a<b>c:d")
+        assert result == "a_b_c_d"
+
+    def test_dot_and_dash_replaced(self):
+        result = safe_fmt("my-dir.name")
+        assert result == "my_dir_name"
+
+    def test_consecutive_underscores_collapsed(self):
+        result = safe_fmt("a<>b<>c")
+        assert result == "a_b_c"
+
+    def test_leading_trailing_stripped(self):
+        result = safe_fmt("---hello---")
+        assert result == "hello"
+
+    def test_chinese_preserved(self):
+        result = safe_fmt("我的电脑")
+        assert result == "我的电脑"
+
+    def test_all_illegal_uses_fallback(self):
+        result = safe_fmt("<>:|?*#%", fallback="my_fb")
+        assert result == "my_fb"
+
+    def test_all_illegal_default_fallback(self):
+        result = safe_fmt("<>:|?*#%")
+        assert result == "unknown"
+
+    def test_custom_fallback(self):
+        result = safe_fmt("<>:|?*#%", fallback="unknown_host")
+        assert result == "unknown_host"
+
+    def test_empty_string_uses_fallback(self):
+        assert safe_fmt("") == "unknown"
+
+    def test_whitespace_only_uses_fallback(self):
+        assert safe_fmt("   ") == "unknown"
+
+    def test_mixed_chinese_and_illegal(self):
+        result = safe_fmt("我的:电脑/主机")
+        assert result == "我的_电脑_主机"
+
+
+class TestSafeTruncate:
+    def test_short_name_unchanged(self):
+        result, truncated = safe_truncate("hello", 255)
+        assert result == "hello"
+        assert truncated is False
+
+    def test_exact_length_unchanged(self):
+        name = "a" * 10
+        result, truncated = safe_truncate(name, 10)
+        assert result == name
+        assert truncated is False
+
+    def test_truncate_basic(self):
+        name = "a" * 20
+        result, truncated = safe_truncate(name, 10)
+        assert truncated is True
+        assert result.startswith("aaa...")
+        assert len(result.encode("utf-8")) <= 10
+
+    def test_truncate_format(self):
+        name = "abcdefghijklmnopqrstuvwxyz"
+        result, truncated = safe_truncate(name, 10)
+        assert truncated is True
+        assert "..." in result
+        assert result.startswith("abc")
+
+    def test_max_length_too_small(self):
+        with pytest.raises(ValueError, match="must be >= 7"):
+            safe_truncate("a" * 20, 5)
+
+    def test_max_length_exactly_7(self):
+        name = "a" * 20
+        result, truncated = safe_truncate(name, 7)
+        assert truncated is True
+        assert len(result.encode("utf-8")) <= 7
+        assert "..." in result
+
+    def test_chinese_within_limit(self):
+        name = "测试" * 100
+        result, truncated = safe_truncate(name, 30)
+        assert truncated is True
+        assert len(result.encode("utf-8")) <= 30
+
+    def test_chinese_prefix_exceeds_max_length(self):
+        name = "测试" * 100
+        with pytest.raises(ValueError, match="first 3 characters"):
+            safe_truncate(name, 7)
+
+    def test_byte_length_not_character_length(self):
+        name = "测试" * 50
+        result, truncated = safe_truncate(name, 20)
+        assert truncated is True
+        assert len(result.encode("utf-8")) <= 20
+        assert len(result) != len(result.encode("utf-8"))
+
+    def test_default_max_length(self):
+        name = "a" * 300
+        result, truncated = safe_truncate(name)
+        assert truncated is True
+        assert len(result.encode("utf-8")) <= 255

--- a/tests/unit/sdk/internal/settings/test_settings_experiment.py
+++ b/tests/unit/sdk/internal/settings/test_settings_experiment.py
@@ -63,6 +63,14 @@ def test_run_resume_parse(monkeypatch):
         Settings.model_validate({"run": {"resume": 1}})
 
 
+def test_run_parallel_forces_resume_allow():
+    s = Settings.model_validate({"run": {"parallel": "shared"}})
+    assert s.run.resume == "allow"
+
+    s = Settings.model_validate({"run": {"parallel": "shared", "resume": "never"}})
+    assert s.run.resume == "allow"
+
+
 class TestMapResumeValue:
     @pytest.mark.parametrize(
         "input_value,expected",


### PR DESCRIPTION
## Summary

本次变更为 SwanLab 新增并行执行（parallel）能力，主要包括：

1. **新增 `parallel` 参数**：`swanlab.init(parallel="shared")` 支持 shared 并行模式
2. **Shared 模式强制 `resume="allow"`**：通过 `RunSettings` 的 `model_validator` 自动联动
3. **Shared 模式 run 目录名升级**：格式变为 `run-{timestamp}-{run_id}-{hostname}-{pid}`，避免大规模分布式训练时目录名冲突
4. **Settings 模型统一添加 `frozen=True`**：`ProjectSettings`、`ExperimentSettings`、`RunSettings`、`IntegrationSettings` 及其子模型均设为不可变

## Changes

### `swanlab/sdk/typings/run/__init__.py`
- 新增 `ParallelType = Literal["none", "shared"]`

### `swanlab/sdk/internal/settings/experiment.py`
- `RunSettings` 新增 `parallel` 字段
- 新增 `force_resume_for_parallel` model validator：`parallel != "none"` 时强制 `resume="allow"`
- `ProjectSettings`、`ExperimentSettings`、`RunSettings` 添加 `ConfigDict(frozen=True)`

### `swanlab/sdk/internal/settings/integration.py`
- `IntegrationSettings` 及其子模型添加 `ConfigDict(frozen=True)`

### `swanlab/sdk/cmd/init.py`
- `swanlab.init()` 新增 `parallel` 参数
- 新增 `_fmt_safe_dirname()`：格式化目录名，移除 OS\_SAFE\_PATTERN 禁用的非法字符，保留中文等 Unicode
- 新增 `_truncate_dirname()`：统一截断逻辑，用 `...` 中间省略（如 `abc...yz`）
- 重写 `_generate_run_dir_name()`：shared 模式下目录名增加 hostname + pid，hostname 和 run\_id 共享可用长度，优先保证 hostname 完整性
- 去掉旧的 hash 摘要截断方式，改用 `...` 省略

### `swanlab/__init__.pyi`
- `init()` 签名新增 `parallel: Optional[ParallelType] = None`

### 测试

- **`TestEnsureRunDir`**：将直接调用 `_generate_run_dir_name` 的测试改为通过 `ensure_run_dir` 间接验证
  - `test_keeps_short_name`、`test_truncates_long_name`、`test_truncation_same_prefix` 适配新的 `...` 截断格式
- **`TestEnsureRunDirShared`**（新增）：7 个 shared 模式测试
  - 目录名包含 hostname + pid
  - hostname 非法字符 sanitize（`:` `/` `.` → `_`）
  - 中文 hostname 保留
  - 全非法字符 fallback 为 `unknown_host`
  - hostname 超长截断为 `abc...yz`
  - long run\_id 截断不超限
  - none 模式不含 hostname
- **`test_settings_experiment.py`**：新增 `test_run_parallel_forces_resume_allow` 测试 parallel 联动 resume

## Testing

```
uv run pytest tests/unit/sdk/cmd/init/test_init_helper.py tests/unit/sdk/internal/settings/test_settings_experiment.py -v
# 60 passed
uv run ruff check swanlab/sdk/cmd/init.py tests/unit/sdk/cmd/init/test_init_helper.py
# All checks passed
uv run basedpyright swanlab/sdk/cmd/init.py tests/unit/sdk/cmd/init/test_init_helper.py
# 0 errors, 0 warnings, 0 notes
```

## Closes

Closes #1636