### PR TITLE
fix: add error resilience to log internal implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ runs/
 # test-integration-lightning
 LightningTest/
 
-# Coding Agent docs
+# Coding Agent & Tools
 CLAUDE.md
 AGENTS.md
 FEATURE_SUMMARY.md
@@ -60,3 +60,4 @@ QWEN.md
 .omx/
 .opencode/
 CODEBUDDY.md
+.codegraph/

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -361,7 +361,6 @@ class Run:
         # 3. 推送日志事件
         # 展平字典并在内部进行合规性验证和截断
         flatten_data = fmt.flatten_dict(this_data)
-        # 推送日志事件
         self._components.emitter.emit(MetricLogEvent(data=flatten_data, step=next_step, timestamp=ts))
 
     @with_api("run.async_log()")

--- a/swanlab/sdk/internal/run/__init__.py
+++ b/swanlab/sdk/internal/run/__init__.py
@@ -336,8 +336,10 @@ class Run:
         """
         self._log_impl(data, step)
 
+    @safe.decorator(message="SwanLab failed to log data due to unexpected error")
     def _log_impl(self, data: Mapping[str, Any], step: Optional[int] = None):
         """log 的无锁内部实现，供 async_log 回调调用以避免与 finish() 的 _api_lock 死锁。"""
+        # 1. 验证输入
         if not (this_data := fmt.safe_validate_log_data(data)):
             console.error(f"Log data must be a dict, but got {type(data).__name__}. SwanLab will ignore this log.")
             return
@@ -351,14 +353,14 @@ class Run:
                 console.error(f"Step must be non-negative, but got {step}. SwanLab will ignore this log.")
                 return
 
+        # 2. 获取当前log快照，如步骤、时间戳等
         next_step = self._ctx.next_step(step)
-
         ts = Timestamp()
         ts.GetCurrentTime()
 
+        # 3. 推送日志事件
         # 展平字典并在内部进行合规性验证和截断
         flatten_data = fmt.flatten_dict(this_data)
-
         # 推送日志事件
         self._components.emitter.emit(MetricLogEvent(data=flatten_data, step=next_step, timestamp=ts))
 

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -363,7 +363,7 @@ class TestInitDisabledMode:
         assert not log_dir.exists()
 
     def test_log_ignores_unexpected_emitter_error(self, monkeypatch):
-        """log 内部 emit 未预期异常不应中断用户代码"""
+        """log 内部未预期异常不应中断用户代码"""
         with init(mode="disabled") as run:
             trace = MagicMock()
             monkeypatch.setattr(console, "trace", trace)

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -29,7 +29,7 @@ from swanlab.sdk.cmd.init import init
 from swanlab.sdk.cmd.login import login_cli
 from swanlab.sdk.cmd.merge_settings import merge_settings
 from swanlab.sdk.internal.bus import MetricLogEvent, RunEmitter
-from swanlab.sdk.internal.pkg import fork
+from swanlab.sdk.internal.pkg import console, fork
 from swanlab.sdk.internal.run import Run, get_run, has_run
 from swanlab.sdk.internal.run.components import BackgroundConsumer, NullConsumer, NullEmitter
 from swanlab.sdk.internal.run.components.config import config as global_config
@@ -361,6 +361,28 @@ class TestInitDisabledMode:
 
         # log_dir 不应存在，或者即使存在也不应包含媒体文件
         assert not log_dir.exists()
+
+    def test_log_ignores_unexpected_emitter_error(self, monkeypatch):
+        """log 内部 emit 未预期异常不应中断用户代码"""
+        with init(mode="disabled") as run:
+            trace = MagicMock()
+            monkeypatch.setattr(console, "trace", trace)
+            run._components.emitter.emit = MagicMock(side_effect=RuntimeError("emit failed"))
+
+            try:
+                run.log({"loss": 0.5})
+            except RuntimeError as e:
+                pytest.fail(f"run.log() raised unexpected error: {e}")
+
+            event = run._components.emitter.emit.call_args.args[0]
+            assert isinstance(event, MetricLogEvent)
+            assert event.data == {"loss": 0.5}
+            trace.assert_called_once_with(
+                "SwanLab failed to log data due to unexpected error",
+                write_to_file=True,
+                write_to_tty=True,
+                level_name="error",
+            )
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
为 `Run._log_impl()` 添加 `safe.decorator` 异常保护，避免日志内部未预期异常导致用户训练中断；同时更新 `.gitignore` 忽略 `.codegraph/` 目录，并补充日志异常路径的回归测试。

## Changes
- **`swanlab/sdk/internal/run/__init__.py`**: 在 `_log_impl()` 上添加 `@safe.decorator` 装饰器，捕获内部 Exception 后记录错误信息并静默返回，避免影响用户训练流程；同步调整步骤注释。
- **`tests/unit/sdk/cmd/init/test_init_e2e.py`**: 新增 disabled 模式下 `run.log()` 内部 `emit()` 抛异常时不应中断用户代码的回归测试，并断言内部错误会写入 trace。
- **`.gitignore`**: 新增 `.codegraph/` 忽略规则，微调注释措辞。

## Testing
- `uv run pytest tests/unit/sdk/cmd/init/test_init_e2e.py::TestInitDisabledMode::test_log_ignores_unexpected_emitter_error`
- `uv run pytest tests/unit/sdk/cmd/init/test_init_e2e.py::TestInitDisabledMode`
- `uv run ruff check tests/unit/sdk/cmd/init/test_init_e2e.py`
- commit hook: `ruff check`、`ruff format` 通过

## Notes
- `_log_impl()` 同时服务于同步 `run.log()` 和 `async_log()` 回调，异常静默后调用方不再感知内部失败。当前测试覆盖同步 `run.log()` 的内部 emit 异常路径。