### PR TITLE
fix: remove safe.block from upload_log to enable transport-layer retry

### DIFF
--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -243,25 +243,24 @@ class HttpRecordSender:
         upload_media(self._project_id, self._experiment_id, metrics=metrics)
 
     def upload_log(self, records: Sequence[Record]) -> None:
-        with safe.block(message="Failed to upload terminal logs, skipping"):
-            console.debug(f"Preparing log HTTP request: records={len(records)}", write_to_tty=False)
-            metrics: UploadLogBatch = []
-            for record in records:
-                if not record.HasField("log"):
-                    continue
-                log_record = record.log
-                if log_record.HasField("timestamp"):
-                    create_time = log_record.timestamp.ToJsonString()
-                    metric: UploadLog = {
-                        "level": adapter.level[log_record.level],
-                        "epoch": log_record.epoch,
-                        "message": log_record.line,
-                        "create_time": create_time,
-                    }
-                    metrics.append(metric)
-            console.debug(f"Sending log HTTP request: metrics={len(metrics)}", write_to_tty=False)
-            upload_log(self._project_id, self._experiment_id, metrics=metrics)
-            console.debug(f"Log HTTP request completed: metrics={len(metrics)}", write_to_tty=False)
+        console.debug(f"Preparing log HTTP request: records={len(records)}", write_to_tty=False)
+        metrics: UploadLogBatch = []
+        for record in records:
+            if not record.HasField("log"):
+                continue
+            log_record = record.log
+            if log_record.HasField("timestamp"):
+                create_time = log_record.timestamp.ToJsonString()
+                metric: UploadLog = {
+                    "level": adapter.level[log_record.level],
+                    "epoch": log_record.epoch,
+                    "message": log_record.line,
+                    "create_time": create_time,
+                }
+                metrics.append(metric)
+        console.debug(f"Sending log HTTP request: metrics={len(metrics)}", write_to_tty=False)
+        upload_log(self._project_id, self._experiment_id, metrics=metrics)
+        console.debug(f"Log HTTP request completed: metrics={len(metrics)}", write_to_tty=False)
 
     # ── 文件保存上传 ──
 

--- a/tests/unit/sdk/cmd/init/test_init_e2e.py
+++ b/tests/unit/sdk/cmd/init/test_init_e2e.py
@@ -630,6 +630,7 @@ class TestInitOnlineMode:
         mock_experiment_stop_api,
         mock_profile_api,
         mock_heartbeat_api,
+        mock_metrics_api,
     ):
         """online 模式完整 init 流程：返回 Run，has_run() 为 True"""
         run = init(mode="online", project=PROJECT)
@@ -646,6 +647,7 @@ class TestInitOnlineMode:
         mock_experiment_stop_api,
         mock_profile_api,
         mock_heartbeat_api,
+        mock_metrics_api,
     ):
         """online 模式下，workspace 和 project.name 应与后端响应同步"""
         run = init(mode="online", project=PROJECT)
@@ -663,6 +665,7 @@ class TestInitOnlineMode:
         mock_experiment_stop_api,
         mock_profile_api,
         mock_heartbeat_api,
+        mock_metrics_api,
     ):
         """新版创建接口不可用且旧接口返回 409（项目已存在）时，应继续初始化"""
         rsps.add(responses_lib.POST, f"{API_HOST}/api/projects/{USERNAME}", json={"message": "not found"}, status=404)
@@ -682,6 +685,7 @@ class TestInitOnlineMode:
         mock_experiment_stop_api,
         mock_profile_api,
         mock_heartbeat_api,
+        mock_metrics_api,
         rsps,
     ):
         """验证 online init 确实调用了 project 和 experiment 端点"""
@@ -699,6 +703,7 @@ class TestInitOnlineMode:
         mock_project_get_api,
         mock_experiment_stop_api,
         mock_profile_api,
+        mock_heartbeat_api,
         mock_metrics_api,
         rsps,
     ):
