### PR TITLE
fix: safe thread executor

### DIFF
--- a/swanlab/api/base.py
+++ b/swanlab/api/base.py
@@ -5,7 +5,6 @@
 @description: 所有实体类的公共基类
 """
 
-import asyncio
 import random
 import time
 from abc import ABC, abstractmethod
@@ -13,6 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple
 
 from swanlab.sdk.internal.pkg import safe
+from swanlab.sdk.internal.pkg.executor import SafeThreadPoolExecutor
 
 from .typings.common import MAX_CONCURRENT_COUNT, ApiPaginationType, ApiResponseType, PaginatedQuery
 
@@ -92,33 +92,23 @@ class BaseEntity(ABC):
     def _concurrent_request(
         self,
         requests: Sequence[Tuple[Callable, str, Dict[str, Any]]],
-        semaphore: int = MAX_CONCURRENT_COUNT,
+        max_workers: int = MAX_CONCURRENT_COUNT,
     ) -> List[ApiResponseType]:
         """
-        Execute multiple HTTP requests concurrently, bounded by a semaphore.
+        Execute multiple HTTP requests concurrently via thread pool.
 
         :param requests: List of ``(method, path, kwargs)`` tuples.
             ``method``: one of ``self._get`` / ``self._post`` / ``self._put`` / ``self._delete``.
             ``path``: API endpoint path.
             ``kwargs``: request parameters (``params=``, ``data=``, etc.).
-        :param semaphore: Maximum number of concurrent requests.
+        :param max_workers: Maximum number of concurrent requests (thread pool size).
         :return: ``ApiResponseType`` list with the same length as *requests*.
         """
         if not requests:
             return []
-
-        async def _run():
-            sem = asyncio.Semaphore(semaphore)
-
-            async def _fetch(req: Tuple[Callable, str, Dict[str, Any]]) -> ApiResponseType:
-                method, path, kwargs = req
-                async with sem:
-                    loop = asyncio.get_running_loop()
-                    return await loop.run_in_executor(None, lambda: method(path, **kwargs))
-
-            return await asyncio.gather(*[_fetch(r) for r in requests])
-
-        return asyncio.run(_run())
+        with SafeThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = [pool.submit(method, path, **kwargs) for method, path, kwargs in requests]
+            return [f.result() for f in futures]
 
     def _build_web_url(self, path: str) -> str:
         """Build a frontend web page URL (uses ``_web_host`` instead of ``_api_host``)."""

--- a/swanlab/converter/mlf/converter.py
+++ b/swanlab/converter/mlf/converter.py
@@ -23,13 +23,15 @@ class MLFlowConverter(BaseConverter):
         run_id: Optional[str] = None,
     ) -> None:
         mlflow = vendor.mlflow
+        from mlflow.exceptions import MlflowException
+
         import swanlab
 
         client = mlflow.MlflowClient(tracking_uri=tracking_uri)
 
         try:
             ex = client.get_experiment(experiment)
-        except mlflow.exceptions.MlflowException:
+        except MlflowException:
             ex = client.get_experiment_by_name(experiment)
         if not ex:
             raise ValueError(f'Could not find MLflow experiment with id or name "{experiment}"')

--- a/swanlab/converter/mlf/converter.py
+++ b/swanlab/converter/mlf/converter.py
@@ -23,9 +23,8 @@ class MLFlowConverter(BaseConverter):
         run_id: Optional[str] = None,
     ) -> None:
         mlflow = vendor.mlflow
-        from mlflow.exceptions import MlflowException
-
         import swanlab
+        from swanlab.vendor.mlflow.exceptions import MlflowException  # type: ignore
 
         client = mlflow.MlflowClient(tracking_uri=tracking_uri)
 

--- a/swanlab/plugin/notification/base.py
+++ b/swanlab/plugin/notification/base.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Dict, Optional
 
-from swanlab.sdk.internal.core_python.pkg.executor import SafeThreadPoolExecutor
+from swanlab.sdk.internal.pkg.executor import SafeThreadPoolExecutor
 from swanlab.sdk.internal.pkg.helper import fmt_run_path
 from swanlab.sdk.internal.settings import Settings
 from swanlab.sdk.protocol import Callback

--- a/swanlab/sdk/internal/core_python/api/upload.py
+++ b/swanlab/sdk/internal/core_python/api/upload.py
@@ -14,9 +14,9 @@ from typing import IO, TYPE_CHECKING, Dict, List, Optional, Union
 from requests.sessions import Session
 
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.internal.core_python.pkg.executor import SafeThreadPoolExecutor
 from swanlab.sdk.internal.core_python.utils import ProgressFileWrapper, get_buffer_size
 from swanlab.sdk.internal.pkg import safe
+from swanlab.sdk.internal.pkg.executor import SafeThreadPoolExecutor
 from swanlab.sdk.typings.core_python.api.upload import (
     UploadColumns,
     UploadLogBatch,

--- a/swanlab/sdk/internal/core_python/pkg/__init__.py
+++ b/swanlab/sdk/internal/core_python/pkg/__init__.py
@@ -5,6 +5,6 @@
 @description: core python 工具包
 """
 
