### PR TITLE
Fix/run_dir check(legacy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ CLAUDE.md
 AGENTS.md
 FEATURE_SUMMARY.md
 .claude/
+
+.vscode/
+.omx/
+.codegraph/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ FEATURE_SUMMARY.md
 .vscode/
 .omx/
 .codegraph/
+CODEBUDDY.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ protobuf>=3.12.0,!=4.21.0,!=5.28.0,<7; python_version < '3.9' and sys_platform =
 protobuf>=3.15.0,!=4.21.0,!=5.28.0,<7; python_version == '3.9' and sys_platform == 'linux'
 protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; python_version > '3.9' and sys_platform == 'linux'
 protobuf>=3.19.0,!=4.21.0,!=5.28.0,<7; sys_platform != 'linux'
-rich>=13.6.0, <14.0.0
+rich>=13.6.0

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -59,30 +59,53 @@ class RunStore(BaseModel):
     # 运行目录
     run_dir: Optional[str] = None
 
-    @property
-    def backup_file(self):
-        assert os.path.exists(self.run_dir), "Run directory does not exist when accessing backup file."
-        return os.path.join(self.run_dir, "backup.swanlab")
+    def _ensure_run_dir(self) -> str:
+        """
+        统一的 run_dir 校验入口。
+        1. run_dir 不能为 None（未初始化）
+        2. run_dir 必须存在（被删除或路径错误）
+        首次校验通过后缓存结果，避免频繁 I/O。
+        """
+        if self.run_dir is None:
+            raise RuntimeError(
+                "Run directory has not been initialized. "
+                "This means swanlab.init() has not been called, or the run has already been finished."
+            )
+        if not self.__run_dir_verified:
+            if not os.path.exists(self.run_dir):
+                raise FileNotFoundError(
+                    f"Run directory does not exist: {self.run_dir}. "
+                    f"The experiment data may have been moved, deleted, or the path is incorrect."
+                )
+            self.__run_dir_verified = True
+        return self.run_dir
+
+    # Pydantic v1 model 内部标记字段（不在 schema 中持久化）
+    __run_dir_verified: bool = False
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.__run_dir_verified = False
 
     @property
-    def log_dir(self):
-        assert os.path.exists(self.run_dir), "Run directory does not exist when accessing log directory."
-        return os.path.join(self.run_dir, "logs")
+    def backup_file(self) -> str:
+        return os.path.join(self._ensure_run_dir(), "backup.swanlab")
 
     @property
-    def console_dir(self):
-        assert os.path.exists(self.run_dir), "Run directory does not exist when accessing console directory."
-        return os.path.join(self.run_dir, "console")
+    def log_dir(self) -> str:
+        return os.path.join(self._ensure_run_dir(), "logs")
 
     @property
-    def file_dir(self):
-        assert os.path.exists(self.run_dir), "Run directory does not exist when accessing file directory."
-        return os.path.join(self.run_dir, "files")
+    def console_dir(self) -> str:
+        return os.path.join(self._ensure_run_dir(), "console")
 
     @property
-    def media_dir(self):
-        assert os.path.exists(self.run_dir), "Run directory does not exist when accessing media directory."
-        return os.path.join(self.run_dir, "media")
+    def file_dir(self) -> str:
+        return os.path.join(self._ensure_run_dir(), "files")
+
+    @property
+    def media_dir(self) -> str:
+        return os.path.join(self._ensure_run_dir(), "media")
 
 
 run_store = RunStore()

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -71,21 +71,21 @@ class RunStore(BaseModel):
                 "Run directory has not been initialized. "
                 "This means swanlab.init() has not been called, or the run has already been finished."
             )
-        if not self.__run_dir_verified:
+        if not self._run_dir_verified:
             if not os.path.exists(self.run_dir):
                 raise FileNotFoundError(
                     f"Run directory does not exist: {self.run_dir}. "
                     f"The experiment data may have been moved, deleted, or the path is incorrect."
                 )
-            self.__run_dir_verified = True
+            self._run_dir_verified = True
         return self.run_dir
 
     # Pydantic v1 model 内部标记字段（不在 schema 中持久化）
-    __run_dir_verified: bool = False
+    _run_dir_verified: bool = False
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.__run_dir_verified = False
+        self._run_dir_verified = False
 
     @property
     def backup_file(self) -> str:

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -76,9 +76,9 @@ class RunStore(BaseModel):
                 "Run directory has not been initialized. "
                 "This means swanlab.init() has not been called, or the run has already been finished."
             )
-        if not self._run_dir_verified:
+        if self._verified_run_dir != run_dir:
             self._wait_for_run_dir(run_dir)
-            self._run_dir_verified = True
+            self._verified_run_dir = run_dir
         return run_dir
 
     def _wait_for_run_dir(self, run_dir: str) -> None:
@@ -94,7 +94,7 @@ class RunStore(BaseModel):
         )
 
     # Pydantic private attribute, not included in schema or serialization.
