### PR TITLE
fix: relax rich version upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "protobuf>=6.31.1,!=6.31.0,<7; python_version == '3.9' and sys_platform == 'linux'",
     "protobuf>=6.31.1,!=6.31.0,<7; python_version > '3.9' and sys_platform == 'linux'",
     "protobuf>=6.31.1,!=6.31.0,<7; sys_platform != 'linux'",
-    "rich>=13.6.0,<14.0.0",
+    "rich>=13.6.0",
     "pydantic-settings>=2.8.1",
     "orjson<=3.11.5; python_version == '3.9'",
     "orjson; python_version > '3.9'",


### PR DESCRIPTION
## Description

Relax `rich>=13.6.0,<14.0.0` to `rich>=13.6.0`.

Closes: #1668