@@ -1118,6 +1123,7 @@ def mock_online_save_apis(
     mock_experiment_stop_api,
     mock_profile_api,
     mock_heartbeat_api,
+    mock_metrics_api,
     mock_save_prepare_api,
     mock_save_complete_api,
     mock_save_upload_api,
@@ -1136,6 +1142,7 @@ def mock_online_init_only(
     mock_experiment_stop_api,
     mock_profile_api,
     mock_heartbeat_api,
+    mock_metrics_api,
 ):
     """组合 fixture：仅注册 init(mode='online') 所需端点，不含 save/media 上传。"""
     pass

--- a/tests/unit/sdk/internal/core_python/test_core_python.py
+++ b/tests/unit/sdk/internal/core_python/test_core_python.py
@@ -176,6 +176,9 @@ class TestCorePythonFinish:
         mock_heartbeat = MockHeartbeat.return_value
 
         monkeypatch.setattr("swanlab.sdk.internal.core_python.core.stop_experiment", lambda *a, **kw: None)
+        # _store_finish 在 finish_record.state != FINISHED 时会生成一条 error log record 并放入 transport，
+        # 需要注册 upload_log mock 让 transport 排空成功，否则 join 会因持续重试而超时
+        monkeypatch.setattr("swanlab.sdk.internal.core_python.transport.sender.upload_log", lambda *a, **kw: None)
         core.deliver_run_finish(DeliverRunFinishRequest(finish_record=FinishRecord()))
 
         assert core._store is None

--- a/tests/unit/sdk/internal/core_python/transport/test_sender_retry.py
+++ b/tests/unit/sdk/internal/core_python/transport/test_sender_retry.py
@@ -1,0 +1,228 @@
+"""
+重试设计契约测试：验证上传链路中 ApiError 的传播规则和 retries=0 约定。
+
+重试设计分三层：
+  1. API 层（api/upload.py）：所有 /house/metrics 和 column 上传使用 retries=0，
+     HTTP 层不重试，重试交由 transport 层处理。
+  2. sender.upload（sender.py）：重试决定点。5xx ApiError → re-raise（transport 重试）；
+     4xx ApiError → swallow（业务拒绝，不重试）。
+  3. Dispatch（dispatch.py）：safe.block 包裹 sender.upload，捕获所有异常返回 (False, records)。
+
+契约：handler 不得将 HTTP API 调用包裹在 safe.block 中，
+否则 sender.upload 永远看不到 ApiError，transport 层无法重试。
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from swanlab.exceptions import ApiError
+from swanlab.proto.swanlab.metric.column.v1.column_pb2 import ColumnRecord, ColumnType
+from swanlab.proto.swanlab.metric.data.v1.data_pb2 import ScalarRecord, ScalarValue
+from swanlab.proto.swanlab.record.v1.record_pb2 import Record
+from swanlab.proto.swanlab.terminal.v1.log_pb2 import LogLevel, LogRecord
+from swanlab.sdk.internal.core_python.api import upload as upload_api
+from swanlab.sdk.internal.core_python.context import CoreConfig, CoreContext
+from swanlab.sdk.internal.core_python.transport.sender import HttpRecordSender
+from swanlab.sdk.internal.core_python.transport.tracker import UploadTracker
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+class _FakeApiErrorResponse:
+    """构造 ApiError 所需的最小 Response 替身。"""
+
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        self.request = MagicMock()
+        self.url = "https://api.test/upload"
+
+
+def _make_api_error(status_code: int) -> ApiError:
+    return ApiError(
+        _FakeApiErrorResponse(status_code),
+        method="POST",
+        trace_id="trace-id",
+        code="test-error",
+        message=f"http {status_code}",
+    )
+
+
+def _make_sender(tmp_path: Path) -> HttpRecordSender:
+    ctx = CoreContext(
+        config=CoreConfig(
+            run_id="test-run-id",
+            run_dir=tmp_path,
+            section_rule=0,
+            record_batch=10000,
+            record_interval=5.0,
+            save_split=100 * 1024 * 1024,
+            save_size=50 * 1024 * 1024 * 1024,
+            save_part=32 * 1024 * 1024,
+            save_batch=100,
+        )
+    )
+    ctx.set_online_params(
+        username="alice",
+        project="demo",
+        project_id="project-id",
+        project_version=1,
+        experiment_id="experiment-id",
+    )
+    return HttpRecordSender(ctx=ctx)
+
+
+def _make_scalar_record() -> Record:
+    ts = Timestamp()
+    ts.GetCurrentTime()
+    return Record(
+        scalar=ScalarRecord(
+            key="train/loss",
+            step=1,
+            timestamp=ts,
+            type=ColumnType.COLUMN_TYPE_SCALAR,
+            value=ScalarValue(number=0.125),
+        )
+    )
+
+
+def _make_log_record() -> Record:
+    ts = Timestamp()
+    ts.GetCurrentTime()
+    return Record(
+        log=LogRecord(
+            line="training step done",
+            level=LogLevel.LOG_LEVEL_INFO,
+            timestamp=ts,
+            epoch=1,
+        )
+    )
+
+
+def _make_column_record() -> Record:
+    return Record(column=ColumnRecord(column_key="metric-0", column_type=ColumnType.COLUMN_TYPE_SCALAR))
+
+
+@pytest.fixture(autouse=True)
+def _silence_console():
+    """抑制 safe.block 的 console.trace 和 sender.upload 的 console.warning 输出。"""
+    with (
+        patch("swanlab.sdk.internal.pkg.console.trace"),
+        patch("swanlab.sdk.internal.pkg.console.warning"),
+    ):
+        yield
+
+
+# ── Section 1: retries=0 约定 ──────────────────────────────
+# 所有上传 API 函数必须传 retries=0，HTTP 层不重试，重试交由 transport 层处理。
+
+
+_RETRIES_ZERO_CASES = [
+    pytest.param(
+        upload_api.upload_scalar,
+        ("pid", "eid"),
+        {"metrics": [{"key": "loss", "index": 0, "data": 0.1, "create_time": "2024-01-01T00:00:00+08:00"}]},
+        id="scalar",
+    ),
+    pytest.param(
+        upload_api.upload_log,
+        ("pid", "eid"),
+        {"metrics": [{"level": "INFO", "epoch": 0, "message": "hi", "create_time": "2024-01-01T00:00:00+08:00"}]},
+        id="log",
+    ),
+    pytest.param(
+        upload_api.upload_media,
+        ("pid", "eid"),
+        {"metrics": [{"key": "img", "index": 0, "data": [], "more": [], "create_time": "2024-01-01T00:00:00+08:00"}]},
+        id="media",
+    ),
+    pytest.param(
+        upload_api.upload_columns,
+        ("user", "proj"),
+        {"columns": {"series": [{"key": "loss"}]}},
+        id="column",
+    ),
+]
+
+
+@pytest.mark.parametrize("api_func, args, kwargs", _RETRIES_ZERO_CASES)
+def test_upload_api_uses_retries_zero(monkeypatch, api_func, args, kwargs):
+    """验证所有上传 API 函数都传 retries=0，确保 HTTP 层不自行重试。
+
+    retries=0 是刻意设计：将重试责任上移到 transport 层，
+    避免 HTTP 层（urllib3）与 transport 层同时重试造成行为不可预期。
+    """
+    captured: list = []
+
+    def fake_post(url, data=None, **post_kwargs):
+        captured.append(post_kwargs.get("retries"))
+
+    monkeypatch.setattr(upload_api.client, "post", fake_post)
+
+    api_func(*args, **kwargs)
+
+    assert captured == [0]
+
+
+# ── Section 2: handler → sender.upload 错误传播 ─────────────
+# handler 必须让 ApiError 穿透到 sender.upload，后者决定是否重试。
+# 任何 handler 不得将 HTTP API 调用包裹在 safe.block 中。
+
+
+_RETRY_CONTRACT_CASES = [
+    pytest.param("scalar", "upload_scalar", _make_scalar_record, id="scalar"),
+    pytest.param("log", "upload_log", _make_log_record, id="log"),
+    pytest.param("column", "upload_columns", _make_column_record, id="column"),
+]
+
+
+@pytest.mark.parametrize("record_type, api_func_name, make_record", _RETRY_CONTRACT_CASES)
+def test_5xx_reraises_for_transport_retry(tmp_path, record_type, api_func_name, make_record):
+    """5xx ApiError 必须穿透 handler → sender.upload 并 re-raise，供 transport 层重试。
+
+    回归守卫：handler 不得将 HTTP 调用包裹在 safe.block 中，
+    否则 sender.upload 永远看不到错误，transport 层无法重试，数据静默丢失。
+    """
+    tracker = UploadTracker()
+    sender = _make_sender(tmp_path)
+    sender.set_tracker(tracker)
+
+    with patch(
+        f"swanlab.sdk.internal.core_python.transport.sender.{api_func_name}",
+        side_effect=_make_api_error(502),
+    ):
+        with pytest.raises(ApiError):
+            sender.upload(record_type, [make_record()])
+
+    assert tracker.snapshot().uploaded_records == 0
+
+
+@pytest.mark.parametrize("record_type, api_func_name, make_record", _RETRY_CONTRACT_CASES)
+def test_4xx_swallowed_non_retryable(tmp_path, record_type, api_func_name, make_record):
+    """4xx ApiError 被 sender.upload 吞掉（业务拒绝），不重试，records 不递进。"""
+    tracker = UploadTracker()
+    sender = _make_sender(tmp_path)
+    sender.set_tracker(tracker)
+
+    with patch(
+        f"swanlab.sdk.internal.core_python.transport.sender.{api_func_name}",
+        side_effect=_make_api_error(400),
+    ):
+        sender.upload(record_type, [make_record()])
+
+    assert tracker.snapshot().uploaded_records == 0
+
+
+@pytest.mark.parametrize("record_type, api_func_name, make_record", _RETRY_CONTRACT_CASES)
+def test_success_advances_records(tmp_path, record_type, api_func_name, make_record):
+    """成功上传递进 uploaded_records。"""
+    tracker = UploadTracker()
+    sender = _make_sender(tmp_path)
+    sender.set_tracker(tracker)
+
+    with patch(f"swanlab.sdk.internal.core_python.transport.sender.{api_func_name}"):
+        sender.upload(record_type, [make_record()])
+
+    assert tracker.snapshot().uploaded_records == 1


### PR DESCRIPTION
## Summary

`upload_log` 方法被 `safe.block()` 包裹，导致 `ApiError` 异常被静默吞掉，transport 层的重试机制对日志上传完全失效。本次变更移除 `safe.block`，使 `upload_log` 的错误传播行为与 `upload_scalar`、`upload_media` 保持一致——`ApiError` 正确穿透到 `upload()` dispatcher，由后者根据状态码决定重试（5xx re-raise）或放弃（4xx swallow）。

## Changes

- **`swanlab/sdk/internal/core_python/transport/sender.py`**: 移除 `upload_log` 方法的 `safe.block` 包裹，解除因异常被静默吞掉导致的日志上传重试失效问题。
- **`tests/unit/sdk/internal/core_python/transport/test_sender_retry.py`** (新增): 重试契约测试，覆盖：
  - `retries=0` 约定：验证所有上传 API 的 HTTP 层不自行重试
  - 5xx ApiError 传播：验证错误穿透 handler → sender.upload，transport 层可重试
  - 4xx ApiError 吞掉：验证业务拒绝不触发重试
  - 成功递进：验证上传成功后 `uploaded_records` 正确推进

## Testing

- 13 个新增重试契约测试全部通过
- 覆盖 scalar / log / column 三种记录类型的 4xx、5xx 及成功路径