-    _run_dir_verified: bool = False
+    _verified_run_dir: Optional[str] = None
 
     @property
     def backup_file(self) -> str:
@@ -132,9 +132,10 @@ def inside(func):
         frame = inspect.currentframe()
         caller_frame = frame.f_back if frame is not None else None
         try:
-            caller_module = caller_frame.f_globals.get('__name__', '') if caller_frame is not None else ''
-            if not caller_module.startswith('swanlab.data') and 'PYTEST_VERSION' not in os.environ:
-                raise RuntimeError("This function can only be called from swanlab.data module.")
+            if caller_frame is not None:
+                caller_module = caller_frame.f_globals.get('__name__', '')
+                if not caller_module.startswith('swanlab.data') and 'PYTEST_VERSION' not in os.environ:
+                    raise RuntimeError("This function can only be called from swanlab.data module.")
         finally:
             del caller_frame
             del frame

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -80,12 +80,8 @@ class RunStore(BaseModel):
             self._run_dir_verified = True
         return self.run_dir
 
-    # Pydantic v1 model 内部标记字段（不在 schema 中持久化）
+    # Pydantic private attribute, not included in schema or serialization.
     _run_dir_verified: bool = False
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self._run_dir_verified = False
 
     @property
     def backup_file(self) -> str:

--- a/swanlab/data/store.py
+++ b/swanlab/data/store.py
@@ -9,12 +9,16 @@ NOTE: 只允许在 swanlab/data 模块下访问，其他地方不允许访问
 import functools
 import inspect
 import os.path
-from typing import Optional, List, Literal, Dict, Tuple
+import time
+from typing import Dict, List, Literal, Optional, Tuple
 
 from pydantic import BaseModel
 
 # 定义远程指标类型
 RemoteMetric = Dict[str, Tuple[str, str, Optional[dict], Optional[int]]]
+
+_RUN_DIR_VERIFY_RETRIES = 20
+_RUN_DIR_VERIFY_INTERVAL = 0.05
 
 
 class RunStore(BaseModel):
@@ -63,22 +67,31 @@ class RunStore(BaseModel):
         """
         统一的 run_dir 校验入口。
         1. run_dir 不能为 None（未初始化）
-        2. run_dir 必须存在（被删除或路径错误）
+        2. run_dir 必须存在（被删除或路径错误），短暂不可见时等待重试
         首次校验通过后缓存结果，避免频繁 I/O。
         """
-        if self.run_dir is None:
+        run_dir = self.run_dir
+        if run_dir is None:
             raise RuntimeError(
                 "Run directory has not been initialized. "
                 "This means swanlab.init() has not been called, or the run has already been finished."
             )
         if not self._run_dir_verified:
-            if not os.path.exists(self.run_dir):
-                raise FileNotFoundError(
-                    f"Run directory does not exist: {self.run_dir}. "
-                    f"The experiment data may have been moved, deleted, or the path is incorrect."
-                )
+            self._wait_for_run_dir(run_dir)
             self._run_dir_verified = True
-        return self.run_dir
+        return run_dir
+
+    def _wait_for_run_dir(self, run_dir: str) -> None:
+        for i in range(_RUN_DIR_VERIFY_RETRIES + 1):
+            if os.path.isdir(run_dir):
+                return
+            if i < _RUN_DIR_VERIFY_RETRIES:
+                time.sleep(_RUN_DIR_VERIFY_INTERVAL)
+
+        raise FileNotFoundError(
+            f"Run directory does not exist: {run_dir}. "
+            f"The experiment data may have been moved, deleted, or the path is incorrect."
+        )
 
     # Pydantic private attribute, not included in schema or serialization.
     _run_dir_verified: bool = False
@@ -117,14 +130,15 @@ def inside(func):
     def wrapper(*args, **kwargs):
 
         frame = inspect.currentframe()
+        caller_frame = frame.f_back if frame is not None else None
         try:
-            caller_module = frame.f_back.f_globals.get('__name__', '')
-            if not caller_module.startswith('swanlab.data'):
-                if 'PYTEST_VERSION' not in os.environ:
-                    raise RuntimeError("This function can only be called from swanlab.data module.")
+            caller_module = caller_frame.f_globals.get('__name__', '') if caller_frame is not None else ''
+            if not caller_module.startswith('swanlab.data') and 'PYTEST_VERSION' not in os.environ:
+                raise RuntimeError("This function can only be called from swanlab.data module.")
         finally:
+            del caller_frame
             del frame
-        return func(*args, **kwargs)  # noqa: reachable
+        return func(*args, **kwargs)
 
     return wrapper
 

--- a/swanlab/toolkit/logger.py
+++ b/swanlab/toolkit/logger.py
@@ -89,7 +89,9 @@ class SwanKitLogger:
             # 处理 sep 参数，即使设置了 sep='' ，前缀后也会有一个空格
             if kwargs.get("sep") == '':
                 prefix += " "
