### PR TITLE
refactor: defer mimetypes import and register common MIME types

### DIFF
--- a/swanlab/sdk/internal/core_python/pkg/mime/__init__.py
+++ b/swanlab/sdk/internal/core_python/pkg/mime/__init__.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-import mimetypes as _std_mimetypes
+import functools
 import os
 from typing import Union
 
@@ -15,12 +15,39 @@ __all__ = ["guess_type"]
 
 _DEFAULT_MIME_TYPE = "application/octet-stream"
 
-# 注册 YAML 扩展到标准类型表（guess_type 默认只查标准表）
-# strict=True 会覆盖系统已有映射（源码直接赋值，不抛错），保证跨平台确定性
-_std_mimetypes.add_type("application/yaml", ".yaml")
-_std_mimetypes.add_type("application/yaml", ".yml")
+
+@functools.cache
+def _ensure_mimetypes():
+    """惰性导入 mimetypes 并注册自定义扩展，仅首次调用时执行。"""
+    import mimetypes as _std_mimetypes
+
+    # 注册扩展到标准类型表（guess_type 默认只查标准表）
+    # strict=True 会覆盖系统已有映射（源码直接赋值，不抛错），保证跨平台确定性
+    _std_mimetypes.add_type("application/yaml", ".yaml")
+    _std_mimetypes.add_type("application/yaml", ".yml")
+
+    # 图像类型：与前端 image/* 渲染器对齐，避免各平台 mime 差异
+    _std_mimetypes.add_type("image/png", ".png")
+    _std_mimetypes.add_type("image/jpeg", ".jpg")
+    _std_mimetypes.add_type("image/jpeg", ".jpeg")
+    _std_mimetypes.add_type("image/gif", ".gif")
+    _std_mimetypes.add_type("image/bmp", ".bmp")
+    _std_mimetypes.add_type("image/webp", ".webp")
+    _std_mimetypes.add_type("image/svg+xml", ".svg")
+    _std_mimetypes.add_type("image/svg+xml", ".svgz")
+    _std_mimetypes.add_type("image/tiff", ".tiff")
+    _std_mimetypes.add_type("image/tiff", ".tif")
+
+    # 代码 / 文本类型：与前端 CodeRender / MarkdownRender 对齐
+    _std_mimetypes.add_type("text/x-python", ".py")
+    _std_mimetypes.add_type("text/plain", ".txt")
+    _std_mimetypes.add_type("application/json", ".json")
+    _std_mimetypes.add_type("text/markdown", ".md")
+    _std_mimetypes.add_type("text/markdown", ".markdown")
+
+    return _std_mimetypes
 
 
 def guess_type(path: Union[str, "os.PathLike[str]"]) -> str:
     """根据文件路径推断 MIME 类型，无法识别时回退到 application/octet-stream。"""
-    return _std_mimetypes.guess_type(os.fspath(path))[0] or _DEFAULT_MIME_TYPE
+    return _ensure_mimetypes().guess_type(os.fspath(path))[0] or _DEFAULT_MIME_TYPE


### PR DESCRIPTION
## Summary

将 `mimetypes` 模块的导入从模块级别改为惰性加载（`@functools.cache`），减少 SDK 初始化时的导入开销。同时补充注册了图像和代码/文本类 MIME 类型，与前端渲染器保持一致，避免因平台差异导致的 MIME 识别不一致。

## Changes

- `swanlab/sdk/internal/core_python/pkg/mime/__init__.py`
  - 新增 `_ensure_mimetypes()` 函数，使用 `@functools.cache` 实现惰性导入和 MIME 注册
  - 补充注册图像类型（png, jpg, gif, bmp, webp, svg, tiff 等）的 MIME 映射
  - 补充注册代码/文本类型（py, txt, json, md）的 MIME 映射
  - `guess_type()` 改为调用 `_ensure_mimetypes()` 获取类型表

## Testing

未运行测试。

## Notes

- 惰性导入不改变原有行为，向后兼容
- 新增的 MIME 注册与前端 `image/*` 渲染器、`CodeRender`、`MarkdownRender` 对齐