### PR TITLE
fix: filesystem permission check

### DIFF
--- a/swanlab/sdk/internal/pkg/fs/dir.py
+++ b/swanlab/sdk/internal/pkg/fs/dir.py
@@ -50,35 +50,54 @@ def safe_mkdirs(*paths: Union[str, Path], timeout: float = TIMEOUT, ensure_clean
 
 def safe_mkdir(path: Union[str, Path], timeout: float = TIMEOUT, ensure_clean: bool = False) -> Path:
     """
-    安全地创建目录，带有抗 NAS 异步延迟的探针机制。
+    安全地创建目录，带有抗异步文件系统延迟的探针机制。
+
+    创建后会探测目录是否真正可见且可写，以容忍 NAS / NFS 等的异步IO延迟。
+    权限不足属于不可恢复错误，会立即抛出 PermissionError，不会重试。
 
     :param path: 目录路径
     :param timeout: 超时时间（秒）
     :param ensure_clean: 如果为 True，要求目标目录在创建前不存在（原子检查，通过 mkdir(exist_ok=False) 实现）
     :raises FileExistsError: ensure_clean=True 且目录已存在时抛出
+    :raises PermissionError: 目录不可创建或不可写时抛出
     """
     p = Path(path)
-    if ensure_clean:
-        p.mkdir(parents=True, exist_ok=False)
-    else:
-        p.mkdir(parents=True, exist_ok=True)
+    try:
+        if ensure_clean:
+            p.mkdir(parents=True, exist_ok=False)
+        else:
+            p.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        raise PermissionError(
+            f"Cannot create directory [{p}]: permission denied. "
+            "Please choose a writable log_dir or update directory permissions."
+        ) from None
 
     start_time = time.time()
 
+    # 探测一：目录创建后可能因异步延迟暂不可见
     while not (p.exists() and p.is_dir()):
         if time.time() - start_time > timeout:
-            raise TimeoutError(f"Directory creation timeout (NAS delay too high): {p}")
+            raise TimeoutError(f"Directory creation timed out, filesystem may be slow or remote: {p}")
         time.sleep(0.05)
 
+    # 探测二：目录可见后可能仍暂不可写（权限问题立即失败，其余重试到超时）
     while True:
         try:
             with tempfile.TemporaryFile(dir=p, prefix=".swanlab_test_") as f:
                 f.write(b"0")
             break
+        except PermissionError:
+            # 权限不足不会因重试而恢复，立即失败，避免被误判为可重试的文件系统延迟
+            raise PermissionError(
+                f"Directory [{p}] is not writable. Please choose a writable log_dir or update directory permissions."
+            ) from None
         except OSError:
             if time.time() - start_time > timeout:
-                console.trace(f"NAS sync issue? Directory {p} exists but is not writable yet")
-                raise TimeoutError(f"Directory {p} is not writable within {timeout}s.")
+                console.trace(f"Directory {p} exists but is not writable within {timeout}s")
+                raise TimeoutError(
+                    f"Directory [{p}] exists but is not writable within {timeout}s, FILESYSTEM may be slow or remote."
+                )
             time.sleep(0.1)
 
     return p

--- a/swanlab/sdk/protocol/core.py
+++ b/swanlab/sdk/protocol/core.py
@@ -54,7 +54,8 @@ class CoreProtocol(ABC):
         交付运行开始事件，同步事件，等待确认
         约定应该在此处完成Core相关组件的初始化，在这里完成不同模式的初始化函数分发
         """
-        with safe.block(message="run start error"):
+        errors: list[BaseException] = []
+        with safe.block(message="run start error", on_error=errors.append):
             if self._mode == "online":
                 return self._start_when_online(start_request)
             elif self._mode == "local":
@@ -62,7 +63,10 @@ class CoreProtocol(ABC):
             elif self._mode == "offline":
                 return self._start_when_offline(start_request)
             return self._start_when_disabled(start_request)
-        return DeliverRunStartResponse(success=False, message="Failed to start run")
+        message = "Failed to start run"
+        if errors:
+            message = f"{message}: {errors[0]}"
+        return DeliverRunStartResponse(success=False, message=message)
 
     @staticmethod
     def _start_when_disabled(start_request: DeliverRunStartRequest) -> DeliverRunStartResponse:

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -16,6 +16,7 @@
   - TestRunSave              : run.save() 各 policy / 各模式的端到端行为
 """
 
+import errno
 import json
 import multiprocessing
 from typing import cast
@@ -408,6 +409,20 @@ class TestInitLocalMode:
         assert ctx.media_dir.exists()
         assert ctx.files_dir.exists()
         assert ctx.debug_dir.exists()
+
+    def test_init_fails_when_log_dir_is_not_writable(self, tmp_path, monkeypatch):
+        """log_dir 不可写时应在 init 阶段明确失败，避免后续静默丢点。"""
+        log_dir = tmp_path / "root-owned-log-dir"
+        log_dir.mkdir()
+
+        def deny_tempfile(*args, **kwargs):
+            raise PermissionError(errno.EACCES, "Permission denied")
+
+        monkeypatch.setattr("swanlab.sdk.internal.pkg.fs.dir.tempfile.TemporaryFile", deny_tempfile)
+
+        with pytest.raises(PermissionError, match="Directory .* is not writable"):
+            init(mode="local", log_dir=str(log_dir))
+        assert not has_run()
 
     def test_init_workspace_is_none_by_default(self):
         """local 模式下 workspace 默认为 None"""

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -122,6 +122,22 @@ class TestCorePythonStart:
         MockHeartbeat.assert_called_once_with("test-experiment-id")
         MockHeartbeat.return_value.start.assert_called_once()
 
+    def test_start_failure_includes_original_error(self, tmp_path, monkeypatch):
+        core = CorePython("local")
+        error_message = "Cannot create SwanLab data store file /root/run.swanlab: permission denied."
+
+        def deny_store_open(self, filename):
+            raise PermissionError(error_message)
+
+        monkeypatch.setattr("swanlab.sdk.internal.core_python.store.DataStoreWriter.open", deny_store_open)
+
+        resp = core.deliver_run_start(make_start_request(tmp_path, make_start_record()))
+
+        assert resp.success is False
+        assert "Failed to start run" in resp.message
+        assert error_message in resp.message
+        assert core._active is False
+
 
 # ============================================================
 # TestCorePythonFinish

--- a/tests/unit/sdk/internal/pkg/fs/test_pkg_fs_dir.py
+++ b/tests/unit/sdk/internal/pkg/fs/test_pkg_fs_dir.py
@@ -5,6 +5,7 @@
 @description: SwanLab SDK 文件系统辅助函数测试
 """
 
+import errno
 import importlib
 import sys
 from pathlib import Path
@@ -59,6 +60,19 @@ def test_safe_mkdir_nas_timeout(monkeypatch, tmp_path: Path):
     monkeypatch.setattr("swanlab.sdk.internal.pkg.fs.dir.tempfile.TemporaryFile", mock_tempfile)
 
     with pytest.raises(TimeoutError, match="is not writable within"):
+        dir.safe_mkdir(target, timeout=5.0)
+
+
+def test_safe_mkdir_permission_denied_raises_permission_error(monkeypatch, tmp_path: Path):
+    """权限不足时应立即抛 PermissionError，而不是伪装成 NAS 超时。"""
+    target = tmp_path / "readonly_dir"
+
+    def mock_tempfile(*args, **kwargs):
+        raise PermissionError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr("swanlab.sdk.internal.pkg.fs.dir.tempfile.TemporaryFile", mock_tempfile)
+
+    with pytest.raises(PermissionError, match="Directory .* is not writable"):
         dir.safe_mkdir(target, timeout=5.0)
 
 


### PR DESCRIPTION
## Description
- fix when user attempts to write to a directory requiring root privileges, no error is thrown, yet no metrics appear on the dashboard.