-from . import builder, counter, executor
+from . import builder, counter
 
-__all__ = ["executor", "counter", "builder"]
+__all__ = ["counter", "builder"]

--- a/swanlab/sdk/internal/core_python/sync.py
+++ b/swanlab/sdk/internal/core_python/sync.py
@@ -25,7 +25,7 @@ from swanlab.proto.swanlab.terminal.v1.log_pb2 import LogLevel, LogRecord
 from swanlab.sdk.internal.core_python.api.experiment import get_experiment_summary, stop_experiment
 from swanlab.sdk.internal.core_python.context import CoreContext
 from swanlab.sdk.internal.core_python.metrics import RunMetrics
-from swanlab.sdk.internal.core_python.pkg import builder, counter, executor
+from swanlab.sdk.internal.core_python.pkg import builder, counter
 from swanlab.sdk.internal.core_python.store import DataStoreReader
 from swanlab.sdk.internal.core_python.transport import Transport
 from swanlab.sdk.internal.core_python.transport.tracker import UploadTracker
@@ -34,7 +34,7 @@ from swanlab.sdk.internal.core_python.utils import (
     generate_run_online_path,
     prepare_experiment_start,
 )
-from swanlab.sdk.internal.pkg import adapter, console, safe
+from swanlab.sdk.internal.pkg import adapter, console, executor, safe
 from swanlab.sdk.protocol.core import CoreSyncProtocol
 from swanlab.sdk.typings.core_python.api.experiment import ResumeExperimentSummaryType
 

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -40,10 +40,10 @@ from swanlab.sdk.internal.core_python.api.upload import (
     upload_scalar,
 )
 from swanlab.sdk.internal.core_python.context import CoreContext
-from swanlab.sdk.internal.core_python.pkg.executor import SafeThreadPoolExecutor
 from swanlab.sdk.internal.core_python.utils import ProgressFileWrapper, get_buffer_size
 from swanlab.sdk.internal.pkg import adapter, client, console, safe
 from swanlab.sdk.internal.pkg.client.session import SessionWithRetry
