### PR TITLE
refactor: support multi-view project API with legacy project backward compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # test
 temp/
-deprecated/
 package.mock.json
 .env
 !swanlab/deprecated/

--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -2,11 +2,13 @@
 @author: caddiesnew
 @file: __init__.py
 @time: 2026/4/20
-@description: SwanLab 公共查询 API 入口，面向用户的 OOP 查询接口
+@description: SwanLab public query API entry — OOP query interface for users
 """
 
 import warnings
 from typing import Any, Dict, List, Optional
+
+from typing_extensions import deprecated
 
 from swanlab.exceptions import AuthenticationError
 from swanlab.sdk.internal.pkg import nrc, scope
@@ -18,7 +20,15 @@ from .column import Column, Columns
 from .experiment import Experiment, Experiments
 from .project import Project, Projects
 from .self_hosted import SelfHosted
-from .typings.common import ApiColumnClassLiteral, ApiColumnDataTypeLiteral, ApiVisibilityLiteral, PaginatedQuery
+from .series import Series
+from .typings.common import (
+    ApiColumnClassLiteral,
+    ApiColumnDataTypeLiteral,
+    ApiMetricKeyClassLiteral,
+    ApiMetricKeyTypeLiteral,
+    ApiVisibilityLiteral,
+    PaginatedQuery,
+)
 from .user import User
 from .utils import validate_api_path, validate_non_empty_string
 from .workspace import Workspace, Workspaces
@@ -26,17 +36,14 @@ from .workspace import Workspace, Workspaces
 
 class Api(BaseEntity):
     """
-    SwanLab 公共查询 API 入口。
+    SwanLab public query API entry.
 
-    通过独立的 Client 实例与 SwanLab 云端交互，与 SDK 运行时客户端完全隔离。
-    继承 BaseEntity 以复用 _get/_post/_put/_delete/_paginate 等安全 HTTP 方法。
-
-    用法::
+    Usage::
 
         from swanlab import Api
 
-        api = Api()                              # 自动从 .netrc 读取凭证
-        api = Api(api_key="...", host="...")      # 显式传入凭证
+        api = Api()                              # auto-read credentials from .netrc
+        api = Api(api_key="...", host="...")      # explicit credentials
 
         resp = api.project("username/project")
         if resp.ok:
@@ -50,17 +57,15 @@ class Api(BaseEntity):
         host: Optional[str] = None,
     ) -> None:
         """
-        初始化 Api 实例。
+        Initialize an Api instance.
 
-        认证优先级：
-        1. 显式参数 (api_key / host)
-        2. scope 登录态（进程内已调用 swanlab.login 时可用）
-        3. Settings（含 .netrc / 环境变量）
+        Credential resolution order:
+        1. Explicit parameters (``api_key`` / ``host``)
+        2. In-process login state (available when ``swanlab.login`` has been called)
+        3. Settings (including ``.netrc`` / environment variables)
 
-        始终创建独立的 Client 实例，与 SDK 运行时单例互不干扰。
-
-        :param api_key: API 密钥，为 None 时从 Settings / .netrc / 环境变量读取
-        :param host: API 主机地址，为 None 时从 Settings 读取
+        :param api_key: API key; if None, resolved per the order above
+        :param host: API host address; if None, uses default configuration
         """
         # 优先从 scope 获取已有登录态（如进程内已调用 swanlab.login），直接复用凭证
         login_resp = scope.get_context("login_resp")
@@ -78,12 +83,12 @@ class Api(BaseEntity):
         super().__init__(ctx)
 
     def json(self) -> dict:
-        """Api 非数据实体，返回空字典。"""
+        """Return an empty dict."""
         return {}
 
     @property
     def username(self) -> str:
-        """当前认证用户的 username。"""
+        """The authenticated user's username."""
         return self._ctx.username
 
     @staticmethod
@@ -92,8 +97,8 @@ class Api(BaseEntity):
         host: Optional[str],
     ) -> tuple[str, str, str]:
         """
-        按优先级解析凭证：显式参数 > scope 登录态 > Settings（含 .netrc / 环境变量）。
-        返回 (api_key, api_host, web_host)。
+        Resolve credentials by priority: explicit params > in-process login state > Settings (.netrc / env vars).
+        Returns (api_key, api_host, web_host).
         """
         if api_key is None:
             api_key = global_settings.api_key
@@ -118,9 +123,9 @@ class Api(BaseEntity):
 
     def workspace(self, username: Optional[str] = None) -> Workspace:
         """
-        获取工作空间信息，默认为当前登录用户的工作空间。
+        Get workspace info, defaulting to the current logged-in user.
 
-        :param username: 指定工作空间用户名，为 None 时使用当前登录用户
+        :param username: Workspace username; None uses the current logged-in user
         """
         if username is None:
             username = self._ctx.username
@@ -129,9 +134,9 @@ class Api(BaseEntity):
 
     def workspaces(self, username: Optional[str] = None) -> Workspaces:
         """
-        获取工作空间列表迭代器。
+        Get a workspace list iterator.
 
-        :param username: 指定用户名，为 None 时使用当前登录用户
+        :param username: Username; None uses the current logged-in user
         """
         if username is None:
             username = self._ctx.username
@@ -140,9 +145,9 @@ class Api(BaseEntity):
 
     def project(self, path: str) -> Project:
         """
-        获取项目信息。
+        Get project info.
 
-        :param path: 项目路径，格式为 'username/project-name'
+        :param path: Project path, format: ``'username/project-name'``
         """
         validate_api_path(path, segments=2, label="project")
         return Project(self._ctx, path=path)
@@ -158,15 +163,15 @@ class Api(BaseEntity):
         all: bool = False,
     ) -> Projects:
         """
-        获取工作空间下的项目列表迭代器。
+        Get a project list iterator under a workspace.
 
-        :param path: 工作空间名称 'username'
-        :param sort: 排序方式
-        :param search: 搜索关键词
-        :param detail: 是否返回详细信息
-        :param page: 起始页码，默认 1
-        :param size: 每页数量，默认 100
-        :param all: 是否获取全部数据，默认 False
+        :param path: Workspace name, e.g. ``'username'``
+        :param sort: Sort field
+        :param search: Search keyword
+        :param detail: Whether to return detailed info
+        :param page: Page number, default 1
+        :param size: Page size, default 100
+        :param all: If True, fetch all pages, default False
         """
         validate_api_path(path, segments=1, label="workspace")
         query = PaginatedQuery(page=page, size=size, search=search, sort=sort, all=all)
@@ -181,12 +186,12 @@ class Api(BaseEntity):
         description: Optional[str] = None,
     ) -> Optional[Project]:
         """
-        在指定工作空间下创建项目。
+        Create a project under the specified workspace.
 
-        :param username: 工作空间用户名，为 None 时使用当前登录用户
-        :param name: 项目名称 (1-100 字符，仅支持 0-9a-zA-Z-_.+)
-        :param visibility: 可见性，PUBLIC 或 PRIVATE，默认 PRIVATE
-        :param description: 项目描述
+        :param username: Workspace username; None uses the current logged-in user
+        :param name: Project name (1-100 chars, only 0-9a-zA-Z-_.+ supported)
+        :param visibility: Visibility, ``PUBLIC`` or ``PRIVATE``, default ``PRIVATE``
+        :param description: Project description
         """
         if username is None:
             username = self._ctx.username
@@ -196,9 +201,9 @@ class Api(BaseEntity):
 
     def run(self, path: str) -> Experiment:
         """
-        获取单个实验。
+        Get a single experiment.
 
-        :param path: 实验路径，格式为 'username/project/run_id'
+        :param path: Experiment path, format: ``'username/project/run_id'``
         """
         validate_api_path(path, segments=3, label="run")
         return Experiment(self._ctx, path=path)
@@ -209,10 +214,10 @@ class Api(BaseEntity):
         filters: Optional[List[Dict[str, Any]]] = None,
     ) -> Experiments:
         """
-        通过条件过滤获取项目下的实验列表。
+        Get a filtered experiment list under a project.
 
-        :param path: 项目路径，格式为 'username/project'
-        :param filters: 过滤规则列表，每项为 {key, type, op, value}
+        :param path: Project path, format: ``'username/project'``
+        :param filters: Filter rules list, each item is ``{key, type, op, value}``
         """
         validate_api_path(path, segments=2, label="project")
         if not isinstance(filters, list):
@@ -229,12 +234,12 @@ class Api(BaseEntity):
         all: bool = False,
     ) -> Experiments:
         """
-        通过分页获取项目下的实验列表。
+        Get a paginated experiment list under a project.
 
-        :param path: 项目路径，格式为 'username/project'
-        :param page: 起始页码，默认 1
-        :param size: 每页数量，默认 100
-        :param all: 是否获取全部数据，默认 False
+        :param path: Project path, format: ``'username/project'``
+        :param page: Page number, default 1
+        :param size: Page size, default 100
+        :param all: If True, fetch all pages, default False
         """
         validate_api_path(path, segments=2, label="project")
         query = PaginatedQuery(page=page, size=size, all=all)
@@ -243,6 +248,7 @@ class Api(BaseEntity):
     def user(self) -> User:
         return User(self._ctx)
 