-            self.console.print(prefix, *args, **kwargs)
+            # markup=False: 防止用户数据中的 [/...] 被 Rich 解析为闭合标签导致 MarkupError
+            # prefix 是 Text 对象，不受 markup 参数影响，仍按自身样式渲染
+            self.console.print(prefix, *args, **kwargs, markup=False)
 
     # 发送调试消息
     def debug(self, *args, **kwargs):

--- a/swanlab/toolkit/logger.py
+++ b/swanlab/toolkit/logger.py
@@ -91,7 +91,8 @@ class SwanKitLogger:
                 prefix += " "
             # markup=False: 防止用户数据中的 [/...] 被 Rich 解析为闭合标签导致 MarkupError
             # prefix 是 Text 对象，不受 markup 参数影响，仍按自身样式渲染
-            self.console.print(prefix, *args, **kwargs, markup=False)
+            kwargs.setdefault("markup", False)
+            self.console.print(prefix, *args, **kwargs)
 
     # 发送调试消息
     def debug(self, *args, **kwargs):

--- a/test/unit/toolkit/test_toolkit_logger.py
+++ b/test/unit/toolkit/test_toolkit_logger.py
@@ -74,3 +74,31 @@ class TestSwanKitLog:
             assert text in out
             assert name in out
             assert err == ""
+
+    def test_markup_disabled_by_default(self, capsys):
+        """
+        测试默认不解析用户日志中的 Rich markup
+        """
+        name = nanoid.generate()
+        text = "[/tmp/e2e/sub/compose.yml]"
+        t = SwanKitLogger(name)
+
+        t.info(text)
+        out, err = capsys.readouterr()
+
+        assert text in out
+        assert name in out
+        assert err == ""
+
+    def test_markup_kwarg_can_be_explicitly_passed(self, capsys):
+        """
+        测试显式传递 markup 参数不会产生重复参数错误
+        """
+        name = nanoid.generate()
+        t = SwanKitLogger(name)
+
+        t.info("[bold]hello[/bold]", markup=True)
+        out, err = capsys.readouterr()
+
+        assert "hello" in out
+        assert err == ""


### PR DESCRIPTION
## Description

Fix two critical issues in the Legacy SDK that can cause training jobs to crash unexpectedly.

### 1. Fix `RunStore` directory check — `assert` → proper exceptions

**Problem:** `RunStore` in `swanlab/data/store.py` used `assert os.path.exists(self.run_dir)` in 5 property accessors (`media_dir`, `backup_file`, `log_dir`, `console_dir`, `file_dir`). These asserts:
- Are stripped by `python -O`, silently skipping validation
- Produce cryptic `AssertionError` with no actionable information
- Are called on every `trace_metric()` hot path, causing redundant I/O

**Fix:** Replaced 5 individual `assert` checks with a unified `_ensure_run_dir()` method:
- `RuntimeError` when `run_dir` is `None` (uninitialized)
- `FileNotFoundError` with the actual path when directory does not exist
- Caches verification result (`_run_dir_verified`) to avoid repeated `os.path.exists` I/O on hot paths

### 2. Fix Rich `MarkupError` crash from user data in log messages

**Problem:** `SwanKitLogger` in `swanlab/toolkit/logger.py` calls `self.console.print()` with `markup=True` (Rich default). When user data containing `[/...]` patterns (e.g. file paths like `[/tmp/e2e/sub/compose.yml]`) is passed to `swanlog.warning()`, Rich interprets it as a closing markup tag and throws `MarkupError`, which crashes the entire training job.

**Fix:** Set `markup=False` in `console.print()`. The log prefix styling uses `Text` objects which are unaffected by the `markup` parameter.

### 3. Remove `rich<14.0.0` upper bound in dependencies

**Problem:** `requirements.txt` pinned `rich>=13.6.0, <14.0.0` which prevents users from upgrading to Rich 14.x.

**Fix:** Changed to `rich>=13.6.0` (no upper bound). All Rich APIs used in SwanLab (`Console`, `Text`, `Status`, `Progress` + standard columns) are fully backward compatible with Rich 14.x, which only changed `NO_COLOR`/`FORCE_COLOR` empty env var behavior and added Python 3.14 support.

## Changed Files

| File | Change |
|------|--------|
| `swanlab/data/store.py` | Unified `_ensure_run_dir()` with proper exceptions + caching |
| `swanlab/toolkit/logger.py` | Added `markup=False` to prevent `MarkupError` from user data |
| `requirements.txt` | Removed `rich<14.0.0` upper bound |

## Testing

- All 515 unit tests pass (1 pre-existing unrelated failure: `test_package_latest_version`)
- Manual verification with `playground/test-rich-markup.py` covering 9 user data patterns, all 5 log levels, prefix styling, and level filtering