### PR TITLE
refactor: add centralized MIME guesser with YAML support

### DIFF
--- a/swanlab/sdk/internal/core_python/pkg/__init__.py
+++ b/swanlab/sdk/internal/core_python/pkg/__init__.py
@@ -5,6 +5,6 @@
 @description: core python 工具包
 """
 
-from . import builder, counter
+from . import builder, counter, mime
 
-__all__ = ["counter", "builder"]
+__all__ = ["builder", "counter", "mime"]

--- a/swanlab/sdk/internal/core_python/pkg/mime/__init__.py
+++ b/swanlab/sdk/internal/core_python/pkg/mime/__init__.py
@@ -1,0 +1,26 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2026/7/29
+@description: mimetype 封装，注册自定义扩展并提供类型推断
+"""
+
+from __future__ import annotations
+
+import mimetypes as _std_mimetypes
+import os
+from typing import Union
+
+__all__ = ["guess_type"]
+
+_DEFAULT_MIME_TYPE = "application/octet-stream"
+
+# 注册 YAML 扩展到标准类型表（guess_type 默认只查标准表）
+# strict=True 会覆盖系统已有映射（源码直接赋值，不抛错），保证跨平台确定性
+_std_mimetypes.add_type("application/yaml", ".yaml")
+_std_mimetypes.add_type("application/yaml", ".yml")
+
+
+def guess_type(path: Union[str, "os.PathLike[str]"]) -> str:
+    """根据文件路径推断 MIME 类型，无法识别时回退到 application/octet-stream。"""
+    return _std_mimetypes.guess_type(os.fspath(path))[0] or _DEFAULT_MIME_TYPE

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import math
-import mimetypes
 import threading
 from collections.abc import Callable, Sequence
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -40,6 +39,7 @@ from swanlab.sdk.internal.core_python.api.upload import (
     upload_scalar,
 )
 from swanlab.sdk.internal.core_python.context import CoreContext
+from swanlab.sdk.internal.core_python.pkg.mime import guess_type
 from swanlab.sdk.internal.core_python.utils import ProgressFileWrapper, get_buffer_size
 from swanlab.sdk.internal.pkg import adapter, client, console, safe
 from swanlab.sdk.internal.pkg.client.session import SessionWithRetry
@@ -214,7 +214,7 @@ class HttpRecordSender:
                         self._track_file(tracker_key, local_path.as_posix(), size)
                         # 先计算 mime_type, 确保后续 record_paths/paths/buffers/content_types 原子化追加,
                         # 避免 safe.block 内中途异常导致列表长度不一致、MIME 类型错位
-                        mime_type = mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
+                        mime_type = guess_type(local_path)
                         record_paths.append(remote_path_str)
                         paths.append(remote_path_str)
                         buffers.append(local_path)
@@ -395,7 +395,7 @@ class HttpRecordSender:
                     if not isinstance(md5, str):
                         console.warning(f"Save file MD5 computation failed, skipping: {source_path}")
                         continue
-                    mime_type = mimetypes.guess_type(source_path)[0] or "application/octet-stream"
+                    mime_type = guess_type(source_path)
                     file_entries.append(
                         {
                             "path": name,

--- a/tests/unit/sdk/internal/core_python/pkg/mime/test_mime.py
+++ b/tests/unit/sdk/internal/core_python/pkg/mime/test_mime.py
@@ -1,0 +1,44 @@
+"""
+@author: cunyue
+@file: test_mime.py
+@time: 2026/7/29
+@description: 测试 swanlab.sdk.internal.core_python.pkg.mime 模块
+
+测试分组：
+  - TestGuessTypeRegistered : 已注册扩展（.yaml/.yml）的类型推断
+  - TestGuessTypePassthrough : 标准扩展的透传
+  - TestGuessTypeFallback    : 未知扩展/无扩展的兜底
+  - TestGuessTypeInput       : str 与 PathLike 输入兼容
+"""
+
+import pytest
+
+from swanlab.sdk.internal.core_python.pkg.mime import guess_type
+
+
+class TestGuessTypeRegistered:
+    @pytest.mark.parametrize("name", ["config.yaml", "a/b/c.yml", "swanlab.yaml", "UPPER.YAML", "Mixed.YmL"])
+    def test_yaml_extensions(self, name):
+        assert guess_type(name) == "application/yaml"
+
+
+class TestGuessTypePassthrough:
+    def test_known_extension(self):
+        # .txt 在所有平台均映射为 text/plain
+        assert guess_type("readme.txt") == "text/plain"
+
+
+class TestGuessTypeFallback:
+    @pytest.mark.parametrize("name", ["data.unknownext", "archive.zzz", "noextension", ""])
+    def test_unknown_or_missing_extension(self, name):
+        assert guess_type(name) == "application/octet-stream"
+
+
+class TestGuessTypeInput:
+    def test_accepts_path(self, tmp_path):
+        f = tmp_path / "config.yaml"
+        f.write_text("key: value")
+        assert guess_type(f) == "application/yaml"
+
+    def test_accepts_str(self):
+        assert guess_type("config.yaml") == "application/yaml"


### PR DESCRIPTION
## Summary

新增 `swanlab.sdk.internal.core_python.pkg.mime` 模块，封装 `mimetypes` 标准库，统一文件 MIME 类型推断逻辑，并将 `sender.py` 中两处 `mimetypes.guess_type` 调用迁移至新模块。

## Changes

- **新增 `pkg/mime/__init__.py`**：模块导入时注册 `.yaml`/`.yml` → `application/yaml`，对外暴露 `guess_type(path) -> str`，内置 `application/octet-stream` 兜底，消除调用方重复的 fallback 逻辑。
- **更新 `pkg/__init__.py`**：导出 `mime` 子包。
- **重构 `transport/sender.py`**：删除 `import mimetypes`，两处调用统一替换为 `guess_type()`。
- **新增 `tests/unit/.../mime/test_mime.py`**：12 个用例，覆盖 YAML 注册（含大小写）、标准扩展透传、未知扩/无扩展兜底、`str` / `Path` 输入。

## Testing

- [x] ruff + basedpyright 均 0 errors / 0 warnings
- [x] `tests/unit/sdk/internal/core_python/pkg/mime/test_mime.py` — 12 passed
- [x] `tests/unit/sdk/internal/core_python/pkg/builder/test_pkg_builder.py` — 通过
- [x] `tests/unit/sdk/internal/core_python/transport/test_sender.py` — 通过
- [x] `tests/unit/sdk/internal/core_python/transport/test_sender_retry.py` — 通过

## Notes

- `add_type` 使用默认 `strict=True`（写入标准类型表），源码确认会直接覆盖已有映射而不抛错，保证跨平台确定性。
- 本次变更未修改已有代码逻辑，仅统一 MIME 推断入口并注册 YAML 类型。