+from swanlab.sdk.internal.pkg.executor import SafeThreadPoolExecutor
 from swanlab.sdk.typings.core_python.api.save import (
     CompletedMultipartSaveFile,
     CompletedPart,

--- a/swanlab/sdk/internal/pkg/__init__.py
+++ b/swanlab/sdk/internal/pkg/__init__.py
@@ -14,6 +14,6 @@
 >>> is_interactive()
 """
 
-from . import client, console, constraints, fork, fs, helper, nrc, safe, scope, timer
+from . import client, console, constraints, executor, fork, fs, helper, nrc, safe, scope, timer
 
-__all__ = ["scope", "console", "helper", "safe", "nrc", "timer", "constraints", "fs", "client", "fork"]
+__all__ = ["scope", "console", "helper", "safe", "nrc", "timer", "constraints", "fs", "client", "fork", "executor"]

--- a/swanlab/sdk/internal/pkg/executor/__init__.py
+++ b/swanlab/sdk/internal/pkg/executor/__init__.py
@@ -8,6 +8,7 @@
 import asyncio
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import thread as futures_thread
 from typing import Any, Callable, Coroutine, Optional
 
 __all__ = ["SafeThreadPoolExecutor", "EventLoopExecutor"]
@@ -17,22 +18,23 @@ def _is_shutting_down() -> bool:
     """检测 Python 是否正在关闭。
 
     threading 模块在 atexit 中设置 _SHUTTING_DOWN = True，
-    此后 ThreadPoolExecutor 无法启动新线程，submit 后死锁。
-    该属性为私有，但无公开 API 替代。
+    concurrent.futures.thread 也会设置 _shutdown = True。
+    此后 ThreadPoolExecutor 无法启动新线程，submit 后可能抛 RuntimeError。
+    这些属性为私有，但无公开 API 替代。
     """
-    return getattr(threading, "_SHUTTING_DOWN", False)
+    return getattr(threading, "_SHUTTING_DOWN", False) or getattr(futures_thread, "_shutdown", False)
 
 
 class SafeThreadPoolExecutor(ThreadPoolExecutor):
     """在 Python 退出阶段仍能安全使用的线程池。
 
     - run(): 正常时异步提交（fire-and-forget），shutting down 时同步执行，保证任务不丢
-    - submit(): shutting down 时抛 RuntimeError 而非静默死锁
+    - submit(): shutting down 时同步执行并返回已完成 Future
     - shutdown(): 默认 wait=True，确保已提交任务执行完毕
     """
 
     def submit(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        """重写：shutting down 时同步执行并返回已完成 Future，而非死锁。"""
+        """重写：shutting down 时同步执行并返回已完成 Future，而非死锁或抛错。"""
         if _is_shutting_down():
             future: Any = Future()
             try:
@@ -88,8 +90,7 @@ class EventLoopExecutor:
 
     def close(self) -> None:
         if self._loop is not None:
-            loop = self._loop  # make pylint happy
-            # noinspection PyTypeChecker
+            loop = self._loop
             loop.call_soon_threadsafe(loop.stop)
 
         if self._thread is not None:

--- a/swanlab/sdk/internal/probe_python/monitor/__init__.py
+++ b/swanlab/sdk/internal/probe_python/monitor/__init__.py
@@ -5,7 +5,6 @@
 @description: SwanLab 硬件监控对象
 """
 
-from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Dict, List, Optional
 
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -13,6 +12,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord
 from swanlab.sdk.internal.pkg import console, safe, timer
+from swanlab.sdk.internal.pkg.executor import SafeThreadPoolExecutor
 from swanlab.sdk.internal.probe_python.context import ProbeContext
 from swanlab.sdk.internal.probe_python.hardware_vendor.accelerator import ACCELERATOR_REGISTRY
 from swanlab.sdk.internal.probe_python.hardware_vendor.apple import Apple
@@ -36,7 +36,7 @@ class Monitor:
         self._core = core
         self._shim = shim
         self._timer: Optional[timer.Timer] = None
-        self._executor: Optional[ThreadPoolExecutor] = None
+        self._executor: Optional[SafeThreadPoolExecutor] = None
 
     def start(self, ctx: ProbeContext) -> Optional["Monitor"]:
         now_step = ctx.config.global_system_step
@@ -87,7 +87,7 @@ class Monitor:
         # 使用线程池执行任务
         # 监控任务的执行效率不要求特别高，线程池的方式可以兼容大部分采集器的实现方式，同时也避免了某些采集器在执行过程中可能出现的阻塞问题
         first_execute = True
-        self._executor = ThreadPoolExecutor(max_workers=2)
+        self._executor = SafeThreadPoolExecutor(max_workers=2)
 
         def task():
             nonlocal now_step, column_records, first_execute

--- a/swanlab/sdk/internal/run/components/config/parse.py
+++ b/swanlab/sdk/internal/run/components/config/parse.py
@@ -103,7 +103,7 @@ def adapt_third_party(data: Any) -> dict:
 
     # dataclass 实例（注意排除 dataclass 类本身）
     if is_dataclass(data) and not isinstance(data, type):
-        # noqa: 虽然警告 'dataclasses.asdict' method should be called on dataclass instances，但此处 data 已经是 dataclass 实例了
+        # 此处 data 已经是 dataclass 实例；cast 用于配合静态检查。
         return asdict(cast(Any, data))
 
     raise TypeError

--- a/tests/unit/sdk/internal/pkg/executor/test_executor.py
+++ b/tests/unit/sdk/internal/pkg/executor/test_executor.py
@@ -1,7 +1,8 @@
 import threading
+from concurrent.futures import thread as futures_thread
 from unittest.mock import patch
 
-from swanlab.sdk.internal.core_python.pkg.executor import SafeThreadPoolExecutor, _is_shutting_down
+from swanlab.sdk.internal.pkg.executor import SafeThreadPoolExecutor, _is_shutting_down
 
 
 def test_submit_returns_future():
@@ -13,7 +14,7 @@ def test_submit_returns_future():
 
 def test_submit_sync_on_shutting_down():
     """shutting down 时 submit() 同步执行并返回已完成 Future。"""
-    with patch("swanlab.sdk.internal.core_python.pkg.executor._is_shutting_down", return_value=True):
+    with patch("swanlab.sdk.internal.pkg.executor._is_shutting_down", return_value=True):
         e = SafeThreadPoolExecutor(max_workers=2)
         future = e.submit(lambda: 42)
         assert future.result() == 42
@@ -22,7 +23,7 @@ def test_submit_sync_on_shutting_down():
 
 def test_submit_captures_exception_on_shutting_down():
     """shutting down 时 submit() 同步执行，异常写入 Future。"""
-    with patch("swanlab.sdk.internal.core_python.pkg.executor._is_shutting_down", return_value=True):
+    with patch("swanlab.sdk.internal.pkg.executor._is_shutting_down", return_value=True):
         e = SafeThreadPoolExecutor(max_workers=2)
         future = e.submit(lambda: 1 / 0)
         assert future.exception() is not None
@@ -41,7 +42,7 @@ def test_run_async_on_normal():
 def test_run_sync_on_shutting_down():
     """shutting down 时 run() 同步执行。"""
     result = []
-    with patch("swanlab.sdk.internal.core_python.pkg.executor._is_shutting_down", return_value=True):
+    with patch("swanlab.sdk.internal.pkg.executor._is_shutting_down", return_value=True):
         e = SafeThreadPoolExecutor(max_workers=2)
         e.run(lambda: result.append(1))
         e.shutdown()
@@ -53,7 +54,7 @@ def test_shutdown_default_wait():
     result = []
     e = SafeThreadPoolExecutor(max_workers=2)
     e.run(lambda: result.append(1))
-    e.shutdown()  # wait=True by default
+    e.shutdown()
     assert result == [1]
 
 
@@ -61,4 +62,11 @@ def test_is_shutting_down():
     """_is_shutting_down() 读取 threading._SHUTTING_DOWN。"""
     assert _is_shutting_down() is False
     with patch.object(threading, "_SHUTTING_DOWN", True):
+        assert _is_shutting_down() is True
+
+
+def test_is_shutting_down_when_futures_thread_pool_is_shutting_down():
+    """_is_shutting_down() 也应识别 concurrent.futures 的解释器关闭标记。"""
+    assert _is_shutting_down() is False
+    with patch.object(futures_thread, "_shutdown", True):
         assert _is_shutting_down() is True

--- a/tests/unit/sdk/internal/probe_python/monitor/test_monitor_shutdown.py
+++ b/tests/unit/sdk/internal/probe_python/monitor/test_monitor_shutdown.py
@@ -1,0 +1,60 @@
+from concurrent.futures import thread as futures_thread
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+
+from swanlab.sdk.internal.pkg import console
+from swanlab.sdk.internal.probe_python.context import ProbeConfig, ProbeContext
+from swanlab.sdk.internal.probe_python.monitor import Monitor
+from swanlab.sdk.internal.probe_python.protocol import CollectorProtocol
+from swanlab.sdk.internal.probe_python.typings import SystemScalar, SystemShim
+from swanlab.sdk.protocol import CoreProtocol
+
+
+class _Collector(CollectorProtocol):
+    def collect(self):
+        return [("cpu.util", 0.5)]
+
+
+def test_monitor_collects_without_executor_error_during_interpreter_shutdown(monkeypatch, tmp_path):
+    shim = SystemShim(slug="linux", enable_cpu=True)
+    collector = _Collector(shim)
+    scalar = SystemScalar(key="cpu.util", chart_name="CPU")
+    upsert_scalars = MagicMock()
+    core = cast(CoreProtocol, SimpleNamespace(upsert_columns=MagicMock(), upsert_scalars=upsert_scalars))
+    ctx = ProbeContext(
+        config=ProbeConfig(
+            run_id="run-id",
+            run_dir=tmp_path,
+            global_system_step=0,
+            hardware=True,
+            runtime=False,
+            requirements=False,
+            conda=False,
+            git=False,
+            swanlab=False,
+            monitor=True,
+            monitor_interval=3600,
+            monitor_disk_dir=Path(tmp_path),
+        )
+    )
+
+    monkeypatch.setattr("swanlab.sdk.internal.probe_python.monitor.CPU.new", lambda _shim: (collector, [scalar]))
+    monkeypatch.setattr("swanlab.sdk.internal.probe_python.monitor.Memory.new", lambda _shim: None)
+    monkeypatch.setattr("swanlab.sdk.internal.probe_python.monitor.Apple.new", lambda _shim: None)
+    monkeypatch.setattr("swanlab.sdk.internal.pkg.timer.Timer.start", lambda self: self)
+
+    trace_mock = MagicMock()
+    monkeypatch.setattr(console, "trace", trace_mock)
+
+    monitor = Monitor(shim, core).start(ctx)
+    assert monitor is not None
+
+    monkeypatch.setattr(futures_thread, "_shutdown", True)
+    monitor._timer._execute_once()  # type: ignore[union-attr]
+    monkeypatch.setattr(futures_thread, "_shutdown", False)
+    monitor.stop()
+
+    trace_mock.assert_not_called()
+    upsert_scalars.assert_called_once()


### PR DESCRIPTION
## Description
- Move `SafeThreadExecutor` to `internal/pkg/executor` avoid of `RuntimeError: cannot schedule new futures after interpreter shutdown` error