+    @deprecated("Use `series()` method instead.")
     def columns(
         self,
         path: str,
@@ -256,13 +262,10 @@ class Api(BaseEntity):
         """
         List columns under an experiment (paginated, with optional fuzzy search).
 
-        The ``search`` parameter performs **fuzzy matching** (case-insensitive ``contains``)
-        on the column ``name`` field.
-
         :param path: Experiment path, format: ``'username/project/run_id'``
         :param page: Page number, default 1
         :param size: Page size, default 100
-        :param search: Fuzzy search keyword (matches column **name**, not key)
+        :param search: Fuzzy search keyword
         :param column_class: Column class, ``CUSTOM`` or ``SYSTEM``, default ``CUSTOM``
         :param column_type: Column data type, e.g. ``FLOAT``, ``STRING``, ``IMAGE``
         :param all: If True, fetch all pages, default False
@@ -277,6 +280,7 @@ class Api(BaseEntity):
             column_class=column_class,
         )
 
+    @deprecated("Use `series()` method instead.")
     def column(
         self,
         path: str,
@@ -287,10 +291,6 @@ class Api(BaseEntity):
         """
         Get a single column by key (fuzzy search, first match).
 
-        Performs fuzzy search (``contains`` on ``name``) and returns the first matching
-        column. If multiple columns share a similar name, the first one (ordered by
-        ``id DESC``) is returned.
-
         :param path: Experiment path, format: ``'username/project/run_id'``
         :param key: Column key to search, e.g. ``"loss"``, ``"acc"``
         :param column_class: Column class, ``CUSTOM`` or ``SYSTEM``, default ``CUSTOM``
@@ -300,6 +300,26 @@ class Api(BaseEntity):
         validate_non_empty_string(key, label="column key")
         return Column(self._ctx, path=path, key=key, column_class=column_class, column_type=column_type)
 
+    def series(
+        self,
+        path: str,
+        metric_type: ApiMetricKeyTypeLiteral = "SCALAR",
+        metric_class: ApiMetricKeyClassLiteral = "CUSTOM",
+        search: str = "",
+    ) -> Series:
+        """
+        List all metric keys for the given experiment.
+
+        :param path: Experiment path, format: ``'username/project/run_id'``
+        :param metric_type: ``"SCALAR"`` (default) or ``"MEDIA"``
+        :param metric_class: ``"CUSTOM"`` (default) or ``"SYSTEM"`` — filter keys by class.
+        :param search: Fuzzy search filter — case-insensitive substring match on key names.
+        :returns: :class:`Series`
+        """
+        validate_api_path(path, segments=3, label="run")
+        exp = Experiment(self._ctx, path=path)
+        return exp.series(metric_type=metric_type, metric_class=metric_class, search=search)
+
     # -------
     # 私有化相关接口
     # --------
@@ -307,4 +327,4 @@ class Api(BaseEntity):
         return SelfHosted(self._ctx)
 
 
-__all__ = ["Api"]
+__all__ = ["Api", "Series"]

--- a/swanlab/api/column.py
+++ b/swanlab/api/column.py
@@ -3,6 +3,11 @@
 @file: column.py
 @time: 2026/4/20
 @description: Column 实体类 — 实验列的查询与操作
+
+.. deprecated::
+    Use :meth:`Api.series` / :meth:`Experiment.series` instead.
+    Column metadata (name/class/type) is no longer maintained by the backend;
+    ``Series`` offers cursor-paginated key listing directly from House.
 """
 
 from typing import Any, Callable, Dict, Iterator, Optional, cast
@@ -12,7 +17,7 @@ from swanlab.api.typings.column import ApiColumnType
 from swanlab.api.typings.common import (
     ApiColumnClassLiteral,
     ApiColumnDataTypeLiteral,
-    ApiMetricColumnTypeLiteral,
+    ApiMetricKeyTypeLiteral,
     ApiResponseType,
     PaginatedQuery,
 )
@@ -157,7 +162,7 @@ class Column(BaseEntity):
     def metric(
         self,
         sample: int = 1500,
-        metric_type: ApiMetricColumnTypeLiteral = "SCALAR",
+        metric_type: ApiMetricKeyTypeLiteral = "SCALAR",
         ignore_timestamp: bool = False,
         media_step: Optional[int] = None,
     ) -> Dict[str, Any]:

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -5,13 +5,19 @@
 @description: Experiment 实体类 — 单个实验的查询与操作
 """
 
-from typing import Any, Dict, Iterator, List, Optional, Union, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union, cast
+
+from typing_extensions import deprecated
 
 from swanlab.api.base import ApiClientContext, BaseEntity
 from swanlab.api.typings import ApiResponseType
 from swanlab.api.typings.common import (
     ApiColumnClassLiteral,
     ApiColumnDataTypeLiteral,
+    ApiMetricKeyClassLiteral,
+    ApiMetricKeyTypeLiteral,
     ApiMetricLogLevelLiteral,
     PaginatedQuery,
     RangeQuery,
@@ -32,6 +38,9 @@ from swanlab.api.utils import (
     validate_update_active,
 )
 from swanlab.sdk.internal.pkg import console
+
+if TYPE_CHECKING:
+    from swanlab.api.series import Series
 
 
 class Experiment(BaseEntity):
@@ -165,6 +174,7 @@ class Experiment(BaseEntity):
                 data = self._data
         return cast(ApiExperimentProfileType, self._ensure_data().get("profile", {}))
 
+    @deprecated("Use `series()` method instead.")
     def column(
         self,
         key: str,
@@ -306,6 +316,7 @@ class Experiment(BaseEntity):
             range_query=rq,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            experiment_name=self.name,
         ).json()
 
     def summary(
@@ -407,6 +418,7 @@ class Experiment(BaseEntity):
         )
         return metric.export_logs(start=start, rows=rows)
 
+    @deprecated("Use `series()` method instead.")
     def columns(
         self,
         page: int = 1,
@@ -418,9 +430,6 @@ class Experiment(BaseEntity):
     ):
         """
         List columns under this experiment (paginated, with optional fuzzy search).
-
-        The ``search`` parameter performs **fuzzy matching** (case-insensitive ``contains``)
-        on the column ``name`` field.
 
         :param page: Page number, default 1
         :param size: Page size, default 100
@@ -444,6 +453,44 @@ class Experiment(BaseEntity):
             project_id_getter=lambda: self.project_id,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+        )
+
+    def series(
+        self,
+        metric_type: ApiMetricKeyTypeLiteral = "SCALAR",
+        metric_class: ApiMetricKeyClassLiteral = "CUSTOM",
+        search: str = "",
+    ) -> "Series":
+        """
+        List all metric keys for this experiment.
+
+        :param metric_type: ``"SCALAR"`` (default) or ``"MEDIA"``.
+        :param metric_class: ``"CUSTOM"`` (default) or ``"SYSTEM"`` — filter keys by class.
+        :param search: Fuzzy search filter — case-insensitive substring match on key names.
+        :returns: :class:`Series`
+        """
+        from swanlab.api.series import Series
+
+        run_id = self.run_id
+        project_id = self.project_id
+        root_pro_id = self.root_pro_id
+        root_exp_id = self.root_exp_id
+
+        # 克隆实验的数据存在根实验下，因此查询时直接用根实验的 ID。
+        query_pro_id = root_pro_id or project_id
+        query_exp_id = root_exp_id or run_id
+        experiments: List[Dict[str, str]] = [{"projectId": query_pro_id, "experimentId": query_exp_id}]
+        return Series(
+            self._ctx,
+            experiments=experiments,
+            metric_type=metric_type,
+            metric_class=metric_class,
+            search=search,
+            project_id=project_id,
+            run_id=run_id,
+            root_pro_id=root_pro_id,
+            root_exp_id=root_exp_id,
+            experiment_name_getter=lambda: self.name,
         )
 
     def delete(self, commit: bool = False) -> bool:

--- a/swanlab/api/metric.py
+++ b/swanlab/api/metric.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 from swanlab.api.base import ApiClientContext, BaseEntity
 from swanlab.api.typings import ApiColumnCsvExportType, ApiResponseType
 from swanlab.api.typings.common import (
+    MAX_CONCURRENT_COUNT,
     MAX_METRIC_KEY_BATCH_SIZE,
     ApiMetricKeyTypeLiteral,
     ApiMetricLogLevelLiteral,
@@ -758,7 +759,7 @@ class Metrics(BaseEntity):
         """根据 metric_type 和模式分发到具体的获取方法。"""
         if self._metric_type == "SCALAR":
             if self._range_query is not None or self._all:
-                data_list = self._batch_keys(self._fetch_scalar_csv)
+                data_list = self._fetch_scalar_csv(self._keys)
             else:
                 data_list = self._batch_keys(self._fetch_scalar_lines)
         else:
@@ -892,6 +893,25 @@ class Metrics(BaseEntity):
 
     def _fetch_scalar_csv(self, keys: List[str]) -> List[Dict[str, Any]]:
         """CSV 全量下载 + value stats，使用 House 批量导出接口。
+
+        将 keys 按 ``_CSV_KEY_BATCH_SIZE``（16）个一组分批，4 线程并发获取。
+        通过 ``POST /house/metrics/scalar/export`` 一次性导出每批 key 到 CSV 文件，
+        再通过 ``/files/presigned/get`` 获取预签名下载链接。
+        value stats 批量获取，与导出请求并发执行。
+        """
+        if len(keys) <= MAX_METRIC_KEY_BATCH_SIZE:
+            return self._fetch_scalar_csv_batch(keys)
+
+        chunks = [keys[i : i + MAX_METRIC_KEY_BATCH_SIZE] for i in range(0, len(keys), MAX_METRIC_KEY_BATCH_SIZE)]
+        with SafeThreadPoolExecutor(max_workers=MAX_CONCURRENT_COUNT) as pool:
+            futures = [pool.submit(self._fetch_scalar_csv_batch, chunk) for chunk in chunks]
+            results: List[Dict[str, Any]] = []
+            for f in futures:
+                results.extend(f.result())
+            return results
+
+    def _fetch_scalar_csv_batch(self, keys: List[str]) -> List[Dict[str, Any]]:
+        """单批 CSV 导出 + value stats（≤16 keys）。
 
         通过 ``POST /house/metrics/scalar/export`` 一次性导出所有 key 到一个 CSV 文件，
         再通过 ``/files/presigned/get`` 获取预签名下载链接。

--- a/swanlab/api/metric.py
+++ b/swanlab/api/metric.py
@@ -7,13 +7,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
 from swanlab.api.base import ApiClientContext, BaseEntity
 from swanlab.api.typings import ApiColumnCsvExportType, ApiResponseType
 from swanlab.api.typings.common import (
     MAX_METRIC_KEY_BATCH_SIZE,
-    ApiMetricColumnTypeLiteral,
+    ApiMetricKeyTypeLiteral,
     ApiMetricLogLevelLiteral,
     RangeQuery,
 )
@@ -73,25 +73,25 @@ def _merge_value_stats(
     return merged
 
 
-def _extract_csv_url(data: Any) -> str:
-    if isinstance(data, list) and data:
-        return _extract_csv_url(data[0])
-    if isinstance(data, dict):
-        url = data.get("url", "")
-        if isinstance(url, str) and url:
-            return url
-        return _extract_csv_url(data.get("data"))
-    return ""
-
-
 @safe.decorator(message="Failed to download CSV")
-def _stream_csv_rows(
+def _stream_export_csv(
     client: "Client",
     url: str,
+    keys: List[str],
     rq: Optional[RangeQuery] = None,
     timeout: int = 30,
-) -> Optional[List[Dict[str, Any]]]:
-    """Stream-download CSV and parse rows, reusing the Client session (preserving proxy/retry config)."""
+) -> Optional[Dict[str, List[Dict[str, Any]]]]:
+    """Stream-download wide-format export CSV and parse per-key rows.
+
+    CSV layout (from ``POST /house/metrics/scalar/export``)::
+
+        step, {exp}-{key1}_step, {exp}-{key1}_timestamp,
+              {exp}-{key2}_step, {exp}-{key2}_timestamp, …
+
+    One row per step; columns are interleaved as ``(value, timestamp)`` pairs.
+    The ``{exp}-{key}_step`` column actually holds the metric **value** despite
+    its name — the suffix is a House naming convention.
+    """
     import csv
     import time
     from collections import deque
@@ -99,73 +99,98 @@ def _stream_csv_rows(
     resp = client._session.get(url, stream=True, timeout=timeout)
     resp.raise_for_status()
     resp.encoding = "utf-8"
-
     lines = resp.iter_lines(decode_unicode=True)
-    next(lines, None)  # skip header
+    next(lines, None)  # skip header — column order is known from ``keys``
 
-    max_len = rq.tail if rq is not None and rq.tail is not None else None
-    rows: Union[deque[Dict[str, Any]], List[Dict[str, Any]]] = deque(maxlen=max_len) if max_len is not None else []
+    n_keys = len(keys)
+    tail_limit = rq.tail if rq is not None and rq.tail is not None else None
+    rows_per_key: List[Any] = [deque(maxlen=tail_limit) if tail_limit is not None else [] for _ in range(n_keys)]
 
-    # Pre-compute timestamp lower bound for ``last`` mode
     last_start_ts: Optional[int] = None
     if rq is not None and rq.last is not None:
         last_start_ts = int(time.time() * 1000) - rq.last
 
+    # CSV is ``ORDER BY step`` — safe to break once step exceeds the range end.
+    step_end_bound: Optional[int] = None
+    if rq is not None and rq.type != "timestamp" and last_start_ts is None and rq.end is not None:
+        step_end_bound = rq.end
+
+    head_limit = rq.head if rq is not None and rq.head is not None else None
     _warned_missing_ts = False
 
     for row in csv.reader(lines):
-        if not row or len(row) < 2:
+        if not row:
             continue
         try:
             step = int(row[0])
-            value = float(row[1])
         except (ValueError, IndexError):
             continue
 
-        item: Dict[str, Any] = {"step": step, "value": value}
+        if step_end_bound is not None and step > step_end_bound:
+            break
 
-        if len(row) >= 3:
+        for i in range(n_keys):
+            vc = 1 + i * 2  # value column index
+            tc = 2 + i * 2  # timestamp column index
+            if vc >= len(row):
+                continue
+            raw_val = row[vc]
+            if not raw_val:
+                continue
             try:
-                item["timestamp"] = int(row[2])
-            except (ValueError, IndexError):
-                pass
+                value = float(raw_val)
+            except ValueError:
+                continue
 
-        if rq is not None:
-            # --- ``last`` mode: filter by timestamp >= (now - last) ---
-            if last_start_ts is not None:
-                ts = item.get("timestamp")
-                if ts is None:
-                    if not _warned_missing_ts:
-                        console.warning("CSV row missing `timestamp` column.")
-                        _warned_missing_ts = True
-                    continue
-                if ts < last_start_ts:
-                    continue
-            # --- timestamp range mode ---
-            elif rq.type == "timestamp":
-                ts = item.get("timestamp")
-                if ts is None:
-                    if not _warned_missing_ts:
-                        console.warning("CSV row missing `timestamp` column.")
-                        _warned_missing_ts = True
-                    continue
-                if rq.start is not None and ts < rq.start:
-                    continue
-                if rq.end is not None and ts > rq.end:
-                    break
-            # --- step range mode ---
-            else:
-                if rq.start is not None and step < rq.start:
-                    continue
-                if rq.end is not None and step > rq.end:
-                    break
-            # --- head early-stop ---
-            if rq.head is not None and len(rows) >= rq.head:
-                break
+            ts: Optional[int] = None
+            if tc < len(row) and row[tc]:
+                try:
+                    ts = int(row[tc])
+                except ValueError:
+                    pass
 
-        rows.append(item)
+            if rq is not None:
+                # --- ``last`` mode: filter by timestamp >= (now - last) ---
+                if last_start_ts is not None:
+                    if ts is None:
+                        if not _warned_missing_ts:
+                            console.warning("CSV row missing `timestamp` column.")
+                            _warned_missing_ts = True
+                        continue
+                    if ts < last_start_ts:
+                        continue
+                # --- timestamp range mode ---
+                elif rq.type == "timestamp":
+                    if ts is None:
+                        if not _warned_missing_ts:
+                            console.warning("CSV row missing `timestamp` column.")
+                            _warned_missing_ts = True
+                        continue
+                    if rq.start is not None and ts < rq.start:
+                        continue
+                    if rq.end is not None and ts > rq.end:
+                        continue
+                # --- step range mode (end handled by step_end_bound break) ---
+                else:
+                    if rq.start is not None and step < rq.start:
+                        continue
 
-    return list(rows)
+            item: Dict[str, Any] = {"step": step, "value": value}
+            if ts is not None:
+                item["timestamp"] = ts
+            rows_per_key[i].append(item)
+
+        # head early-stop: all keys collected enough rows
+        if head_limit is not None and all(len(r) >= head_limit for r in rows_per_key):
+            break
+
+    result: Dict[str, List[Dict[str, Any]]] = {}
+    for i, key in enumerate(keys):
+        rows = list(rows_per_key[i])
+        if head_limit is not None:
+            rows = rows[:head_limit]
+        result[key] = rows
+    return result
 
 
 class Metric(BaseEntity):
@@ -192,6 +217,7 @@ class Metric(BaseEntity):
         all: bool = False,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        experiment_name: str = "",
     ) -> None:
         super().__init__(ctx)
         validate_metric_type(metric_type, key)
@@ -212,6 +238,7 @@ class Metric(BaseEntity):
         self._all = all
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._experiment_name = experiment_name
 
     # 类型 → 加载方法 的分发表，新增类型只需在此注册
     _FETCH_DISPATCH = {
@@ -333,6 +360,32 @@ class Metric(BaseEntity):
         if step is not None:
             payload["step"] = step
         return payload
+
+    @staticmethod
+    def _build_export_payload(
+        project_id: str,
+        run_id: str,
+        keys: List[str],
+        experiment_name: str = "",
+        root_pro_id: str = "",
+        root_exp_id: str = "",
+    ) -> Dict[str, Any]:
+        """Build payload for ``POST /house/metrics/scalar/export``.
+
+        ``experimentName`` is required by the API but only used for CSV column
+        headers — the actual query uses ``experimentId``. Falls back to ``run_id``
+        when the real name is unavailable.
+        """
+        exp_name = experiment_name or run_id
+        columns: List[Dict[str, str]] = []
+        for key in keys:
+            col: Dict[str, str] = {"experimentName": exp_name, "experimentId": run_id, "key": key}
+            if root_pro_id:
+                col["rootProId"] = root_pro_id
+            if root_exp_id:
+                col["rootExpId"] = root_exp_id
+            columns.append(col)
+        return {"projectId": project_id, "columns": columns}
 
     def _build_log_params(self) -> Dict[str, Any]:
         params: Dict[str, Any] = {
@@ -516,15 +569,31 @@ class Metric(BaseEntity):
     # ------------------------------------------------------------------
 
     def export_csv(self) -> ApiResponseType:
-        """导出列数据为 CSV。"""
+        """导出列数据为 CSV。
+
+        通过 ``POST /house/metrics/scalar/export`` 获取 ``key``，
+        再通过 ``/files/presigned/get`` 转换为预签名下载链接。
+        """
         if self.metric_type != "SCALAR":
             return ApiResponseType(ok=False, errmsg="export_csv() only support SCALAR metric_type", data=None)
-        resp = self._get(f"/experiment/{self._run_id}/column/csv", params={"key": self.key})
-        if not resp.ok:
+        payload = Metric._build_export_payload(
+            self._project_id,
+            self._run_id,
+            [self.key],
+            experiment_name=self._experiment_name,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
+        resp = self._post("/house/metrics/scalar/export", data=payload)
+        if not resp.ok or not resp.data:
             return resp
-        url = _extract_csv_url(resp.data)
+        cos_key = resp.data.get("cosKey", "") if isinstance(resp.data, dict) else ""
+        if not cos_key:
+            return ApiResponseType(ok=False, errmsg="Invalid response format: missing cosKey", data=None)
+        url_map = Metric._fetch_file_presigned_urls(self, [cos_key])
+        url = url_map.get(cos_key, "")
         if not url:
-            return ApiResponseType(ok=False, errmsg="Invalid response format", data=None)
+            return ApiResponseType(ok=False, errmsg="Failed to get presigned download URL", data=None)
         return ApiResponseType(ok=True, data=ApiColumnCsvExportType(url=url))
 
     def export_logs(self, start: int = 0, rows: int = 500_000) -> ApiResponseType:
@@ -618,7 +687,7 @@ class Metrics(BaseEntity):
         project_id: str,
         run_id: str,
         keys: List[str],
-        metric_type: ApiMetricColumnTypeLiteral,
+        metric_type: ApiMetricKeyTypeLiteral,
         sample: int = 1500,
         ignore_timestamp: bool = False,
         media_step: Optional[int] = None,
@@ -626,6 +695,7 @@ class Metrics(BaseEntity):
         range_query: Optional[RangeQuery] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        experiment_name: str = "",
     ) -> None:
         super().__init__(ctx)
         validate_metric_keys(keys)
@@ -645,6 +715,7 @@ class Metrics(BaseEntity):
         self._range_query = range_query
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._experiment_name = experiment_name
         self._page_info: Dict[str, Any] = {
             "keys": keys,
             "metricType": metric_type,
@@ -732,6 +803,7 @@ class Metrics(BaseEntity):
             all=self._all,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            experiment_name=self._experiment_name,
         )
 
     # ------------------------------------------------------------------
@@ -819,38 +891,43 @@ class Metrics(BaseEntity):
     # ------------------------------------------------------------------
 
     def _fetch_scalar_csv(self, keys: List[str]) -> List[Dict[str, Any]]:
-        """CSV 全量下载 + value stats，URL 获取并发，CSV 顺序下载。
+        """CSV 全量下载 + value stats，使用 House 批量导出接口。
 
-        value stats 通过后端 ``columns`` 批量获取；
-        CSV presigned URL 通过 ``GET /experiment/{run_id}/column/csv`` per-key 获取，
-        多 key 时并发拉取 URL，但 CSV 下载为顺序执行（每批最多 4 个 key）。
+        通过 ``POST /house/metrics/scalar/export`` 一次性导出所有 key 到一个 CSV 文件，
+        再通过 ``/files/presigned/get`` 获取预签名下载链接。
+        value stats 批量获取，与导出请求并发执行。
         """
-        # 并发：step 统计 + time 统计 + per-key CSV URL
+        # 并发：step 统计 + time 统计 + 批量 CSV 导出
         requests: List[tuple] = self._build_value_stats_requests(keys)
-        for key in keys:
-            requests.append((self._get, f"/experiment/{self._run_id}/column/csv", {"params": {"key": key}}))
+        export_payload = Metric._build_export_payload(
+            self._project_id,
+            self._run_id,
+            keys,
+            experiment_name=self._experiment_name,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
+        requests.append((self._post, "/house/metrics/scalar/export", {"data": export_payload}))
 
         all_resps = self._concurrent_request(requests)
         step_resp, time_resp = all_resps[0], all_resps[1]
-        csv_resps = all_resps[2:]
+        export_resp = all_resps[2]
 
         value_list = self._extract_value_stats(step_resp, time_resp, keys)
         value_by_key: Dict[str, Dict[str, Any]] = {keys[i]: v for i, v in enumerate(value_list)}
 
-        # 提取 presigned CSV URL（按 key 索引）
-        url_by_key: Dict[str, Optional[str]] = {}
-        for i, key in enumerate(keys):
-            url = ""
-            if i < len(csv_resps) and csv_resps[i].ok and csv_resps[i].data:
-                url = _extract_csv_url(csv_resps[i].data)
-            url_by_key[key] = url or None
-
-        # 下载 CSV 并解析（每批最多 _BATCH_SIZE 个 key，穿行执行防止并发膨胀）
-        urls_ordered = [url_by_key.get(key) for key in keys]
-        csv_rows_list = self._download_csvs(urls_ordered)
-        metrics_by_key: Dict[str, Any] = {
-            keys[i]: csv_rows_list[i] if i < len(csv_rows_list) else [] for i, key in enumerate(keys)
-        }
+        # cosKey → presigned URL → download → parse per-key rows
+        metrics_by_key: Dict[str, Any] = {key: [] for key in keys}
+        cos_key = ""
+        if export_resp.ok and isinstance(export_resp.data, dict):
+            cos_key = export_resp.data.get("cosKey", "")
+        if cos_key:
+            url_map = Metric._fetch_file_presigned_urls(self, [cos_key])
+            url = url_map.get(cos_key, "")
+            if url:
+                parsed = _stream_export_csv(self._ctx.client, url, keys, self._range_query)
+                if parsed:
+                    metrics_by_key = parsed
 
         return self._build_scalar_results(keys, metrics_by_key, value_by_key)
 
@@ -880,21 +957,6 @@ class Metrics(BaseEntity):
             if stats:
                 data.update(stats)
             results.append(data)
-        return results
-
-    # ------------------------------------------------------------------
-    # CSV 后处理
-    # ------------------------------------------------------------------
-
-    def _download_csvs(self, urls: List[Optional[str]]) -> List[List[Dict[str, Any]]]:
-        """顺序下载并解析 CSV 文件（每批最多 ``_BATCH_SIZE`` 个 key，无需并发）。"""
-        results: List[List[Dict[str, Any]]] = []
-        for url in urls:
-            if url:
-                rows = _stream_csv_rows(self._ctx.client, url, self._range_query)
-                results.append(rows or [])
-            else:
-                results.append([])
         return results
 
     # ------------------------------------------------------------------

--- a/swanlab/api/series.py
+++ b/swanlab/api/series.py
@@ -1,0 +1,327 @@
+"""
+@author: caddiesnew
+@file: series.py
+@time: 2026/7/9
+@description: Series 实体类 — 实验指标序列查询
+"""
+
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+from swanlab.api.base import ApiClientContext, BaseEntity
+from swanlab.api.typings import ApiMetricKeyClassLiteral, ApiMetricKeyTypeLiteral, ApiResponseType
+from swanlab.api.utils import get_properties
+
+# 系统指标 key 前缀：SCALAR 类型且以此前缀开头的 key 分类为 SYSTEM
+_SYSTEM_KEY_PREFIX = "__swanlab__"
+
+
+class Key(BaseEntity):
+    """A single metric key — lightweight handle for querying metric data and exporting CSV.
+
+    Usage::
+
+        key = experiment.key("loss")
+        print(key.json())          # {key, metric_type, key_class, ...}
+        data = key.metric()        # scalar line data
+        url = key.export_csv()     # CSV download URL
+    """
+
+    def __init__(
+        self,
+        ctx: ApiClientContext,
+        *,
+        project_id: str,
+        run_id: str,
+        key: str,
+        metric_type: ApiMetricKeyTypeLiteral = "SCALAR",
+        experiment_name_getter: Optional[Callable[[], str]] = None,
+        root_pro_id: str = "",
+        root_exp_id: str = "",
+    ) -> None:
+        super().__init__(ctx)
+        self._project_id = project_id
+        self._run_id = run_id
+        self._key = key
+        self._metric_type = metric_type
+        self._experiment_name_getter = experiment_name_getter
+        self._cached_experiment_name: Optional[str] = None
+        self._root_pro_id = root_pro_id
+        self._root_exp_id = root_exp_id
+
+    def _resolve_experiment_name(self) -> str:
+        if self._cached_experiment_name is not None:
+            return self._cached_experiment_name
+        if self._experiment_name_getter is not None:
+            self._cached_experiment_name = self._experiment_name_getter()
+        if self._cached_experiment_name is None:
+            self._cached_experiment_name = ""
+        return self._cached_experiment_name
+
+    @property
+    def project_id(self) -> str:
+        return self._project_id
+
+    @property
+    def run_id(self) -> str:
+        return self._run_id
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    @property
+    def metric_type(self) -> str:
+        return self._metric_type
+
+    @property
+    def key_class(self) -> ApiMetricKeyClassLiteral:
+        """Key classification: ``"CUSTOM"`` or ``"SYSTEM"``."""
+        if self._metric_type == "SCALAR" and self._key.startswith(_SYSTEM_KEY_PREFIX):
+            return "SYSTEM"
+        return "CUSTOM"
+
+    def metric(
+        self,
+        sample: int = 1500,
+        ignore_timestamp: bool = False,
+        media_step: Optional[int] = None,
+        all: bool = False,
+    ) -> Dict[str, Any]:
+        """Fetch metric data points for this key.
+
+        :param sample: Max data points (downsampled server-side). Default 1500, max 1500.
+        :param ignore_timestamp: If True, omit ``timestamp`` field from each data point.
+        :param media_step: Step filter for MEDIA metrics. If None, returns all steps.
+        :param all: If True, fetch full-resolution data without downsampling.
+        :returns: ``{"list": [{"step", "value", "timestamp", "key"}], ...}``
+        """
+        from swanlab.api.metric import Metric
+
+        metric = Metric(
+            ctx=self._ctx,
+            project_id=self._project_id,
+            run_id=self._run_id,
+            key=self._key,
+            sample=sample,
+            metric_type=self._metric_type,
+            ignore_timestamp=ignore_timestamp,
+            media_step=media_step,
+            all=all,
+            root_pro_id=self._root_pro_id,
+            root_exp_id=self._root_exp_id,
+        )
+        return metric.json()
+
+    def export_csv(self) -> ApiResponseType:
+        """Export this key's data as a CSV file (SCALAR only).
+
+        :returns: ``ApiResponseType(ok=True, data={"url": "<download_url>"})``.
+            Returns ``ok=False`` for MEDIA keys.
+        """
+        from swanlab.api.metric import Metric
+
+        if self._metric_type != "SCALAR":
+            return ApiResponseType(ok=False, errmsg="export_csv() only support SCALAR metric_type", data=None)
+
+        experiment_name = self._resolve_experiment_name()
+
+        export_column: Dict[str, str] = {
+            "experimentId": self._run_id,
+            "key": self._key,
+        }
+        if experiment_name:
+            export_column["experimentName"] = experiment_name
+        if self._root_pro_id:
+            export_column["rootProId"] = self._root_pro_id
+        if self._root_exp_id:
+            export_column["rootExpId"] = self._root_exp_id
+
+        resp = self._post(
+            "/house/metrics/scalar/export",
+            data={"projectId": self._project_id, "columns": [export_column]},
+        )
+        if not resp.ok or not resp.data:
+            return resp
+
+        cos_key = resp.data.get("cosKey", "")
+        if not cos_key:
+            return ApiResponseType(ok=False, errmsg="Invalid response format: missing cosKey", data=None)
+
+        url_map = Metric._fetch_file_presigned_urls(self, [cos_key])
+        url = url_map.get(cos_key, "")
+        if not url:
+            return ApiResponseType(ok=False, errmsg="Failed to get presigned download URL", data=None)
+        return ApiResponseType(ok=True, data={"url": url})
+
+    def json(self) -> Dict[str, Any]:
+        return get_properties(self)
+
+
+class Series(BaseEntity):
+    """Metric key listing for one or more experiments.
+
+    Iterating yields :class:`Key` objects. Use :meth:`json` for a plain-dict summary.
+
+    Usage::
+
+        series = experiment.series()
+        for key in series:              # iterate Key objects
+            print(key.json())
+        series.availability(["loss"])   # check key existence
+    """
+
+    _PAGE_SIZE = 2000
+
+    def __init__(
+        self,
+        ctx: ApiClientContext,
+        *,
+        experiments: List[Dict[str, str]],
+        metric_type: ApiMetricKeyTypeLiteral = "SCALAR",
+        metric_class: ApiMetricKeyClassLiteral = "CUSTOM",
+        search: str = "",
+        project_id: str = "",
+        run_id: str = "",
+        root_pro_id: str = "",
+        root_exp_id: str = "",
+        experiment_name_getter: Optional[Callable[[], str]] = None,
+    ) -> None:
+        super().__init__(ctx)
+        if metric_type not in ("SCALAR", "MEDIA"):
+            raise ValueError(f"Invalid metric_type: {metric_type!r}, expected 'SCALAR' or 'MEDIA'")
+        if metric_class not in ("CUSTOM", "SYSTEM"):
+            raise ValueError(f"Invalid metric_class: {metric_class!r}, expected 'CUSTOM' or 'SYSTEM'")
+        if not isinstance(experiments, list) or not experiments:
+            raise ValueError("experiments must be a non-empty list of dicts")
+
+        self._experiments = experiments
+        self._metric_type: ApiMetricKeyTypeLiteral = metric_type
+        self._metric_class: ApiMetricKeyClassLiteral = metric_class
+        self._search = search
+        self._project_id = project_id
+        self._run_id = run_id
+        self._root_pro_id = root_pro_id
+        self._root_exp_id = root_exp_id
+        self._experiment_name_getter = experiment_name_getter
+        self._all_keys: Optional[List[str]] = None
+        self._cached_filtered: Optional[List[str]] = None
+        self._cached_list: Optional[List[Key]] = None
+
+    # ------------------------------------------------------------------
+    # 内部：全量拉取 + 缓存
+    # ------------------------------------------------------------------
+
+    def _fetch_all_keys(self) -> List[str]:
+        """Fetch all keys across all pages (cursor pagination), cache and return."""
+        if self._all_keys is not None:
+            return self._all_keys
+        keys: List[str] = []
+        cursor = ""
+        path = f"/house/metrics/{self._metric_type.lower()}/keys"
+        while True:
+            resp = self._post(
+                path,
+                data={
+                    "experiments": self._experiments,
+                    "limit": self._PAGE_SIZE,
+                    "cursor": cursor,
+                },
+            )
+            if not resp.ok or not resp.data:
+                break
+            page: Dict[str, Any] = resp.data
+            keys.extend(page.get("keys", []))
+            if not page.get("hasMore", False) or not page.get("nextCursor", ""):
+                break
+            cursor = page["nextCursor"]
+        self._all_keys = keys
+        return keys
+
+    def _filtered_keys(self) -> List[str]:
+        """Apply metric_class + search post-filter on cached full key list. Result is cached."""
+        if self._cached_filtered is not None:
+            return self._cached_filtered
+        keys = self._fetch_all_keys()
+        want_system = self._metric_class == "SYSTEM"
+        # 分支提循环外，用 not 替代 == bool 比较
+        if self._metric_type == "SCALAR":
+            if want_system:
+                result = [k for k in keys if k.startswith(_SYSTEM_KEY_PREFIX)]
+            else:
+                result = [k for k in keys if not k.startswith(_SYSTEM_KEY_PREFIX)]
+        else:
+            # MEDIA: 全为 CUSTOM
+            result = [] if want_system else keys
+        # 模糊搜索：大小写不敏感的子串匹配
+        if self._search:
+            needle = self._search.lower()
+            result = [k for k in result if needle in k.lower()]
+        self._cached_filtered = result
+        return result
+
+    def _ensure_batch(self) -> List["Key"]:
+        if self._cached_list is not None:
+            return self._cached_list
+        self._cached_list = [
+            Key(
+                self._ctx,
+                project_id=self._project_id,
+                run_id=self._run_id,
+                key=key_str,
+                metric_type=self._metric_type,
+                experiment_name_getter=self._experiment_name_getter,
+                root_pro_id=self._root_pro_id,
+                root_exp_id=self._root_exp_id,
+            )
+            for key_str in self._filtered_keys()
+        ]
+        return self._cached_list
+
+    # ------------------------------------------------------------------
+    # 公开接口
+    # ------------------------------------------------------------------
+
+    def __iter__(self) -> Iterator[Key]:
+        yield from self._ensure_batch()
+
+    def availability(self, keys: List[str]) -> Dict[str, List[str]]:
+        """Check which of the given keys exist in the experiment(s).
+
+        :param keys: Key names to check.
+        :returns: ``{key_name: [experiment_id, ...]}``. An empty list means no experiment has that key.
+        """
+        if not isinstance(keys, list) or not keys:
+            return {}
+        path = f"/house/metrics/{self._metric_type.lower()}/availability"
+        resp = self._post(path, data={"keys": keys, "experiments": self._experiments})
+        if resp.ok and isinstance(resp.data, dict):
+            return resp.data
+        return {}
+
+    @property
+    def total(self) -> int:
+        """Number of keys after filtering."""
+        return len(self._filtered_keys())
+
+    def json(self) -> Dict[str, Any]:
+        """Serialize to a JSON-compatible dict.
+
+        :returns:
+
+            ========== ============ ===========================================
+            Field       Type         Description
+            ========== ============ ===========================================
+            ``keys``    ``list[str]`` Filtered key names.
+            ``metricClass`` ``str``   ``"CUSTOM"`` or ``"SYSTEM"``.
+            ``metricType`` ``str``    ``"SCALAR"`` or ``"MEDIA"``.
+            ``projectId`` ``str``     Project ID.
+            ``runId``   ``str``       Experiment (run) ID.
+            ========== ============ ===========================================
+        """
+        return {
+            "keys": self._filtered_keys(),
+            "metricClass": self._metric_class,
+            "metricType": self._metric_type,
+            "projectId": self._project_id,
+            "runId": self._run_id,
+        }

--- a/swanlab/api/typings/__init__.py
+++ b/swanlab/api/typings/__init__.py
@@ -10,7 +10,8 @@ from .common import (
     ApiIdentityLiteral,
     ApiLicensePlanLiteral,
     ApiMetricAllTypeLiteral,
-    ApiMetricColumnTypeLiteral,
+    ApiMetricKeyClassLiteral,
+    ApiMetricKeyTypeLiteral,
     ApiMetricLogLevelLiteral,
     ApiMetricXAxisLiteral,
     ApiPaginationType,
@@ -43,7 +44,7 @@ __all__ = [
     "ApiLicensePlanLiteral",
     "ApiMetricLogLevelLiteral",
     "ApiMetricAllTypeLiteral",
-    "ApiMetricColumnTypeLiteral",
+    "ApiMetricKeyTypeLiteral",
     "ApiMetricXAxisLiteral",
     # General TypedDicts
     "ApiPaginationType",
@@ -68,6 +69,7 @@ __all__ = [
     "ApiColumnType",
     "ApiColumnCsvExportType",
     # Metric
+    "ApiMetricKeyClassLiteral",
     "ApiLogSeriesType",
     "ApiMediaSeriesType",
     "ApiScalarSeriesType",

--- a/swanlab/api/typings/common.py
+++ b/swanlab/api/typings/common.py
@@ -147,7 +147,7 @@ VALID_PAGE_SIZES = (10, 12, 15, 20, 24, 27, 50, 100)
 MAX_CONCURRENT_COUNT: int = 4
 
 # CH 每次查询 key 数量上限
-MAX_METRIC_KEY_BATCH_SIZE: int = 4
+MAX_METRIC_KEY_BATCH_SIZE: int = 16
 
 
 class RangeQuery(BaseModel, frozen=True):

--- a/swanlab/api/typings/common.py
+++ b/swanlab/api/typings/common.py
@@ -66,7 +66,11 @@ ApiIdentityLiteral = Literal["root", "user"]
 ApiLicensePlanLiteral = Literal["free", "commercial"]
 
 # 指标类型（log 不属于 column-backed metrics，使用独立查询方法）
-ApiMetricColumnTypeLiteral = Literal["SCALAR", "MEDIA"]
+ApiMetricKeyTypeLiteral = Literal["SCALAR", "MEDIA"]
+
+# 指标 key 分类(自定义与系统指标）
+ApiMetricKeyClassLiteral = Literal["CUSTOM", "SYSTEM"]
+
 
 # 指标扩展类型（包含 LOG，用于内部 Metric 调度）
 ApiMetricAllTypeLiteral = Literal["SCALAR", "MEDIA", "LOG"]

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -10,6 +10,8 @@ from swanlab.api.typings.common import RangeQuery
 from swanlab.cli.api.helper import (
     COLUMN_CLASS_TYPE,
     COLUMN_DATA_TYPE,
+    METRIC_KEY_CLASS,
+    METRIC_KEY_TYPE,
     METRIC_LOG_LEVEL_TYPE,
     PAGE_SIZE_TYPE,
     format_output,
@@ -112,7 +114,7 @@ def filter_experiments(project_path: str, filter_query: str, save_name: str, api
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
 
 
-@run_cli.command("columns")
+@run_cli.command("columns", deprecated=True)
 @click.argument("path", required=True)
 @click.option(
     "--page_num",
@@ -182,6 +184,60 @@ def list_experiment_columns(
         all=fetch_all,
     )
     resp = columns.wrapper()
+    payload = format_output(resp)
+    if save_name is not None:
+        save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
+
+
+@run_cli.command("series")
+@click.argument("path", required=True)
+@click.option(
+    "--type",
+    "metric_type",
+    default="SCALAR",
+    type=METRIC_KEY_TYPE,
+    help="Metric type: SCALAR or MEDIA. Default SCALAR.",
+)
+@click.option(
+    "--class",
+    "metric_class",
+    default="CUSTOM",
+    type=METRIC_KEY_CLASS,
+    help="Metric class: CUSTOM or SYSTEM. Default CUSTOM.",
+)
+@click.option(
+    "--search",
+    default="",
+    type=str,
+    help="Fuzzy search keyword (case-insensitive substring match on key names).",
+)
+@click.option(
+    "--save",
+    "save_name",
+    is_flag=False,
+    flag_value=".",
+    help="Save output as JSON to current directory.",
+)
+@with_custom_host
+def list_experiment_series(
+    path: str,
+    metric_type: str,
+    metric_class: str,
+    search: str,
+    save_name: str,
+    api: Api,
+):
+    """List metric keys of an experiment.
+
+    PATH format: username/project_name/run_id
+    """
+    series = api.series(
+        path=path,
+        metric_type=metric_type.upper(),  # type: ignore
+        metric_class=metric_class.upper(),  # type: ignore
+        search=search,
+    )
+    resp = series.wrapper()
     payload = format_output(resp)
     if save_name is not None:
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
@@ -344,7 +400,7 @@ def get_experiment_summary(path: str, keys: Optional[str], save_name: str, api: 
         save_output(orjson.dumps(payload, option=orjson.OPT_INDENT_2), name=save_name)
 
 
-@run_cli.command("column")
+@run_cli.command("column", deprecated=True)
 @click.argument("path", required=True)
 @click.option(
     "--key",

--- a/swanlab/cli/api/helper.py
+++ b/swanlab/cli/api/helper.py
@@ -12,6 +12,8 @@ from swanlab.api.typings.common import (
     VALID_PAGE_SIZES,
     ApiColumnClassLiteral,
     ApiColumnDataTypeLiteral,
+    ApiMetricKeyClassLiteral,
+    ApiMetricKeyTypeLiteral,
     ApiMetricLogLevelLiteral,
     ApiResponseType,
     ApiVisibilityLiteral,
@@ -26,6 +28,8 @@ class _SaveFormatEnum(enum.Enum):
 PAGE_SIZE_TYPE = click.Choice([str(s) for s in VALID_PAGE_SIZES])
 COLUMN_CLASS_TYPE = click.Choice(list(get_args(ApiColumnClassLiteral)), case_sensitive=False)
 COLUMN_DATA_TYPE = click.Choice(list(get_args(ApiColumnDataTypeLiteral)), case_sensitive=False)
+METRIC_KEY_TYPE = click.Choice(list(get_args(ApiMetricKeyTypeLiteral)), case_sensitive=False)
+METRIC_KEY_CLASS = click.Choice(list(get_args(ApiMetricKeyClassLiteral)), case_sensitive=False)
 VISIBILITY_TYPE = click.Choice(list(get_args(ApiVisibilityLiteral)), case_sensitive=False)
 METRIC_LOG_LEVEL_TYPE = click.Choice(list(get_args(ApiMetricLogLevelLiteral)), case_sensitive=False)
 

--- a/swanlab/deprecated/callbacks.py
+++ b/swanlab/deprecated/callbacks.py
@@ -14,7 +14,7 @@ from swanlab.sdk.cmd.merge_callbacks import merge_callbacks
 def register_callbacks(*args, **kwargs):
     warnings.warn(
         "`swanlab.register_callbacks()` is deprecated, use `swanlab.merge_callbacks()` instead",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
     return merge_callbacks(*args, **kwargs)

--- a/swanlab/deprecated/echarts.py
+++ b/swanlab/deprecated/echarts.py
@@ -14,7 +14,7 @@ from swanlab.sdk.internal.run.transforms import echarts
 def roc_curve(*args, **kwargs):
     warnings.warn(
         "`swanlab.roc_curve()` is deprecated, use `swanlab.echarts.roc_curve()` instead",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=2,
     )
     return echarts.roc_curve(*args, **kwargs)
@@ -23,7 +23,7 @@ def roc_curve(*args, **kwargs):
 @deprecated("use `swanlab.echarts.pr_curve()` instead")
 def pr_curve(*args, **kwargs):
     warnings.warn(
-        "`swanlab.pr_curve()` is deprecated, use `swanlab.echarts.pr_curve()` instead", DeprecationWarning, stacklevel=2
+        "`swanlab.pr_curve()` is deprecated, use `swanlab.echarts.pr_curve()` instead", FutureWarning, stacklevel=2
     )
     return echarts.pr_curve(*args, **kwargs)
 

--- a/swanlab/deprecated/project.py
+++ b/swanlab/deprecated/project.py
@@ -1,0 +1,34 @@
+"""
+@author: cunyue
+@description: 项目相关将被弃用的接口
+"""
+
+import warnings
+
+from typing_extensions import deprecated
+
+from swanlab.exceptions import ApiError
+from swanlab.sdk.internal.core_python import client
+
+
+@deprecated("legacy projects without views will no longer be supported in v0.10.")
+def get_or_create_old_project(*, data: dict):
+    """
+    旧接口创建、获取项目信息，主要用于兼容旧版本的项目创建接口
+    :param data: 项目数据
+    :return: 项目信息
+    """
+    warnings.warn(
+        "You are accessing a legacy project that does not support views. "
+        "Legacy projects will no longer be supported in v0.10, scheduled for release on 2026-10-01. "
+        "Please create a new project or migrate this project in the web app.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    try:
+        # 1. 尝试调用旧接口创建项目
+        # 已创建：200 ; 创建成功：201 ; 失败：4xx/5xx
+        client.post("/project", data=data, log_error=False)
+    except ApiError as e:
+        if e.response.status_code != 409:
+            raise e

--- a/swanlab/deprecated/project.py
+++ b/swanlab/deprecated/project.py
@@ -21,8 +21,8 @@ def get_or_create_old_project(*, data: dict):
     warnings.warn(
         "You are accessing a legacy project that does not support views. "
         "Legacy projects will no longer be supported in v0.10, scheduled for release on 2026-10-01. "
-        "Please create a new project or migrate this project in the web app.",
-        DeprecationWarning,
+        "Please create a new project or upgrade this project in the web app.",
+        FutureWarning,
         stacklevel=2,
     )
     try:

--- a/swanlab/deprecated/sender.py
+++ b/swanlab/deprecated/sender.py
@@ -1,5 +1,7 @@
 from typing import Literal, Optional, Sequence, cast
 
+from typing_extensions import deprecated
+
 from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord, ColumnType
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.sdk.internal.core_python import client
@@ -8,6 +10,7 @@ from swanlab.sdk.internal.pkg import adapter
 from swanlab.sdk.typings.core_python.api.upload import DeprecatedUploadColumn, DeprecatedUploadColumns
 
 
+@deprecated("legacy projects without views will no longer be supported in v0.10.")
 class DeprecatedHttpRecordSender(HttpRecordSender):
     """
     DeprecatedHttpRecordSender 是一个过时的类，用于适应多视图版本前的列上传逻辑

--- a/swanlab/sdk/internal/core_python/api/project.py
+++ b/swanlab/sdk/internal/core_python/api/project.py
@@ -36,11 +36,11 @@ def get_or_create_project(*, username: Optional[str], name: str, public: bool) -
         # 已创建：200 ; 创建成功：201 ; 失败：4xx/5xx
         client.post(f"/projects/{username}", data=data)
     except ApiError as e:
-        # 项目已存在同名项目且版本不兼容
-        if e.response.status_code == 409:
+        # 3. 如果新接口不存在，则调用旧接口创建项目
+        if e.response.status_code == 404:
+            get_or_create_old_project(data={**data, "username": username})
+        else:
             raise e
-        # 3. 如果新接口创建失败，则调用旧接口创建项目
-        get_or_create_old_project(data={**data, "username": username})
 
     # 4. 获取项目信息
     return client.get(f"/project/{username}/{name}").data

--- a/swanlab/sdk/internal/core_python/api/project.py
+++ b/swanlab/sdk/internal/core_python/api/project.py
@@ -7,6 +7,7 @@
 
 from typing import Optional
 
+from swanlab.deprecated.project import get_or_create_old_project
 from swanlab.exceptions import ApiError
 from swanlab.sdk.internal.core_python import client
 from swanlab.sdk.typings.core_python.api.project import ProjectType
@@ -35,12 +36,8 @@ def get_or_create_project(*, username: Optional[str], name: str, public: bool) -
         # 已创建：200 ; 创建成功：201 ; 失败：4xx/5xx
         client.post(f"/projects/{username}", data=data, log_error=False)
     except ApiError:
-        try:
-            # 3. 如果新接口失败，尝试调用旧接口创建项目
-            client.post("/project", data=data, log_error=False).data
-        except ApiError as e:
-            if e.response.status_code != 409:
-                raise e
+        # 3. 如果新接口创建失败，则调用旧接口创建项目
+        get_or_create_old_project(data=data)
 
     # 4. 获取项目信息
     return client.get(f"/project/{username}/{name}").data

--- a/swanlab/sdk/internal/core_python/api/project.py
+++ b/swanlab/sdk/internal/core_python/api/project.py
@@ -29,15 +29,18 @@ def get_or_create_project(*, username: Optional[str], name: str, public: bool) -
     # 1. 参数准备
     # username 默认使用当前用户名
     username = username or client.username()
-    data = {"name": name, "visibility": "PUBLIC" if public else "PRIVATE", "username": username}
+    data = {"name": name, "visibility": "PUBLIC" if public else "PRIVATE"}
 
     try:
         # 2. 尝试调用新接口创建项目
         # 已创建：200 ; 创建成功：201 ; 失败：4xx/5xx
-        client.post(f"/projects/{username}", data=data, log_error=False)
-    except ApiError:
+        client.post(f"/projects/{username}", data=data)
+    except ApiError as e:
+        # 项目已存在同名项目且版本不兼容
+        if e.response.status_code == 409:
+            raise e
         # 3. 如果新接口创建失败，则调用旧接口创建项目
-        get_or_create_old_project(data=data)
+        get_or_create_old_project(data={**data, "username": username})
 
     # 4. 获取项目信息
     return client.get(f"/project/{username}/{name}").data

--- a/swanlab/sdk/internal/core_python/api/project.py
+++ b/swanlab/sdk/internal/core_python/api/project.py
@@ -5,40 +5,42 @@
 @description: SwanLab 运行时项目API
 """
 
-from typing import Optional, cast
+from typing import Optional
 
 from swanlab.exceptions import ApiError
 from swanlab.sdk.internal.core_python import client
-from swanlab.sdk.internal.pkg import helper
-from swanlab.sdk.internal.pkg.client.utils import decode_response
-from swanlab.sdk.typings.core_python.api.project import InitProjectType, ProjectType
+from swanlab.sdk.typings.core_python.api.project import ProjectType
 
 
-def get_project(*, username: str, name: str) -> ProjectType:
+def get_or_create_project(*, username: Optional[str], name: str, public: bool) -> ProjectType:
     """
-    获取项目详情信息
-    :param username: 项目所属的用户名
-    :param name: 项目名称
-    :return: 项目信息
-    """
-    return client.get(f"/project/{username}/{name}").data
+    创建、获取项目信息，本函数还有个目标是完成多视图更新前后的兼容，breaking change 主要是在创建项目的接口上
+    多视图前后的创建项目接口发生变化，原本接口不再使用，这里的流程是：
+    1. 创建项目时先调用新接口，如果失败则调用旧接口
+    2. 创建成功或者项目存在时再次调用获取项目信息的接口
 
 
-def get_or_create_project(*, username: Optional[str], name: str, public: bool) -> InitProjectType:
-    """
-    创建项目，如果项目已存在，则获取项目信息
     :param name: 项目名称
     :param username: 项目所属的用户名
     :param public: 项目是否公开
     :return: 项目信息
     """
+    # 1. 参数准备
+    # username 默认使用当前用户名
+    username = username or client.username()
+    data = {"name": name, "visibility": "PUBLIC" if public else "PRIVATE", "username": username}
+
     try:
-        data = {"name": name, "visibility": "PUBLIC" if public else "PRIVATE", "username": username}
-        return client.post("/project", data=helper.strip_none(data, strip_empty_str=True)).data
-    except ApiError as e:
-        if e.response.status_code == 409:
-            # 项目已经存在，从对象中解析信息
-            return cast(InitProjectType, cast(object, decode_response(e.response)))
-        else:
-            # 此接口为后端处理，sdk 在理论上不会出现其他错误，因此不需要处理其他错误
-            raise e
+        # 2. 尝试调用新接口创建项目
+        # 已创建：200 ; 创建成功：201 ; 失败：4xx/5xx
+        client.post(f"/projects/{username}", data=data, log_error=False)
+    except ApiError:
+        try:
+            # 3. 如果新接口失败，尝试调用旧接口创建项目
+            client.post("/project", data=data, log_error=False).data
+        except ApiError as e:
+            if e.response.status_code != 409:
+                raise e
+
+    # 4. 获取项目信息
+    return client.get(f"/project/{username}/{name}").data

--- a/swanlab/sdk/internal/core_python/api/upload.py
+++ b/swanlab/sdk/internal/core_python/api/upload.py
@@ -78,11 +78,11 @@ def upload_config(username: str, project: str, experiment_id: str, *, content: D
     client.put(f"/project/{username}/{project}/runs/{experiment_id}/profile", {"config": content})
 
 
-def upload_columns(experiment_id: str, *, columns: UploadColumns) -> None:
+def upload_columns(username: str, project: str, *, columns: UploadColumns) -> None:
     """
     上传列信息
     """
-    client.post(f"/experiment/{experiment_id}/columns", columns, retries=0)
+    client.post(f"/projects/{username}/{project}/series", columns, retries=0)
 
 
 def upload_log(project_id: str, experiment_id: str, *, metrics: UploadLogBatch) -> None:

--- a/swanlab/sdk/internal/core_python/client/__init__.py
+++ b/swanlab/sdk/internal/core_python/client/__init__.py
@@ -69,3 +69,7 @@ def patch(url: str, data: JSONBody = None, retries: Optional[int] = None, log_er
 
 def delete(url: str, retries: Optional[int] = None, log_error: bool = True):
     return _get_client().delete(url, retries=retries, log_error=log_error)
+
+
+def username() -> str:
+    return _get_client().username

--- a/swanlab/sdk/internal/core_python/client/__init__.py
+++ b/swanlab/sdk/internal/core_python/client/__init__.py
@@ -51,21 +51,21 @@ def _get_client() -> client.Client:
     return _default_client
 
 
-def get(url: str, params: Optional[JSONDict] = None, retries: Optional[int] = None):
-    return _get_client().get(url, params=params, retries=retries)
+def get(url: str, params: Optional[JSONDict] = None, retries: Optional[int] = None, log_error: bool = True):
+    return _get_client().get(url, params=params, retries=retries, log_error=log_error)
 
 
-def post(url: str, data: JSONBody = None, retries: Optional[int] = None):
-    return _get_client().post(url, data=data, retries=retries)
+def post(url: str, data: JSONBody = None, retries: Optional[int] = None, log_error: bool = True):
+    return _get_client().post(url, data=data, retries=retries, log_error=log_error)
 
 
-def put(url: str, data: JSONBody = None, retries: Optional[int] = None):
-    return _get_client().put(url, data=data, retries=retries)
+def put(url: str, data: JSONBody = None, retries: Optional[int] = None, log_error: bool = True):
+    return _get_client().put(url, data=data, retries=retries, log_error=log_error)
 
 
-def patch(url: str, data: JSONBody = None, retries: Optional[int] = None):
-    return _get_client().patch(url, data=data, retries=retries)
+def patch(url: str, data: JSONBody = None, retries: Optional[int] = None, log_error: bool = True):
+    return _get_client().patch(url, data=data, retries=retries, log_error=log_error)
 
 
-def delete(url: str, retries: Optional[int] = None):
-    return _get_client().delete(url, retries=retries)
+def delete(url: str, retries: Optional[int] = None, log_error: bool = True):
+    return _get_client().delete(url, retries=retries, log_error=log_error)

--- a/swanlab/sdk/internal/core_python/context/__init__.py
+++ b/swanlab/sdk/internal/core_python/context/__init__.py
@@ -37,6 +37,7 @@ class CoreContext:
         self._username: Optional[str] = None
         self._project: Optional[str] = None
         self._project_id: Optional[str] = None
+        self._project_version: Optional[Literal[1]] = None
         self._experiment_id: Optional[str] = None
 
     @classmethod
@@ -54,7 +55,14 @@ class CoreContext:
         )
         return cls(config=config, mode=mode)
 
-    def set_online_params(self, username: str, project: str, project_id: str, experiment_id: str):
+    def set_online_params(
+        self,
+        username: str,
+        project: str,
+        project_id: str,
+        project_version: Optional[Literal[1]],
+        experiment_id: str,
+    ):
         """
         设置云端信息
         :param username: 用户名
@@ -65,6 +73,7 @@ class CoreContext:
         self._username = username
         self._project = project
         self._project_id = project_id
+        self._project_version = project_version
         self._experiment_id = experiment_id
 
     @cached_property

--- a/swanlab/sdk/internal/core_python/core.py
+++ b/swanlab/sdk/internal/core_python/core.py
@@ -153,7 +153,8 @@ class CorePython(CoreProtocol):
         self._ctx.set_online_params(
             username=run_info.username,
             project=run_info.project,
-            project_id=run_info.project_info["cuid"],
+            project_id=run_info.project_data["cuid"],
+            project_version=run_info.project_data.get("version", None),
             experiment_id=run_info.experiment["cuid"],
         )
         # 3. resume 时，向后端获取数据

--- a/swanlab/sdk/internal/core_python/sync.py
+++ b/swanlab/sdk/internal/core_python/sync.py
@@ -123,7 +123,8 @@ class CoreSyncPython(CoreSyncProtocol):
             self._ctx.set_online_params(
                 username=result.username,
                 project=result.project,
-                project_id=result.project_info["cuid"],
+                project_id=result.project_data["cuid"],
+                project_version=result.project_data.get("version", None),
                 experiment_id=result.experiment["cuid"],
             )
 

--- a/swanlab/sdk/internal/core_python/transport/deprecated/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/deprecated/sender.py
@@ -1,0 +1,75 @@
+from typing import Literal, Optional, Sequence, cast
+
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord, ColumnType
+from swanlab.proto.swanlab.record.v1.record_pb2 import Record
+from swanlab.sdk.internal.core_python import client
+from swanlab.sdk.internal.core_python.transport.sender import HttpRecordSender
+from swanlab.sdk.internal.pkg import adapter
+from swanlab.sdk.typings.core_python.api.upload import DeprecatedUploadColumn, DeprecatedUploadColumns
+
+
+class DeprecatedHttpRecordSender(HttpRecordSender):
+    """
+    DeprecatedHttpRecordSender 是一个过时的类，用于适应多视图版本前的列上传逻辑
+    """
+
+    def upload_column(self, records: Sequence[Record], batch_size: int = 3000) -> None:
+        columns = []
+        for record in records:
+            r = encode_desprecated_column(record.column)
+            if r:
+                columns.append(r)
+        if not columns:
+            return
+        for i in range(0, len(columns), batch_size):
+            upload_deprecated_columns(self._experiment_id, columns=columns[i : i + batch_size])
+
+
+def upload_deprecated_columns(experiment_id: str, *, columns: DeprecatedUploadColumns) -> None:
+    """
+    上传列信息
+    """
+    client.post(f"/experiment/{experiment_id}/columns", columns, retries=0)
+
+
+def encode_desprecated_column(record: ColumnRecord) -> Optional[DeprecatedUploadColumn]:
+    """
+    将列记录编码为后端所需的格式（DTO）
+    NOTE: 此接口为多视图之前的版本
+    """
+    column: DeprecatedUploadColumn = {"key": record.column_key, "type": adapter.column[record.column_type]}  # noqa: F821
+    # class: 是否为系统列
+    if record.column_class == ColumnClass.COLUMN_CLASS_SYSTEM:
+        column["class"] = cast(Literal["SYSTEM"], "SYSTEM")
+    # name: 列的展示名称
+    if record.column_name:
+        column["name"] = record.column_name
+    # section name: section 名称
+    if record.section_name:
+        column["sectionName"] = record.section_name
+    # section type: section 类型，目前仅处理系统列
+    if record.column_class == ColumnClass.COLUMN_CLASS_SYSTEM:
+        column["sectionType"] = cast(Literal["SYSTEM"], "SYSTEM")
+    # yRange: 数值列的 y 轴范围
+    if record.column_type == ColumnType.COLUMN_TYPE_SCALAR:
+        if record.HasField("y_range"):
+            y_range = record.y_range
+            min_value = y_range.min if y_range.HasField("min") else None
+            max_value = y_range.max if y_range.HasField("max") else None
+            column["yRange"] = (min_value, max_value)
+    # chartName: 图表名称
+    if record.chart_name:
+        column["chartName"] = record.chart_name
+    # chartIndex: 图表索引
+    if record.chart_index:
+        column["chartIndex"] = record.chart_index
+    # metricName: 指标名称
+    if record.metric_name:
+        column["metricName"] = record.metric_name
+    # metricColors: 指标颜色
+    if record.HasField("metric_colors"):
+        column["metricColors"] = (record.metric_colors.light, record.metric_colors.dark)
+    return column
+
+
+__all__ = ["DeprecatedHttpRecordSender"]

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -18,7 +18,7 @@ from typing import IO, TYPE_CHECKING, Literal, Optional, Union, cast
 import yaml
 
 from swanlab.exceptions import ApiError
-from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord, ColumnType
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnClass, ColumnRecord
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.proto.swanlab.save.v1.save_pb2 import SaveType
 from swanlab.sdk.internal.core_python.api.save import (
@@ -156,7 +156,8 @@ class HttpRecordSender:
         if not columns:
             return
         for i in range(0, len(columns), batch_size):
-            upload_columns(self._experiment_id, columns=columns[i : i + batch_size])
+            columns = columns[i : i + batch_size]
+            upload_columns(self._username, self._project, columns={"series": columns})
 
     def upload_scalar(self, records: Sequence[Record]) -> None:
         metrics: UploadScalarBatch = []
@@ -524,38 +525,12 @@ def encode_column(record: ColumnRecord) -> Optional[UploadColumn]:
     """
     将列记录编码为后端所需的格式（DTO）
     """
+    # TODO 未来精简一下 column 的类型定义
     column: UploadColumn = {"key": record.column_key, "type": adapter.column[record.column_type]}
-    # class: 是否为系统列
     if record.column_class == ColumnClass.COLUMN_CLASS_SYSTEM:
-        column["class"] = cast(Literal["SYSTEM"], "SYSTEM")
-    # name: 列的展示名称
-    if record.column_name:
-        column["name"] = record.column_name
-    # section name: section 名称
+        column["type"] = "SYSTEM"
     if record.section_name:
         column["sectionName"] = record.section_name
-    # section type: section 类型，目前仅处理系统列
-    if record.column_class == ColumnClass.COLUMN_CLASS_SYSTEM:
-        column["sectionType"] = cast(Literal["SYSTEM"], "SYSTEM")
-    # yRange: 数值列的 y 轴范围
-    if record.column_type == ColumnType.COLUMN_TYPE_SCALAR:
-        if record.HasField("y_range"):
-            y_range = record.y_range
-            min_value = y_range.min if y_range.HasField("min") else None
-            max_value = y_range.max if y_range.HasField("max") else None
-            column["yRange"] = (min_value, max_value)
-    # chartName: 图表名称
-    if record.chart_name:
-        column["chartName"] = record.chart_name
-    # chartIndex: 图表索引
-    if record.chart_index:
-        column["chartIndex"] = record.chart_index
-    # metricName: 指标名称
-    if record.metric_name:
-        column["metricName"] = record.metric_name
-    # metricColors: 指标颜色
-    if record.HasField("metric_colors"):
-        column["metricColors"] = (record.metric_colors.light, record.metric_colors.dark)
     return column
 
 

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -525,7 +525,7 @@ def encode_column(record: ColumnRecord) -> Optional[UploadColumn]:
     """
     将列记录编码为后端所需的格式（DTO）
     """
-    # TODO 未来精简一下 column 的类型定义
+    # TODO 在 v0.10.0 版本 精简一下 column 的类型定义
     column: UploadColumn = {"key": record.column_key, "type": adapter.column[record.column_type]}
     if record.column_class == ColumnClass.COLUMN_CLASS_SYSTEM:
         column["type"] = "SYSTEM"

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -156,8 +156,8 @@ class HttpRecordSender:
         if not columns:
             return
         for i in range(0, len(columns), batch_size):
-            columns = columns[i : i + batch_size]
-            upload_columns(self._username, self._project, columns={"series": columns})
+            batch = columns[i : i + batch_size]
+            upload_columns(self._username, self._project, columns={"series": batch})
 
     def upload_scalar(self, records: Sequence[Record]) -> None:
         metrics: UploadScalarBatch = []

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 from swanlab.proto.swanlab.operation.v1.operation_pb2 import CoreState
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.sdk.internal.core_python.context import CoreContext
+from swanlab.sdk.internal.core_python.transport.deprecated.sender import DeprecatedHttpRecordSender
 from swanlab.sdk.internal.pkg import console, safe
 
 from .buffer import RecordBuffer
@@ -63,7 +64,17 @@ class Transport:
         """启动守护线程。"""
         if self._started or self._finished:
             return
-        sender = self._sender or HttpRecordSender(ctx=self._ctx)
+
+        # 初始化sender，根据不同的项目版本选择不同的请求器，以兼容历史版本
+        # NOTE: 相关兼容逻辑将在v0.10.0版本后移除
+        sender = self._sender
+        if sender is None:
+            sender = (
+                HttpRecordSender(ctx=self._ctx)
+                if self._ctx._project_version == 1
+                else DeprecatedHttpRecordSender(ctx=self._ctx)
+            )
+
         if self._tracker is not None:
             sender.set_tracker(self._tracker)
         self._dispatcher = Dispatch(

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -9,10 +9,10 @@ import threading
 import time
 from typing import List, Optional
 
+from swanlab.deprecated.sender import DeprecatedHttpRecordSender
 from swanlab.proto.swanlab.operation.v1.operation_pb2 import CoreState
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.sdk.internal.core_python.context import CoreContext
-from swanlab.sdk.internal.core_python.transport.deprecated.sender import DeprecatedHttpRecordSender
 from swanlab.sdk.internal.pkg import console, safe
 
 from .buffer import RecordBuffer

--- a/swanlab/sdk/internal/core_python/utils.py
+++ b/swanlab/sdk/internal/core_python/utils.py
@@ -14,7 +14,7 @@ from swanlab.proto.swanlab.run.v1.run_pb2 import StartRecord
 from swanlab.sdk.internal.core_python.api.experiment import (
     create_or_resume_experiment as api_create_or_resume_experiment,
 )
-from swanlab.sdk.internal.core_python.api.project import get_or_create_project, get_project
+from swanlab.sdk.internal.core_python.api.project import get_or_create_project
 from swanlab.sdk.internal.pkg import adapter
 from swanlab.sdk.typings.core_python.api.experiment import InitExperimentType
 from swanlab.sdk.typings.core_python.api.project import ProjectType
@@ -25,7 +25,7 @@ from swanlab.utils.experiment import generate_color, generate_name
 class PrepareExperimentStartResult:
     username: str
     project: str
-    project_info: ProjectType
+    project_data: ProjectType
     experiment: InitExperimentType
     new_experiment: bool
     name: str
@@ -42,9 +42,7 @@ def prepare_experiment_start(record: StartRecord) -> PrepareExperimentStartResul
         public=record.public,
     )
     username, project = project_data["username"], project_data["name"]
-
-    project_info = get_project(username=username, name=project)
-    history_experiment_count = project_info["_count"]["experiments"]
+    history_experiment_count = project_data["_count"]["experiments"]
     name = record.name or generate_name(history_experiment_count)
     color = record.color or generate_color(history_experiment_count)
     resume = adapter.resume[record.resume]
@@ -67,7 +65,7 @@ def prepare_experiment_start(record: StartRecord) -> PrepareExperimentStartResul
     return PrepareExperimentStartResult(
         username=username,
         project=project,
-        project_info=project_info,
+        project_data=project_data,
         experiment=experiment,
         new_experiment=new_experiment,
         name=name,
@@ -79,7 +77,7 @@ def generate_run_online_path(result: PrepareExperimentStartResult):
     # 获取path，/:username/:project_name/:run_id
     run_id = result.experiment.get("slug", "") or result.experiment["cuid"]
     # /:username/:project_name
-    project_path = result.project_info["path"]
+    project_path = result.project_data["path"]
     return f"{project_path}/{run_id}"
 
 

--- a/swanlab/sdk/internal/core_python/utils.py
+++ b/swanlab/sdk/internal/core_python/utils.py
@@ -41,7 +41,7 @@ def prepare_experiment_start(record: StartRecord) -> PrepareExperimentStartResul
         name=record.project,
         public=record.public,
     )
-    username, project = project_data["username"], project_data["name"]
+    username, project = project_data["group"]["username"], project_data["name"]
     history_experiment_count = project_data["_count"]["experiments"]
     name = record.name or generate_name(history_experiment_count)
     color = record.color or generate_color(history_experiment_count)

--- a/swanlab/sdk/internal/pkg/client/__init__.py
+++ b/swanlab/sdk/internal/pkg/client/__init__.py
@@ -96,17 +96,17 @@ class Client:
         resp = self._session.request(method, full_url, **kwargs)
         return ApiResponse(data=decode_response(resp), raw=resp)
 
-    def get(self, url: str, params: Optional[JSONDict] = None, retries: Optional[int] = None):
-        return self.request("GET", url, params=params, retries=retries)
+    def get(self, url: str, params: Optional[JSONDict] = None, retries: Optional[int] = None, log_error: bool = True):
+        return self.request("GET", url, params=params, retries=retries, log_error=log_error)
 
-    def post(self, url: str, data: JSONBody = None, retries: Optional[int] = None):
-        return self.request("POST", url, json=data, retries=retries)
+    def post(self, url: str, data: JSONBody = None, retries: Optional[int] = None, log_error: bool = True):
+        return self.request("POST", url, json=data, retries=retries, log_error=log_error)
 
-    def put(self, url: str, data: JSONBody = None, retries: Optional[int] = None):
-        return self.request("PUT", url, json=data, retries=retries)
+    def put(self, url: str, data: JSONBody = None, retries: Optional[int] = None, log_error: bool = True):
+        return self.request("PUT", url, json=data, retries=retries, log_error=log_error)
 
-    def patch(self, url: str, data: JSONBody = None, retries: Optional[int] = None):
-        return self.request("PATCH", url, json=data, retries=retries)
+    def patch(self, url: str, data: JSONBody = None, retries: Optional[int] = None, log_error: bool = True):
+        return self.request("PATCH", url, json=data, retries=retries, log_error=log_error)
 
-    def delete(self, url: str, retries: Optional[int] = None):
-        return self.request("DELETE", url, retries=retries)
+    def delete(self, url: str, retries: Optional[int] = None, log_error: bool = True):
+        return self.request("DELETE", url, retries=retries, log_error=log_error)

--- a/swanlab/sdk/internal/pkg/client/__init__.py
+++ b/swanlab/sdk/internal/pkg/client/__init__.py
@@ -44,6 +44,7 @@ class Client:
         # 移除末尾的斜杠，防止 URL 拼接时出现双斜杠
         self._base_url = nrc.fmt(base_url) + "/api"
         self._expired_at: Optional[datetime] = None
+        self._username: Optional[str] = None
 
         # 初始化时仅创建一次会话，以复用底层 TCP 连接池
         self._session: session.SessionWithRetry = session.create()
@@ -75,6 +76,7 @@ class Client:
         self._expired_at = datetime.strptime(login_resp["expiredAt"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
             tzinfo=timezone.utc
         )
+        self._username = login_resp["userInfo"]["username"]
         return login_resp
 
     def _before_request(self):
@@ -86,6 +88,11 @@ class Client:
             console.debug("Session is about to expire. Triggering token refresh.")
             self._refresh_auth()
         return None
+
+    @property
+    def username(self) -> str:
+        assert self._username is not None, "Username is not set. Ensure that the client is authenticated."
+        return self._username
 
     # ---------------------------------- 实例 HTTP 方法 ----------------------------------
     def request(self, method: str, url: str, **kwargs):

--- a/swanlab/sdk/internal/pkg/client/session.py
+++ b/swanlab/sdk/internal/pkg/client/session.py
@@ -25,6 +25,7 @@ VERSION_HEADER = "X-SwanLab-SDK-Version"
 TRACE_ID = "swanlab.client"
 # 用于存储当前请求的重试次数，避免在请求中传递 retries 参数
 request_retries_ctx: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar("request_retries", default=None)
+request_log_error_ctx: contextvars.ContextVar[bool] = contextvars.ContextVar("request_log_error", default=True)
 
 
 class WarningRetry(Retry):
@@ -78,23 +79,22 @@ class TimeoutHTTPAdapter(HTTPAdapter):
 
 class SessionWithRetry(Session):
     """
-    支持在请求级别自定义重试次数的 Session。
-    通过拦截 retries 参数并将其转化为隐式 Header 传递给 Adapter。
+    支持在请求级别自定义重试次数和错误日志开关的 Session。
     """
 
     def request(self, method, url, *args, **kwargs):
         retries = kwargs.pop("retries", None)
+        log_error = kwargs.pop("log_error", True)
 
-        if retries is not None:
-            # 3. 将自定义参数放入上下文，并获取 token 以便后续清理
-            token = request_retries_ctx.set(retries)
-            try:
-                return super().request(method, url, *args, **kwargs)
-            finally:
-                # 4. 请求结束后，务必清理上下文，避免影响复用该线程的其他请求
-                request_retries_ctx.reset(token)
-        else:
+        retries_token = request_retries_ctx.set(retries) if retries is not None else None
+        log_error_token = request_log_error_ctx.set(log_error)
+        try:
             return super().request(method, url, *args, **kwargs)
+        finally:
+            # 请求结束后清理上下文，避免影响复用该线程的其他请求。
+            request_log_error_ctx.reset(log_error_token)
+            if retries_token is not None:
+                request_retries_ctx.reset(retries_token)
 
     def send(self, request, **kwargs):
         """
@@ -127,9 +127,7 @@ class SessionWithRetry(Session):
             error_code, error_message = decoded
 
         # 4. 记录错误日志
-        # 对于 POST /api/project 接口不记录错误日志，因为是预期行为
-        # FIXME 等待后端新增专用接口后删除此特殊处理
-        if not (method == "POST" and request.url.endswith("/api/project")):
+        if request_log_error_ctx.get():
             console.error(
                 f"[HTTP] {method} {request.url} -> {response.status_code} ({elapsed_ms:.0f}ms) trace:{trace_id}"
                 f" | [ERR] code={error_code} message={error_message}"

--- a/swanlab/sdk/typings/core_python/api/project.py
+++ b/swanlab/sdk/typings/core_python/api/project.py
@@ -21,6 +21,10 @@ class _ProjectCount(TypedDict):
     clones: int
 
 
+class _ProjectGroup(TypedDict):
+    username: str
+
+
 class ProjectType(TypedDict):
     # 项目ID
     cuid: str
@@ -28,11 +32,11 @@ class ProjectType(TypedDict):
     name: str
     # 项目版本，如果不存在此字段则按照最低版本处理
     version: NotRequired[Literal[1]]
-    # 项目所属的用户名
-    username: str
     # 项目路径 '/:username/:name'
     path: str
     # 项目可见性
     visibility: Literal["PUBLIC", "PRIVATE"]
+    # 项目所属空间
+    group: _ProjectGroup
     # 项目统计信息
     _count: _ProjectCount

--- a/swanlab/sdk/typings/core_python/api/project.py
+++ b/swanlab/sdk/typings/core_python/api/project.py
@@ -7,6 +7,8 @@
 
 from typing import Literal, TypedDict
 
+from typing_extensions import NotRequired
+
 
 class _ProjectCount(TypedDict):
     # 项目历史实验数量
@@ -24,6 +26,8 @@ class ProjectType(TypedDict):
     cuid: str
     # 项目名称
     name: str
+    # 项目版本，如果不存在此字段则按照最低版本处理
+    version: NotRequired[Literal[1]]
     # 项目所属的用户名
     username: str
     # 项目路径 '/:username/:name'
@@ -32,12 +36,3 @@ class ProjectType(TypedDict):
     visibility: Literal["PUBLIC", "PRIVATE"]
     # 项目统计信息
     _count: _ProjectCount
-
-
-class InitProjectType(TypedDict):
-    # 项目名称
-    name: str
-    # 项目所属的用户名
-    username: str
-    # 项目路径 '/:username/:name'
-    path: str

--- a/swanlab/sdk/typings/core_python/api/upload.py
+++ b/swanlab/sdk/typings/core_python/api/upload.py
@@ -18,8 +18,8 @@ else:
 # ============================================================
 
 
-UploadColumn = TypedDict(
-    "UploadColumn",
+DeprecatedUploadColumn = TypedDict(
+    "DeprecatedUploadColumn",
     {
         # ---- 必填 ----
         "type": Required[str],
@@ -39,10 +39,25 @@ UploadColumn = TypedDict(
 )
 
 
-UploadColumns = List[UploadColumn]
+DeprecatedUploadColumns = List[DeprecatedUploadColumn]
 """
-列指标
+列指标，多视图之前的版本
 """
+
+UploadColumn = TypedDict(
+    "UploadColumn",
+    {
+        "key": Required[str],
+        "type": Required[str],
+        "sectionName": NotRequired[str],
+    },
+)
+
+
+class UploadColumns(TypedDict):
+    """列指标 DTO，多视图之后的版本"""
+
+    series: List[UploadColumn]
 
 
 # ============================================================

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -23,6 +23,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 import responses as responses_lib
 import yaml
 
@@ -57,11 +58,16 @@ API_KEY = "test-api-key"
 
 def make_login_resp(**overrides) -> dict:
     """POST /api/login/api_key 响应体"""
-    return {"sid": "mock-sid", "expiredAt": "2099-12-31T23:59:59.000Z", **overrides}
+    return {
+        "sid": "mock-sid",
+        "expiredAt": "2099-12-31T23:59:59.000Z",
+        "userInfo": {"username": USERNAME, "name": "Test User"},
+        **overrides,
+    }
 
 
 def make_init_project_resp(**overrides) -> dict:
-    """POST /api/project 响应体（创建/获取项目）"""
+    """POST /api/projects/{username} 响应体（创建/获取项目）"""
     return {
         "name": PROJECT,
         "username": USERNAME,
@@ -75,6 +81,7 @@ def make_project_detail_resp(experiment_count: int = 0, **overrides) -> dict:
     return {
         "cuid": "test-project-cuid",
         "name": PROJECT,
+        "version": 1,
         "username": USERNAME,
         "path": f"/{USERNAME}/{PROJECT}",
         "visibility": "PRIVATE",
@@ -104,7 +111,7 @@ def make_profile_resp(**overrides) -> dict:
 
 
 def make_columns_resp(**overrides) -> dict:
-    """POST /api/experiment/{experiment_id}/columns 响应体"""
+    """列信息上传响应体"""
     return {"message": "ok", **overrides}
 
 
@@ -162,8 +169,8 @@ def mock_login_api(rsps):
 
 @pytest.fixture
 def mock_project_create_api(rsps):
-    """注册 POST /api/project 端点（创建或获取项目）"""
-    rsps.add(responses_lib.POST, f"{API_HOST}/api/project", json=make_init_project_resp(), status=201)
+    """注册 POST /api/projects/{username} 端点（创建或获取项目）"""
+    rsps.add(responses_lib.POST, f"{API_HOST}/api/projects/{USERNAME}", json=make_init_project_resp(), status=201)
     return rsps
 
 
@@ -214,7 +221,13 @@ def mock_profile_api(rsps):
 
 @pytest.fixture
 def mock_columns_api(rsps):
-    """注册 POST /api/experiment/{experiment_id}/columns 端点（列信息上传）"""
+    """注册新版和 legacy 端点（列信息上传）"""
+    rsps.add(
+        responses_lib.POST,
+        f"{API_HOST}/api/projects/{USERNAME}/{PROJECT}/series",
+        json=make_columns_resp(),
+        status=200,
+    )
     rsps.add(
         responses_lib.POST,
         f"{API_HOST}/api/experiment/{EXPERIMENT_CUID}/columns",
@@ -300,6 +313,15 @@ def mock_online_init_apis(
     所有子 fixture 通过 pytest 的 fixture 缓存机制共享同一个 rsps 实例。
     """
     pass
+
+
+def test_mock_columns_api_registers_new_and_legacy_endpoints(mock_columns_api):
+    """列上传 mock 同时覆盖新版项目和 legacy 项目的 sender。"""
+    new_resp = requests.post(f"{API_HOST}/api/projects/{USERNAME}/{PROJECT}/series", json={})
+    legacy_resp = requests.post(f"{API_HOST}/api/experiment/{EXPERIMENT_CUID}/columns", json={})
+
+    assert new_resp.status_code == 200
+    assert legacy_resp.status_code == 200
 
 
 @pytest.fixture
@@ -640,7 +662,8 @@ class TestInitOnlineMode:
         mock_profile_api,
         mock_heartbeat_api,
     ):
-        """POST /project 返回 409（项目已存在）时，应优雅降级为获取项目，继续初始化"""
+        """新版创建接口不可用且旧接口返回 409（项目已存在）时，应继续初始化"""
+        rsps.add(responses_lib.POST, f"{API_HOST}/api/projects/{USERNAME}", json={"message": "not found"}, status=404)
         rsps.add(responses_lib.POST, f"{API_HOST}/api/project", json=make_init_project_resp(), status=409)
 
         run = init(mode="online", project=PROJECT)

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -19,6 +19,7 @@
 import errno
 import json
 import multiprocessing
+import sys
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -919,6 +920,17 @@ class TestForkDetection:
         assert fork.current_pid() == run._init_pid
         assert has_run()
 
+    # 参考: https://docs.python.org/3.9/library/multiprocessing.html#contexts-and-start-methods
+    # macOS 多进程不支持 fork
+    @pytest.mark.skipif(
+        sys.platform == "darwin" and sys.version_info < (3, 10),
+        reason=(
+            "CPython < 3.10 on macOS segfaults on Path.cwd()/os.getcwd() after fork in a "
+            "multithreaded process (corrupted malloc arena); fixed in CPython 3.10. "
+            "This is a CPython runtime bug, not a SwanLab bug — fork-safety of the Run "
+            "singleton is covered on other platforms."
+        ),
+    )
     def test_can_init_new_run_in_child_after_fork(self):
         """真实 fork 后，子进程中可以重新 init 创建新 Run"""
         init(mode="disabled")

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -82,6 +82,7 @@ def make_project_detail_resp(experiment_count: int = 0, **overrides) -> dict:
         "cuid": "test-project-cuid",
         "name": PROJECT,
         "version": 1,
+        "group": {"username": USERNAME},
         "username": USERNAME,
         "path": f"/{USERNAME}/{PROJECT}",
         "visibility": "PRIVATE",

--- a/tests/unit/sdk/cmd/login/test_login_e2e.py
+++ b/tests/unit/sdk/cmd/login/test_login_e2e.py
@@ -15,6 +15,15 @@ from swanlab.sdk.internal.pkg import nrc
 from swanlab.sdk.internal.settings import Settings, settings
 
 
+def make_login_resp(**overrides) -> dict:
+    return {
+        "sid": "mock_sid",
+        "expiredAt": "2099-12-31T23:59:59.000Z",
+        "userInfo": {"username": "mock_user", "name": "Mock User"},
+        **overrides,
+    }
+
+
 class TestLoginE2E:
     @staticmethod
     def _reinit_settings():
@@ -42,7 +51,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{expected_clean_host}/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -62,7 +71,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{expected_api_host}/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -81,7 +90,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://api.swanlab.cn/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
         login(api_key="first-key")
@@ -113,7 +122,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://api.swanlab.cn/api/login/api_key",
-            json={"sid": "mock_sid", "user": "mock_user", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(user="mock_user"),
             status=200,
         )
 
@@ -133,7 +142,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://fake.swanlab.cn/api/login/api_key",
-            json={"sid": "mock_sid", "user": "mock_user", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(user="mock_user"),
             status=200,
         )
 
@@ -159,13 +168,13 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://api.swanlab.cn/api/login/api_key",
-            json={"sid": "initial_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(sid="initial_sid"),
             status=200,
         )
         responses.add(
             responses.POST,
             f"{custom_host}/api/login/api_key",
-            json={"sid": "mock_private_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(sid="mock_private_sid"),
             status=200,
         )
 
@@ -204,7 +213,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{old_host}/api/login/api_key",
-            json={"sid": "mock_old_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(sid="mock_old_sid"),
             status=200,
         )
 
@@ -226,13 +235,13 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{host_a}/api/login/api_key",
-            json={"sid": "sid_a", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(sid="sid_a"),
             status=200,
         )
         responses.add(
             responses.POST,
             f"{host_b}/api/login/api_key",
-            json={"sid": "sid_b", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(sid="sid_b"),
             status=200,
         )
 
@@ -269,7 +278,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{new_host}/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -298,7 +307,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{stored_host}/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -352,7 +361,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             f"{new_host}/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -381,7 +390,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://api.swanlab.cn/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -400,7 +409,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://api.swanlab.cn/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 
@@ -420,7 +429,7 @@ class TestLoginE2E:
         responses.add(
             responses.POST,
             "https://api.swanlab.cn/api/login/api_key",
-            json={"sid": "mock_sid", "expiredAt": "2099-12-31T23:59:59.000Z"},
+            json=make_login_resp(),
             status=200,
         )
 

--- a/tests/unit/sdk/cmd/sync/test_sync_e2e.py
+++ b/tests/unit/sdk/cmd/sync/test_sync_e2e.py
@@ -61,10 +61,10 @@ def make_prepare_result(new_experiment: bool = True) -> PrepareExperimentStartRe
     return PrepareExperimentStartResult(
         username="alice",
         project="demo",
-        project_info={
+        project_data={
             "cuid": "project-id",
             "name": "demo",
-            "username": "alice",
+            "group": {"username": "alice"},
             "path": "/alice/demo",
             "visibility": "PRIVATE",
             "_count": {"experiments": 0, "contributors": 0, "collaborators": 0, "clones": 0},

--- a/tests/unit/sdk/internal/core_python/api/test_project.py
+++ b/tests/unit/sdk/internal/core_python/api/test_project.py
@@ -50,8 +50,7 @@ def test_get_or_create_project_defaults_to_current_username(monkeypatch):
     username.assert_called_once_with()
     post.assert_called_once_with(
         "/projects/alice",
-        data={"name": "demo", "visibility": "PRIVATE", "username": "alice"},
-        log_error=False,
+        data={"name": "demo", "visibility": "PRIVATE"},
     )
     get.assert_called_once_with("/project/alice/demo")
 
@@ -70,8 +69,7 @@ def test_get_or_create_project_uses_explicit_username_without_current_username(m
     username.assert_not_called()
     post.assert_called_once_with(
         "/projects/team",
-        data={"name": "demo", "visibility": "PUBLIC", "username": "team"},
-        log_error=False,
+        data={"name": "demo", "visibility": "PUBLIC"},
     )
     get.assert_called_once_with("/project/team/demo")
 
@@ -89,8 +87,7 @@ def test_get_or_create_project_falls_back_to_old_helper_when_new_endpoint_fails(
     assert result == _project_data(username="team", name="demo")
     post.assert_called_once_with(
         "/projects/team",
-        data={"name": "demo", "visibility": "PRIVATE", "username": "team"},
-        log_error=False,
+        data={"name": "demo", "visibility": "PRIVATE"},
     )
     get_or_create_old_project.assert_called_once_with(
         data={"name": "demo", "visibility": "PRIVATE", "username": "team"}
@@ -98,7 +95,7 @@ def test_get_or_create_project_falls_back_to_old_helper_when_new_endpoint_fails(
     get.assert_called_once_with("/project/team/demo")
 
 
-def test_get_or_create_project_currently_falls_back_for_any_new_endpoint_api_error(monkeypatch):
+def test_get_or_create_project_raises_non_not_found_new_endpoint_api_error(monkeypatch):
     post = MagicMock(side_effect=_api_error(500))
     get_or_create_old_project = MagicMock()
     get = MagicMock(return_value=SimpleNamespace(data=_project_data(username="team", name="demo")))
@@ -106,11 +103,11 @@ def test_get_or_create_project_currently_falls_back_for_any_new_endpoint_api_err
     monkeypatch.setattr(project_api, "get_or_create_old_project", get_or_create_old_project)
     monkeypatch.setattr(project_api.client, "get", get)
 
-    project_api.get_or_create_project(username="team", name="demo", public=False)
+    with pytest.raises(ApiError):
+        project_api.get_or_create_project(username="team", name="demo", public=False)
 
-    get_or_create_old_project.assert_called_once_with(
-        data={"name": "demo", "visibility": "PRIVATE", "username": "team"}
-    )
+    get_or_create_old_project.assert_not_called()
+    get.assert_not_called()
 
 
 def test_get_or_create_old_project_ignores_conflict(monkeypatch):

--- a/tests/unit/sdk/internal/core_python/api/test_project.py
+++ b/tests/unit/sdk/internal/core_python/api/test_project.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from swanlab.deprecated import project as deprecated_project_api
+from swanlab.exceptions import ApiError
+from swanlab.sdk.internal.core_python.api import project as project_api
+
+
+class _FakeApiErrorResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        self.request = MagicMock()
+        self.url = "https://api.test/project"
+
+
+def _api_error(status_code: int) -> ApiError:
+    return ApiError(
+        _FakeApiErrorResponse(status_code),
+        method="POST",
+        trace_id="trace-id",
+        code="api-error",
+        message="api error",
+    )
+
+
+def _project_data(username: str = "alice", name: str = "demo") -> dict:
+    return {
+        "cuid": "project-id",
+        "name": name,
+        "username": username,
+        "path": f"/{username}/{name}",
+        "visibility": "PRIVATE",
+        "_count": {"experiments": 3, "contributors": 0, "collaborators": 0, "clones": 0},
+    }
+
+
+def test_get_or_create_project_defaults_to_current_username(monkeypatch):
+    post = MagicMock()
+    get = MagicMock(return_value=SimpleNamespace(data=_project_data()))
+    username = MagicMock(return_value="alice")
+    monkeypatch.setattr(project_api.client, "post", post)
+    monkeypatch.setattr(project_api.client, "get", get)
+    monkeypatch.setattr(project_api.client, "username", username)
+
+    result = project_api.get_or_create_project(username=None, name="demo", public=False)
+
+    assert result == _project_data()
+    username.assert_called_once_with()
+    post.assert_called_once_with(
+        "/projects/alice",
+        data={"name": "demo", "visibility": "PRIVATE", "username": "alice"},
+        log_error=False,
+    )
+    get.assert_called_once_with("/project/alice/demo")
+
+
+def test_get_or_create_project_uses_explicit_username_without_current_username(monkeypatch):
+    post = MagicMock()
+    get = MagicMock(return_value=SimpleNamespace(data=_project_data(username="team", name="demo")))
+    username = MagicMock(return_value="alice")
+    monkeypatch.setattr(project_api.client, "post", post)
+    monkeypatch.setattr(project_api.client, "get", get)
+    monkeypatch.setattr(project_api.client, "username", username)
+
+    result = project_api.get_or_create_project(username="team", name="demo", public=True)
+
+    assert result == _project_data(username="team", name="demo")
+    username.assert_not_called()
+    post.assert_called_once_with(
+        "/projects/team",
+        data={"name": "demo", "visibility": "PUBLIC", "username": "team"},
+        log_error=False,
+    )
+    get.assert_called_once_with("/project/team/demo")
+
+
+def test_get_or_create_project_falls_back_to_old_helper_when_new_endpoint_fails(monkeypatch):
+    post = MagicMock(side_effect=_api_error(404))
+    get_or_create_old_project = MagicMock()
+    get = MagicMock(return_value=SimpleNamespace(data=_project_data(username="team", name="demo")))
+    monkeypatch.setattr(project_api.client, "post", post)
+    monkeypatch.setattr(project_api, "get_or_create_old_project", get_or_create_old_project)
+    monkeypatch.setattr(project_api.client, "get", get)
+
+    result = project_api.get_or_create_project(username="team", name="demo", public=False)
+
+    assert result == _project_data(username="team", name="demo")
+    post.assert_called_once_with(
+        "/projects/team",
+        data={"name": "demo", "visibility": "PRIVATE", "username": "team"},
+        log_error=False,
+    )
+    get_or_create_old_project.assert_called_once_with(
+        data={"name": "demo", "visibility": "PRIVATE", "username": "team"}
+    )
+    get.assert_called_once_with("/project/team/demo")
+
+
+def test_get_or_create_project_currently_falls_back_for_any_new_endpoint_api_error(monkeypatch):
+    post = MagicMock(side_effect=_api_error(500))
+    get_or_create_old_project = MagicMock()
+    get = MagicMock(return_value=SimpleNamespace(data=_project_data(username="team", name="demo")))
+    monkeypatch.setattr(project_api.client, "post", post)
+    monkeypatch.setattr(project_api, "get_or_create_old_project", get_or_create_old_project)
+    monkeypatch.setattr(project_api.client, "get", get)
+
+    project_api.get_or_create_project(username="team", name="demo", public=False)
+
+    get_or_create_old_project.assert_called_once_with(
+        data={"name": "demo", "visibility": "PRIVATE", "username": "team"}
+    )
+
+
+def test_get_or_create_old_project_ignores_conflict(monkeypatch):
+    post = MagicMock(side_effect=_api_error(409))
+    monkeypatch.setattr(deprecated_project_api.client, "post", post)
+
+    with pytest.warns(DeprecationWarning, match="legacy project"):
+        deprecated_project_api.get_or_create_old_project(
+            data={"name": "demo", "visibility": "PRIVATE", "username": "team"}
+        )
+
+    post.assert_called_once_with(
+        "/project",
+        data={"name": "demo", "visibility": "PRIVATE", "username": "team"},
+        log_error=False,
+    )

--- a/tests/unit/sdk/internal/core_python/client/test_core_client.py
+++ b/tests/unit/sdk/internal/core_python/client/test_core_client.py
@@ -17,6 +17,7 @@ from swanlab.sdk.internal.core_python.client import (
     reset,
 )
 from swanlab.sdk.internal.core_python.client import get as global_get
+from swanlab.sdk.internal.core_python.client import post as global_post
 
 
 @pytest.fixture()
@@ -76,8 +77,15 @@ def test_global_proxy_functions(mock_login, mock_base_url, mock_api_url):
     resp = global_get("/global-test")
 
     # 注意这里断言的应该是拼接后的 mock_api_url
-    global_client._session.request.assert_called_with("GET", mock_api_url + "/global-test", params=None, retries=None)
+    global_client._session.request.assert_called_with(
+        "GET", mock_api_url + "/global-test", params=None, retries=None, log_error=True
+    )
     assert resp.data == {"ok": True}
+
+    global_post("/global-submit", data={"name": "test"}, log_error=False)
+    global_client._session.request.assert_called_with(
+        "POST", mock_api_url + "/global-submit", json={"name": "test"}, retries=None, log_error=False
+    )
 
     # 5. 销毁并验证
     reset()

--- a/tests/unit/sdk/internal/core_python/client/test_core_client.py
+++ b/tests/unit/sdk/internal/core_python/client/test_core_client.py
@@ -18,6 +18,7 @@ from swanlab.sdk.internal.core_python.client import (
 )
 from swanlab.sdk.internal.core_python.client import get as global_get
 from swanlab.sdk.internal.core_python.client import post as global_post
+from swanlab.sdk.internal.core_python.client import username as global_username
 
 
 @pytest.fixture()
@@ -36,7 +37,11 @@ def mock_api_url(mock_base_url):
 def mock_login():
     patcher = patch("swanlab.sdk.internal.pkg.client.login_by_api_key")
     mock_func = patcher.start()
-    mock_func.return_value = {"sid": "mock-token-123", "expiredAt": "2999-01-01T00:00:00.000Z"}
+    mock_func.return_value = {
+        "sid": "mock-token-123",
+        "expiredAt": "2999-01-01T00:00:00.000Z",
+        "userInfo": {"username": "test-user", "name": "Test User"},
+    }
     yield mock_func
     patcher.stop()
 
@@ -62,6 +67,7 @@ def test_global_proxy_functions(mock_login, mock_base_url, mock_api_url):
     global_client = new("global-key", mock_base_url)
     assert exists() is True
     assert global_client._api_key == "global-key"
+    assert global_username() == "test-user"
 
     # 3. 重复初始化应该报错
     with pytest.raises(RuntimeError, match="already exists"):

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -75,6 +75,7 @@ def set_online_params(core: CorePython) -> None:
         username="test-user",
         project="test-project",
         project_id="test-project-id",
+        project_version=1,
         experiment_id="test-experiment-id",
     )
 

--- a/tests/unit/sdk/internal/core_python/test_core_sync.py
+++ b/tests/unit/sdk/internal/core_python/test_core_sync.py
@@ -73,10 +73,10 @@ def make_prepare_result(new_experiment: bool = True) -> PrepareExperimentStartRe
     return PrepareExperimentStartResult(
         username="alice",
         project="demo",
-        project_info={
+        project_data={
             "cuid": "project-id",
             "name": "demo",
-            "username": "alice",
+            "group": {"username": "alice"},
             "path": "/alice/demo",
             "visibility": "PRIVATE",
             "_count": {"experiments": 1, "contributors": 0, "collaborators": 0, "clones": 0},
@@ -390,7 +390,7 @@ def test_deliver_sync_flush_returns_failure_when_metrics_init_fails(tmp_path: Pa
 def test_read_uploads_newer_logs_and_captures_finish_record(tmp_path: Path):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     finish_record = FinishRecord(state=RunState.RUN_STATE_FINISHED, finished_at=make_timestamp())
     old_log = Record(log=LogRecord(epoch=1, level=LogLevel.LOG_LEVEL_INFO, line="old"))
     new_log = Record(log=LogRecord(epoch=3, level=LogLevel.LOG_LEVEL_INFO, line="new"))
@@ -411,7 +411,7 @@ def test_read_uploads_newer_logs_and_captures_finish_record(tmp_path: Path):
 def test_read_skips_columns_already_in_metrics(tmp_path: Path):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     core._reader = FakeReader(  # type: ignore[assignment]
         [Record(column=ColumnRecord(column_key="loss", column_type=ColumnType.COLUMN_TYPE_SCALAR))]
     )
@@ -429,7 +429,7 @@ def test_read_skips_columns_already_in_metrics(tmp_path: Path):
 def test_read_auto_defines_scalar_column_when_metric_is_missing(tmp_path: Path):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     scalar = ScalarRecord(
         key="loss",
         step=1,
@@ -453,7 +453,7 @@ def test_read_auto_defines_scalar_column_when_metric_is_missing(tmp_path: Path):
 def test_read_auto_defines_media_column_when_metric_is_missing(tmp_path: Path):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     media = MediaRecord(key="images/sample", step=1, type=ColumnType.COLUMN_TYPE_IMAGE)
     core._reader = FakeReader([Record(media=media)])  # type: ignore[assignment]
     transport = FakeTransport(core._ctx)
@@ -472,7 +472,7 @@ def test_read_auto_defines_media_column_when_metric_is_missing(tmp_path: Path):
 def test_read_skips_invalid_protobuf_payload_and_continues(tmp_path: Path):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     first = Record(
         scalar=ScalarRecord(
             key="loss",
@@ -506,7 +506,7 @@ def test_read_skips_invalid_protobuf_payload_and_continues(tmp_path: Path):
 def test_confirm_sync_finish_marks_missing_finish_record_as_crashed(tmp_path: Path, monkeypatch):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     transport = FakeTransport(core._ctx)
     core._transport = transport  # type: ignore[assignment]
     core._read_executor = FakeExecutor()  # type: ignore[assignment]
@@ -528,7 +528,7 @@ def test_confirm_sync_finish_marks_missing_finish_record_as_crashed(tmp_path: Pa
 def test_confirm_sync_finish_uploads_error_log_for_failed_finish_record(tmp_path: Path, monkeypatch):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     transport = FakeTransport(core._ctx)
     core._transport = transport  # type: ignore[assignment]
     core._read_executor = FakeExecutor()  # type: ignore[assignment]
@@ -557,7 +557,7 @@ def test_confirm_sync_finish_uploads_error_log_for_failed_finish_record(tmp_path
 def test_confirm_sync_finish_uses_existing_finish_record(tmp_path: Path, monkeypatch):
     core = CoreSyncPython()
     core._ctx = CoreContext(config=make_core_config(tmp_path), mode="sync")
-    core._ctx.set_online_params("alice", "demo", "project-id", "experiment-id")
+    core._ctx.set_online_params("alice", "demo", "project-id", None, "experiment-id")
     transport = FakeTransport(core._ctx)
     core._transport = transport  # type: ignore[assignment]
     core._read_executor = FakeExecutor()  # type: ignore[assignment]

--- a/tests/unit/sdk/internal/core_python/transport/conftest.py
+++ b/tests/unit/sdk/internal/core_python/transport/conftest.py
@@ -33,6 +33,7 @@ def _build_mock_ctx(**core_overrides):
         username="test-user",
         project="test-project",
         project_id="test-project-id",
+        project_version=1,
         experiment_id="test-experiment-id",
     )
     return ctx

--- a/tests/unit/sdk/internal/core_python/transport/test_sender.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_sender.py
@@ -66,6 +66,7 @@ def _make_sender(
         username="alice",
         project="demo",
         project_id="project-id",
+        project_version=1,
         experiment_id="experiment-id",
     )
     return HttpRecordSender(ctx=ctx)

--- a/tests/unit/sdk/internal/core_python/transport/test_sender.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_sender.py
@@ -5,7 +5,7 @@ from unittest.mock import ANY, MagicMock, patch
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from swanlab.exceptions import ApiError
-from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnType
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
 from swanlab.proto.swanlab.metric.data.v1.data_pb2 import MediaItem, MediaRecord, MediaValue
 from swanlab.proto.swanlab.record.v1.record_pb2 import Record
 from swanlab.proto.swanlab.save.v1.save_pb2 import SaveRecord
@@ -88,6 +88,22 @@ def _make_media_record(filename: str, media_type=ColumnType.COLUMN_TYPE_IMAGE) -
             value=MediaValue(items=[MediaItem(filename=filename)]),
         )
     )
+
+
+def test_upload_column_batches_all_columns_without_dropping_tail(tmp_path: Path):
+    sender = _make_sender(tmp_path)
+    records = [
+        Record(column=ColumnRecord(column_key=f"metric-{index}", column_type=ColumnType.COLUMN_TYPE_SCALAR))
+        for index in range(3)
+    ]
+
+    with patch("swanlab.sdk.internal.core_python.transport.sender.upload_columns") as mock_upload_columns:
+        sender.upload_column(records, batch_size=2)
+
+    assert mock_upload_columns.call_count == 2
+    assert [call.args[:2] for call in mock_upload_columns.call_args_list] == [("alice", "demo"), ("alice", "demo")]
+    batches = [call.kwargs["columns"]["series"] for call in mock_upload_columns.call_args_list]
+    assert [[column["key"] for column in batch] for batch in batches] == [["metric-0", "metric-1"], ["metric-2"]]
 
 
 def test_upload_save_delegates_small_file_s3_put_to_upload_resources(tmp_path: Path):

--- a/tests/unit/sdk/internal/pkg/client/test_client.py
+++ b/tests/unit/sdk/internal/pkg/client/test_client.py
@@ -31,7 +31,11 @@ def mock_api_url(mock_base_url):
 def mock_login():
     patcher = patch("swanlab.sdk.internal.pkg.client.login_by_api_key")
     mock_func = patcher.start()
-    mock_func.return_value = {"sid": "mock-token-123", "expiredAt": "2999-01-01T00:00:00.000Z"}
+    mock_func.return_value = {
+        "sid": "mock-token-123",
+        "expiredAt": "2999-01-01T00:00:00.000Z",
+        "userInfo": {"username": "test-user", "name": "Test User"},
+    }
     yield mock_func
     patcher.stop()
 

--- a/tests/unit/sdk/internal/pkg/client/test_client.py
+++ b/tests/unit/sdk/internal/pkg/client/test_client.py
@@ -82,12 +82,22 @@ def test_client_http_methods_and_url_join(client, mock_api_url):
 
     # 1. 测试 GET 请求
     resp = client.get("/project", params={"id": 1})
-    client._session.request.assert_called_with("GET", mock_api_url + "/project", params={"id": 1}, retries=None)
+    client._session.request.assert_called_with(
+        "GET", mock_api_url + "/project", params={"id": 1}, retries=None, log_error=True
+    )
     assert resp.data == {"msg": "success"}  # 顺便验证数据类的 data 是否正确包装
 
     # 2. 测试 POST 请求
     client.post("run", data={"name": "test"})
-    client._session.request.assert_called_with("POST", mock_api_url + "/run", json={"name": "test"}, retries=None)
+    client._session.request.assert_called_with(
+        "POST", mock_api_url + "/run", json={"name": "test"}, retries=None, log_error=True
+    )
+
+    # 3. 测试单次请求错误日志开关透传
+    client.post("run", data={"name": "test"}, log_error=False)
+    client._session.request.assert_called_with(
+        "POST", mock_api_url + "/run", json={"name": "test"}, retries=None, log_error=False
+    )
 
 
 # -------------------------------------------------------------------

--- a/tests/unit/sdk/internal/pkg/client/test_client_session.py
+++ b/tests/unit/sdk/internal/pkg/client/test_client_session.py
@@ -91,6 +91,40 @@ def test_session_send_api_error_fallback(session):
 
 
 @responses.activate()
+def test_session_send_logs_project_error_by_default(session, mocker):
+    """测试 /api/project 不再被传输层 URL 特判静默"""
+    responses.add(responses.POST, "http://api.test/api/project", json={"code": "409", "message": "exists"}, status=409)
+    mock_error = mocker.patch("swanlab.sdk.internal.pkg.client.session.console.error")
+
+    with pytest.raises(ApiError):
+        session.post("http://api.test/api/project")
+
+    mock_error.assert_called_once()
+
+
+@responses.activate()
+def test_session_send_can_suppress_error_log_per_request(session, mocker):
+    """测试单次请求可以关闭错误日志，但仍然抛出 ApiError"""
+    responses.add(responses.POST, "http://api.test/submit", json={"code": "1001", "message": "invalid"}, status=401)
+    responses.add(
+        responses.POST, "http://api.test/submit-again", json={"code": "1002", "message": "invalid"}, status=401
+    )
+    mock_error = mocker.patch("swanlab.sdk.internal.pkg.client.session.console.error")
+
+    with pytest.raises(ApiError) as exc_info:
+        session.post("http://api.test/submit", log_error=False)
+
+    assert exc_info.value.code == "1001"
+    assert exc_info.value.message == "invalid"
+    mock_error.assert_not_called()
+
+    with pytest.raises(ApiError):
+        session.post("http://api.test/submit-again")
+
+    mock_error.assert_called_once()
+
+
+@responses.activate()
 def test_request_retries_context_cleanup(session):
     """测试无论请求成功与否，重试次数的 ContextVar 都会被清理"""
     responses.add(responses.GET, "http://api.test/fail", status=500)


### PR DESCRIPTION
## Summary

为支持多视图功能，对项目创建和列上传接口进行重构，同时保持对旧版本项目的向下兼容。

> 对多视图功能的支持为 v0.9.0 版本的必要功能

## Changes

**项目 API 重构**
- 项目创建从 `POST /api/project` 迁移到 `POST /api/projects/{username}`，移除 payload 中的 `username` 字段
- 项目详情接口响应新增 `group.username`、可选 `version` 字段
- 新版接口不可用（404）时自动 fallback 到旧 `/api/project` 接口，旧项目可使用到 v0.10.0

**列上传接口重构**
- 列上传端点从 `POST /experiment/{id}/columns` 迁移到 `POST /projects/{username}/{project}/series`
- 新版列 DTO 简化为 `{key, type, sectionName}`，去掉冗余字段
- 修复 column 分批上传时变量重绑定导致超 3000 条时尾批次丢失的 bug

**旧版兼容逻辑**
- 旧项目创建/列上传逻辑迁移到 `swanlab/deprecated/project.py` 和 `swanlab/deprecated/sender.py`
- `Transport.start()` 根据项目版本自动选择 `HttpRecordSender`（新版）或 `DeprecatedHttpRecordSender`（旧版）
- deprecated 警告从 `DeprecationWarning` 改为 `FutureWarning`

**HTTP Client 改进**
- `Client`/`SessionWithRetry` 新增 per-request `log_error` 参数，替代对 `/api/project` URL 的硬编码特判
- `Client` 登录时缓存 `username`，新增 `username` 属性和模块级 `username()` 代理函数

**类型定义**
- `ProjectType` 新增 `group._ProjectGroup` 和可选 `version` 字段
- 移除 `InitProjectType`
- Column DTO 拆分为 `UploadColumn`（新版）和 `DeprecatedUploadColumn`（旧版）

## Testing

已执行：
- `uv run pytest tests/unit/sdk/internal/core_python/api/test_project.py` — 5 passed
- `uv run pytest tests/unit/sdk/internal/core_python/transport/test_sender.py` — 11 passed
- `uv run ruff check` — 相关文件通过
- `git diff --check` — 无空白问题

未运行：完整测试套件、basedpyright 类型检查。

## Notes

- 旧版兼容逻辑计划在 v0.10.0（2026-10-01）后移除
- `encode_column` 新 DTO 去除了 `name`、`yRange`、`chartName`、`metricName` 等字段，需确认新版后端不再依赖这些字段
- 旧项目的 `prepare_experiment_start()` 通过 `project_data["group"]["username"]` 获取用户名，旧后端需保证返回 `group` 字段