### PR TITLE
fix: video column type compatible

### DIFF
--- a/swanlab/sdk/internal/run/transforms/video/__init__.py
+++ b/swanlab/sdk/internal/run/transforms/video/__init__.py
@@ -99,7 +99,8 @@ class Video(TransformMedia):
 
     @classmethod
     def column_type(cls) -> ColumnType:
-        return ColumnType.COLUMN_TYPE_VIDEO
+        # TODO: 服务端支持 VIDEO 列类型后，改回 ColumnType.COLUMN_TYPE_VIDEO
+        return ColumnType.COLUMN_TYPE_IMAGE
 
     def transform(self, *, step: int, path: Path) -> MediaItem:
         content = self.buffer.getvalue()

--- a/tests/unit/sdk/internal/run/transforms/test_video.py
+++ b/tests/unit/sdk/internal/run/transforms/test_video.py
@@ -118,7 +118,8 @@ class TestVideoColumnType:
     def test_column_type(self):
         from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnType
 
-        assert Video.column_type() == ColumnType.COLUMN_TYPE_VIDEO
+        # TODO: 服务端 column 暂时不支持 VIDEO，临时回退为 IMAGE
+        assert Video.column_type() == ColumnType.COLUMN_TYPE_IMAGE
 
 
 class TestVideoBuildDataRecord:


### PR DESCRIPTION
## Description
- Revert `Video` type to `column_image` for compatible field

## Test Code
```python
import swanlab

if __name__ == "__main__":
    swanlab.init(project="demo-charts-test", name="video-chart-test")

    swanlab.log({"video": swanlab.Video("./demo.gif", caption="test caption")})

    swanlab.finish()

```

## 📊 Demo Runs:
- Image Type: `nexisato/demo-charts-test/runs/c7e7ozl2/chart`
- Video Type: `nexisato/demo-charts-test/runs/ls17l20a/chart` 


TODO: docs (url ref)
