### PR TITLE
fix: tolerate invalid env vars in settings, with SWANLAB_STRICT_ENV toggle

### DIFF
--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -24,9 +24,11 @@ from typing import Any, ClassVar, Dict, Optional, Tuple, Type, Union, get_args
 
 import yaml
 from pydantic import Field, field_validator
+from pydantic.fields import FieldInfo
 from pydantic.functional_validators import model_validator
 from pydantic_settings import (
     BaseSettings,
+    EnvSettingsSource,
     PydanticBaseSettingsSource,
     SecretsSettingsSource,
     SettingsConfigDict,
@@ -61,6 +63,28 @@ CONFIG_DIR: str = config_dir_env or "/etc/swanlab"
 def log_dir_factory() -> Path:
     # 向下兼容旧版本环境变量
     return Path(os.environ.get("SWANLAB_LOGDIR", str(Path.cwd() / "swanlog")))
+
+
+class _TolerantEnvSettingsSource(EnvSettingsSource):
+    """对默认 EnvSettingsSource 的扩展：容忍复杂字段（嵌套模型）的非 JSON 环境变量值。
+
+    当环境变量直接映射到某个嵌套模型字段（例如 SWANLAB_RUN=hello）但其值并非合法 JSON 时，
+    pydantic-settings 默认会抛出 SettingsError，导致整个 SDK 导入失败。
+    此处在解析失败时跳过该字段并告警，避免单个环境变量配置错误影响导入。
+    嵌套子字段（如 SWANLAB_RUN_ID）的解析不受影响。
+    """
+
+    def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
+        try:
+            return super().prepare_field_value(field_name, field, value, value_is_complex)
+        except ValueError:
+            # 仅容忍复杂字段的非 JSON 值，简单字段的类型错误仍然抛出
+            if self.field_is_complex(field) or value_is_complex:
+                console.warning(
+                    f'Failed to parse environment variable for "{field_name}" (value is not valid JSON); ignoring.'
+                )
+                return None
+            raise
 
 
 class Settings(BaseSettings):
@@ -400,7 +424,7 @@ class Settings(BaseSettings):
         sources.append(file_secret_settings)
 
         # 6. 环境变量
-        sources.append(env_settings)
+        sources.append(_TolerantEnvSettingsSource(settings_cls))
 
         # 7. 当前工作目录下 .swanlab/config.{yaml,yml}
         # 项目级别的配置文件，优先级高于环境变量但低于 .env

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -93,14 +93,10 @@ class _TolerantEnvSettingsSource(EnvSettingsSource):
                 raise
             console.warning(f'Failed to parse environment variable for "{field_name}"; ignoring.')
             return None
-        # 非严格模式下，对简单字段预校验类型，避免非法值（如 bool 字段传入非布尔字符串）在模型构造阶段抛出
+        # 非严格模式下，用 TypeAdapter 预校验结果值，避免非法值在模型构造阶段抛出
+        # 覆盖复杂字段（如 json.loads("1")=1 无法构造嵌套模型）和简单字段（如 bool 传入非布尔字符串）
         # 仅在 lenient 模式执行：strict 模式交给模型校验，以保留 before-validator 的转换行为（如 mode=cloud→online）
-        if (
-            not self._strict
-            and result is not None
-            and not (self.field_is_complex(field) or value_is_complex)
-            and field.annotation is not None
-        ):
+        if not self._strict and result is not None and field.annotation is not None:
             try:
                 TypeAdapter(field.annotation).validate_python(result)
             except ValidationError:

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, ClassVar, Dict, Optional, Tuple, Type, Union, get_args
 
 import yaml
-from pydantic import Field, field_validator
+from pydantic import Field, TypeAdapter, ValidationError, field_validator
 from pydantic.fields import FieldInfo
 from pydantic.functional_validators import model_validator
 from pydantic_settings import (
@@ -59,6 +59,10 @@ SECRETS_DIR: Optional[str] = secrets_dir_env or None
 config_dir_env = os.getenv("SWANLAB_CONFIG_DIR")
 CONFIG_DIR: str = config_dir_env or "/etc/swanlab"
 
+# SWANLAB_STRICT_ENV=1 时，环境变量解析失败将直接抛出（便于调试）；默认容忍并跳过
+strict_env = os.getenv("SWANLAB_STRICT_ENV", "")
+STRICT_ENV: bool = strict_env.lower() in ("1", "true", "yes")
+
 
 def log_dir_factory() -> Path:
     # 向下兼容旧版本环境变量
@@ -66,25 +70,43 @@ def log_dir_factory() -> Path:
 
 
 class _TolerantEnvSettingsSource(EnvSettingsSource):
-    """对默认 EnvSettingsSource 的扩展：容忍复杂字段（嵌套模型）的非 JSON 环境变量值。
+    """对默认 EnvSettingsSource 的扩展：可配置是否容忍环境变量解析错误。
 
-    当环境变量直接映射到某个嵌套模型字段（例如 SWANLAB_RUN=hello）但其值并非合法 JSON 时，
+    当环境变量值无法被解析时（例如嵌套模型字段收到非合法 JSON、或简单字段类型转换失败），
     pydantic-settings 默认会抛出 SettingsError，导致整个 SDK 导入失败。
-    此处在解析失败时跳过该字段并告警，避免单个环境变量配置错误影响导入。
-    嵌套子字段（如 SWANLAB_RUN_ID）的解析不受影响。
+
+    - strict=False（默认）：解析失败时跳过该字段并告警，字段回退到默认值，避免影响导入
+    - strict=True：解析失败时直接抛出，便于调试时暴露配置错误
+
+    可通过环境变量 SWANLAB_STRICT_ENV=1 开启严格模式，适用于复杂字段和简单字段。
     """
+
+    def __init__(self, settings_cls: Type[BaseSettings], *, strict: bool = False) -> None:
+        super().__init__(settings_cls)
+        self._strict = strict
 
     def prepare_field_value(self, field_name: str, field: FieldInfo, value: Any, value_is_complex: bool) -> Any:
         try:
-            return super().prepare_field_value(field_name, field, value, value_is_complex)
+            result = super().prepare_field_value(field_name, field, value, value_is_complex)
         except ValueError:
-            # 仅容忍复杂字段的非 JSON 值，简单字段的类型错误仍然抛出
-            if self.field_is_complex(field) or value_is_complex:
-                console.warning(
-                    f'Failed to parse environment variable for "{field_name}" (value is not valid JSON); ignoring.'
-                )
+            if self._strict:
+                raise
+            console.warning(f'Failed to parse environment variable for "{field_name}"; ignoring.')
+            return None
+        # 非严格模式下，对简单字段预校验类型，避免非法值（如 bool 字段传入非布尔字符串）在模型构造阶段抛出
+        # 仅在 lenient 模式执行：strict 模式交给模型校验，以保留 before-validator 的转换行为（如 mode=cloud→online）
+        if (
+            not self._strict
+            and result is not None
+            and not (self.field_is_complex(field) or value_is_complex)
+            and field.annotation is not None
+        ):
+            try:
+                TypeAdapter(field.annotation).validate_python(result)
+            except ValidationError:
+                console.warning(f'Invalid value for environment variable "{field_name}"; ignoring.')
                 return None
-            raise
+        return result
 
 
 class Settings(BaseSettings):
@@ -424,7 +446,7 @@ class Settings(BaseSettings):
         sources.append(file_secret_settings)
 
         # 6. 环境变量
-        sources.append(_TolerantEnvSettingsSource(settings_cls))
+        sources.append(_TolerantEnvSettingsSource(settings_cls, strict=STRICT_ENV))
 
         # 7. 当前工作目录下 .swanlab/config.{yaml,yml}
         # 项目级别的配置文件，优先级高于环境变量但低于 .env

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -335,6 +335,37 @@ def test_core_section_rule_env_overrides_legacy(monkeypatch):
     assert settings.core.section_rule == -1
 
 
+@pytest.mark.parametrize("field", ["run", "project", "experiment", "terminal", "integration", "core", "probe"])
+def test_nested_model_env_invalid_value_ignored(monkeypatch, field):
+    """嵌套模型字段直接收到非 JSON 环境变量值时不应导致导入崩溃，而是跳过并回退默认值"""
+    monkeypatch.setenv(f"SWANLAB_{field.upper()}", "not-a-json")
+
+    # 不应抛出异常
+    settings = Settings()
+
+    # 该字段应保持默认值（此处校验 run 的默认值，其余字段仅验证不崩溃）
+    if field == "run":
+        assert settings.run.id is None
+
+
+def test_nested_model_env_valid_json(monkeypatch):
+    """嵌套模型字段接收合法 JSON 时仍应正常解析"""
+    monkeypatch.setenv("SWANLAB_RUN", '{"id": "r-from-json"}')
+
+    settings = Settings()
+
+    assert settings.run.id == "r-from-json"
+
+
+def test_nested_model_env_subfield_still_works(monkeypatch):
+    """嵌套子字段（如 SWANLAB_RUN_ID）解析不受影响"""
+    monkeypatch.setenv("SWANLAB_RUN_ID", "r-subfield")
+
+    settings = Settings()
+
+    assert settings.run.id == "r-subfield"
+
+
 @pytest.fixture
 def netrc_file(tmp_path, monkeypatch):
     """

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -366,6 +366,51 @@ def test_nested_model_env_subfield_still_works(monkeypatch):
     assert settings.run.id == "r-subfield"
 
 
+def test_simple_field_env_invalid_value_ignored(monkeypatch):
+    """简单字段（如 bool）收到非法环境变量值时也应跳过并回退默认值"""
+    monkeypatch.setenv("SWANLAB_INTERACTIVE", "not-a-bool")
+
+    settings = Settings()
+
+    assert settings.interactive is True  # 回退到默认值
+
+
+def test_mode_cloud_alias_still_works(monkeypatch):
+    """mode=cloud 是 online 的历史别名，在 lenient 模式下应回退到默认值 online"""
+    monkeypatch.setenv("SWANLAB_MODE", "cloud")
+
+    settings = Settings()
+
+    assert settings.mode == "online"
+
+
+class TestStrictEnv:
+    """STRICT_ENV=True 时，环境变量解析错误应直接抛出（通过 patch 模块级常量控制）"""
+
+    def test_strict_complex_field_raises(self, monkeypatch):
+        monkeypatch.setattr("swanlab.sdk.internal.settings.STRICT_ENV", True)
+        monkeypatch.setenv("SWANLAB_RUN", "not-a-json")
+
+        with pytest.raises(Exception, match="run"):
+            Settings()
+
+    def test_strict_simple_field_raises(self, monkeypatch):
+        monkeypatch.setattr("swanlab.sdk.internal.settings.STRICT_ENV", True)
+        monkeypatch.setenv("SWANLAB_INTERACTIVE", "not-a-bool")
+
+        with pytest.raises(Exception):
+            Settings()
+
+    def test_strict_mode_cloud_works(self, monkeypatch):
+        """strict 模式下 mode=cloud 仍可通过 before-validator 转换为 online"""
+        monkeypatch.setattr("swanlab.sdk.internal.settings.STRICT_ENV", True)
+        monkeypatch.setenv("SWANLAB_MODE", "cloud")
+
+        settings = Settings()
+
+        assert settings.mode == "online"
+
+
 @pytest.fixture
 def netrc_file(tmp_path, monkeypatch):
     """

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -348,6 +348,16 @@ def test_nested_model_env_invalid_value_ignored(monkeypatch, field):
         assert settings.run.id is None
 
 
+@pytest.mark.parametrize("value", ["1", "42", "true", "[1,2,3]", '"hello"'])
+def test_nested_model_env_valid_json_but_not_dict_ignored(monkeypatch, value):
+    """嵌套模型字段收到合法 JSON 但非 dict（如 json.loads("1")=1）时也应跳过"""
+    monkeypatch.setenv("SWANLAB_RUN", value)
+
+    settings = Settings()
+
+    assert settings.run.id is None
+
+
 def test_nested_model_env_valid_json(monkeypatch):
     """嵌套模型字段接收合法 JSON 时仍应正常解析"""
     monkeypatch.setenv("SWANLAB_RUN", '{"id": "r-from-json"}')


### PR DESCRIPTION
## Summary

修复当环境变量直接映射到某个字段（嵌套模型或简单字段）但值无法解析时，`pydantic-settings` 抛出 `SettingsError`、导致**整个 `import swanlab` 崩溃**的问题。同时提供 `SWANLAB_STRICT_ENV` 开关，便于调试时切换为严格模式。

## 背景

`Settings` 中的 `run` / `project` / `experiment` / `terminal` / `integration` / `core` / `probe` 均为嵌套子模型（complex 字段）。当环境变量直接命中字段名本身时，`pydantic-settings` 会尝试 `json.loads()` 解析整个子模型，非 JSON 值即崩溃。简单字段（如 `bool`）的非法值则在模型构造阶段抛出 `ValidationError`。

## Changes

### `swanlab/sdk/internal/settings/__init__.py`

- 新增模块级常量 `STRICT_ENV`（读取 `SWANLAB_STRICT_ENV`，与 `SECRETS_DIR`/`CONFIG_DIR` 风格一致）
- 新增 `_TolerantEnvSettingsSource(EnvSettingsSource)`：
  - **复杂字段**：JSON 解析失败时，lenient 模式跳过并告警，strict 模式直接抛出
  - **简单字段**：lenient 模式通过 `TypeAdapter` 预校验类型，非法值跳过并告警；strict 模式交给模型校验（保留 `before-validator` 行为）
- 在 `settings_customise_sources` 中用该子类替换默认的 `env_settings`

### `tests/unit/sdk/internal/settings/test_settings.py`

- 嵌套模型字段非法值忽略（7 个字段参数化）
- 合法 JSON 解析、子字段不受影响
- 简单字段非法值忽略、`mode=cloud` 历史别名兼容
- `TestStrictEnv`：strict 模式下复杂/简单字段抛出、`mode=cloud` 仍正常

## 行为对照

| 场景 | lenient（默认） | strict（`SWANLAB_STRICT_ENV=1`） |
|---|---|---|
| `SWANLAB_RUN=hello`（复杂字段非法 JSON） | ✅ 跳过 + warning | ❌ 抛出 SettingsError |
| `SWANLAB_INTERACTIVE=notabool`（简单字段非法值） | ✅ 跳过 + warning | ❌ 抛出 ValidationError |
| `SWANLAB_RUN={"id":"x"}`（合法 JSON） | ✅ 正常解析 | ✅ 正常解析 |
| `SWANLAB_RUN_ID=xxx`（嵌套子字段） | ✅ 不受影响 | ✅ 不受影响 |
| `SWANLAB_MODE=cloud`（历史别名） | ✅ 回退默认 `online` | ✅ before-validator 转 `online` |

## 范围说明

- **仅环境变量源受开关控制**；YAML / `.env` 文件、init 参数（代码传参）的错误始终抛出
- `STRICT_ENV` 为模块级常量，import 后不变（与 `SECRETS_DIR`/`CONFIG_DIR` 一致）；测试通过 `monkeypatch.setattr` 控制
- `mode=cloud` 在 lenient 模式下被 `TypeAdapter` 拒绝（不在 Literal 中），但回退到默认值 `online`，与 before-validator 转换结果一致

## Testing

- `uv run pytest tests/unit/sdk/internal/settings/` → 78 passed
- `uv run ruff check` / `uv run basedpyright` → 通过
- `uv run pytest tests/unit/sdk/internal tests/unit/sdk/cmd/init/test_init_e2e.py` → 1335 passed（需 `SWANLAB_RUN_ID` 未设置）

## Notes

- `tests/unit/conftest.py` 的 autouse fixture 未清理 `SWANLAB_RUN_ID` 等环境变量，属于既有的测试隔离缺陷，与本 PR 无关，后续可单独修复