### PR TITLE
feat: add Feishu notification on PyPI release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -44,3 +44,158 @@ jobs:
         with:
           files: |
             *.whl
+
+      - name: Notify Feishu on New Release
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+          FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
+        run: |
+          set -euo pipefail
+
+          FEISHU_WEBHOOK_URL="$(printf '%s' "${FEISHU_WEBHOOK_URL:-}" | tr -d '\r\n')"
+
+          if [ -z "${FEISHU_WEBHOOK_URL:-}" ]; then
+            echo "FEISHU_WEBHOOK_URL is empty, skip Feishu notification."
+            exit 0
+          fi
+
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          REPO="${GITHUB_REPOSITORY}"
+
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
+          PYPI_URL="https://pypi.org/project/swanlab/${VERSION}/"
+
+          echo "Notifying Feishu: SwanLab SDK ${TAG}"
+
+          PAYLOAD=$(VERSION="$VERSION" TAG="$TAG" RELEASE_URL="$RELEASE_URL" PYPI_URL="$PYPI_URL" python3 - <<'PY'
+          import json
+          import os
+
+          tag = os.environ["TAG"]
+          release_url = os.environ["RELEASE_URL"]
+          pypi_url = os.environ["PYPI_URL"]
+
+          body = {
+              "msg_type": "interactive",
+              "card": {
+                  "schema": "2.0",
+                  "config": {
+                      "update_multi": True,
+                      "wide_screen_mode": True,
+                  },
+                  "header": {
+                      "title": {
+                          "tag": "plain_text",
+                          "content": "📢 SwanLab SDK 版本更新通知",
+                      },
+                      "template": "blue",
+                  },
+                  "body": {
+                      "direction": "vertical",
+                      "elements": [
+                          {
+                              "tag": "markdown",
+                              "content": (
+                                  f"**版本:** {tag}\n"
+                                  f"**包名:** swanlab\n"
+                                  f"**发布状态:** 已发布到 PyPI / GitHub Release"
+                              ),
+                              "text_align": "left",
+                          },
+                          {
+                              "tag": "column_set",
+                              "flex_mode": "none",
+                              "background_style": "default",
+                              "columns": [
+                                  {
+                                      "tag": "column",
+                                      "width": "auto",
+                                      "elements": [
+                                          {
+                                              "tag": "button",
+                                              "text": {
+                                                  "tag": "plain_text",
+                                                  "content": "📦 查看 PyPI",
+                                              },
+                                              "type": "primary",
+                                              "size": "medium",
+                                              "behaviors": [
+                                                  {
+                                                      "type": "open_url",
+                                                      "default_url": pypi_url,
+                                                  }
+                                              ],
+                                          }
+                                      ],
+                                  },
+                                  {
+                                      "tag": "column",
+                                      "width": "auto",
+                                      "elements": [
+                                          {
+                                              "tag": "button",
+                                              "text": {
+                                                  "tag": "plain_text",
+                                                  "content": "🏷️ GitHub Release",
+                                              },
+                                              "type": "default",
+                                              "size": "medium",
+                                              "behaviors": [
+                                                  {
+                                                      "type": "open_url",
+                                                      "default_url": release_url,
+                                                  }
+                                              ],
+                                          }
+                                      ],
+                                  },
+                              ],
+                          },
+                      ],
+                  },
+              },
+          }
+
+          print(json.dumps(body, ensure_ascii=False))
+          PY
+          )
+
+          WEBHOOK_URL="$FEISHU_WEBHOOK_URL"
+
+          if [ -n "${FEISHU_WEBHOOK_SECRET:-}" ]; then
+            TIMESTAMP=$(python3 -c 'import time; print(int(time.time()))')
+
+            SIGN=$(FEISHU_TS="$TIMESTAMP" FEISHU_WEBHOOK_SECRET="$FEISHU_WEBHOOK_SECRET" python3 - <<'PY'
+          import base64
+          import hashlib
+          import hmac
+          import os
+          import urllib.parse
+
+          ts = os.environ["FEISHU_TS"]
+          secret = os.environ["FEISHU_WEBHOOK_SECRET"]
+          string_to_sign = f"{ts}\n{secret}"
+
+          digest = hmac.new(
+              string_to_sign.encode("utf-8"),
+              msg=b"",
+              digestmod=hashlib.sha256,
+          ).digest()
+
+          print(urllib.parse.quote_plus(base64.b64encode(digest).decode("utf-8")))
+          PY
+          )
+
+            case "$WEBHOOK_URL" in
+              *\?*) SEP="&" ;;
+              *) SEP="?" ;;
+            esac
+
+            WEBHOOK_URL="${WEBHOOK_URL}${SEP}timestamp=${TIMESTAMP}&sign=${SIGN}"
+          fi
+
+          curl -sS -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data-raw "$PAYLOAD"


### PR DESCRIPTION
## Summary
在 PyPI 发布 CI 工作流（publish-to-pypi.yml）中新增飞书通知步骤，SDK 新版本发布后自动向飞书群发送版本更新卡片消息。

## Changes
- `.github/workflows/publish-to-pypi.yml`：在 `publish` job 末尾新增 `Notify Feishu on New Release` 步骤
  - 仅在 tag 触发且上传成功时执行
  - 通过飞书 Webhook 发送交互式卡片消息，包含版本号、PyPI 链接、GitHub Release 链接
  - 支持 Webhook 签名校验（HMAC-SHA256）
  - 使用 `FEISHU_WEBHOOK_URL` 和 `FEISHU_WEBHOOK_SECRET` 两个 GitHub Secrets

## Testing
未运行测试（CI 工作流变更，需在 tag push 触发后实际验证）。

## Notes
- 若 `FEISHU_WEBHOOK_URL` 未配置，步骤会静默跳过，不影响发布流程
- 需在仓库 Settings → Secrets and variables → Actions 中配置对应的 Secrets