### PR TITLE
fix: serialize webhook run dir

### DIFF
--- a/swanlab/sdk/cmd/init.py
+++ b/swanlab/sdk/cmd/init.py
@@ -406,7 +406,7 @@ def send_webhook(ctx: RunContext) -> Tuple[bool, bool]:
             "swanlab": {
                 "version": helper.get_swanlab_version(),
                 "mode": ctx.config.settings.mode,
-                "run_dir": ctx.run_dir,
+                "run_dir": str(ctx.run_dir),
                 "exp_url": exp_url,
             },
         },

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -413,6 +413,35 @@ class TestInitLocalMode:
 
         assert run._ctx.config.settings.experiment.name == "test-save-exp"
 
+    def test_init_local_sends_webhook_with_path_run_dir(self):
+        """local init 发送 webhook 时应支持真实上下文中的 Path run_dir。"""
+        webhook_url = "https://example.com/webhook"
+        webhook_settings = Settings.model_validate(
+            {
+                "integration": {
+                    "webhook": {
+                        "url": webhook_url,
+                        "value": "test_webhook_value",
+                        "timeout": 5,
+                    }
+                },
+                "probe": {"monitor": False},
+            }
+        )
+
+        with responses_lib.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+            rsps.add(responses_lib.POST, webhook_url, status=200)
+            run = init(mode="local", project="webhook-project", settings=webhook_settings)
+            try:
+                assert len(rsps.calls) == 1
+                request = rsps.calls[0].request
+                payload = json.loads(request.body)  # type: ignore
+                assert payload["value"] == "test_webhook_value"
+                assert payload["swanlab"]["mode"] == "local"
+                assert payload["swanlab"]["run_dir"] == str(run._ctx.run_dir)
+            finally:
+                run.finish()
+
 
 # ============================================================
 # TestInitOfflineMode

--- a/tests/unit/sdk/cmd/init/test_init_webhook.py
+++ b/tests/unit/sdk/cmd/init/test_init_webhook.py
@@ -136,4 +136,4 @@ def test_send_webhook_serializes_path_run_dir(mock_ctx, setup_mocks):
     assert len(responses.calls) == 1
     request = responses.calls[0].request
     payload = json.loads(request.body)  # type: ignore
-    assert payload["swanlab"]["run_dir"] == "/path/to/run_dir"
+    assert payload["swanlab"]["run_dir"] == str(mock_ctx.run_dir)

--- a/tests/unit/sdk/cmd/init/test_init_webhook.py
+++ b/tests/unit/sdk/cmd/init/test_init_webhook.py
@@ -6,6 +6,7 @@
 """
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -119,3 +120,20 @@ def test_send_webhook_local_mode(mock_ctx, setup_mocks):
     payload = json.loads(request.body)  # type: ignore
     assert payload["swanlab"]["mode"] == "local"
     assert payload["swanlab"]["exp_url"] is None
+
+
+@responses.activate
+def test_send_webhook_serializes_path_run_dir(mock_ctx, setup_mocks):
+    """webhook 载荷中的 run_dir 应支持真实 RunContext 使用的 Path 类型。"""
+    settings = mock_ctx.config.settings
+    mock_ctx.run_dir = Path("/path/to/run_dir")
+    webhook_url = settings.integration.webhook.url
+
+    responses.add(responses.POST, webhook_url, status=200)
+
+    assert send_webhook(mock_ctx) == (True, True)
+
+    assert len(responses.calls) == 1
+    request = responses.calls[0].request
+    payload = json.loads(request.body)  # type: ignore
+    assert payload["swanlab"]["run_dir"] == "/path/to/run_dir"

--- a/uv.lock
+++ b/uv.lock
@@ -5082,7 +5082,7 @@ requires-dist = [
     { name = "rdkit", marker = "python_full_version == '3.9.*' and extra == 'media'", specifier = "<=2023.9.6" },
     { name = "rdkit", marker = "python_full_version >= '3.10' and extra == 'media'", specifier = ">=2025.9.6" },
     { name = "requests", specifier = ">=2.28.0" },
-    { name = "rich", specifier = ">=13.6.0,<14.0.0" },
+    { name = "rich", specifier = ">=13.6.0" },
     { name = "setuptools" },
     { name = "soundfile", marker = "extra == 'media'" },
     { name = "swanboard", marker = "extra == 'dashboard'", specifier = "==0.1.10b2" },


### PR DESCRIPTION
## Summary
- Convert webhook `run_dir` to a string so JSON serialization works when `RunContext.run_dir` is a `Path`.
- Add direct and local init regression tests for webhook payload serialization.
- Keep `uv.lock` rich constraint relaxation aligned with #1669: https://github.com/SwanHubX/SwanLab/pull/1669

Fixes #1675

## Test Plan
- `uv run pytest tests/unit/sdk/cmd/init/test_init_webhook.py tests/unit/sdk/cmd/init/test_init_e2e.py::TestInitLocalMode`
- `uv run ruff check swanlab/sdk/cmd/init.py tests/unit/sdk/cmd/init/test_init_webhook.py tests/unit/sdk/cmd/init/test_init_e2e.py`