### PR TITLE
chore: add pr-review-lab skill and fix CI test path

### DIFF
--- a/.github/workflows/test-python-pr.yml
+++ b/.github/workflows/test-python-pr.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - "swanlab/**"
-      - "test/**"
+      - "tests/**"
       - "pyproject.toml"
       - "uv.lock"
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ LightningTest/
 CLAUDE.md
 AGENTS.md
 FEATURE_SUMMARY.md
+.agents/
 .claude/
 .skill/
 GEMINI.md
@@ -60,3 +61,6 @@ QWEN.md
 .opencode/
 CODEBUDDY.md
 .codegraph/
+.mimocode/
+.grok/
+.reasonix/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+SKILL_NAME := pr-review-lab
+SKILL_SOURCE := $(CURDIR)/docs/skills/$(SKILL_NAME)
+AGENTS_SKILL_DIR := $(CURDIR)/.agents/skills
+AGENTS_SKILL_LINK := $(AGENTS_SKILL_DIR)/$(SKILL_NAME)
+
 .PHONY:  init sync format proto unit bench clean build
 
 init:
@@ -38,3 +43,24 @@ publish:
 
 clean:
 	@bash scripts/clean_pycache.sh .
+
+link-skills:
+	@if [ ! -d "$(SKILL_SOURCE)" ]; then \
+		echo "Missing skill source: $(SKILL_SOURCE)"; \
+		exit 1; \
+	fi
+	@mkdir -p "$(AGENTS_SKILL_DIR)"
+	@if [ -e "$(AGENTS_SKILL_LINK)" ] && [ ! -L "$(AGENTS_SKILL_LINK)" ]; then \
+		echo "Refusing to replace non-symlink: $(AGENTS_SKILL_LINK)"; \
+		exit 1; \
+	fi
+	@ln -sfn "$(SKILL_SOURCE)" "$(AGENTS_SKILL_LINK)"
+
+unlink-skills:
+	@if [ -L "$(AGENTS_SKILL_LINK)" ]; then \
+		rm "$(AGENTS_SKILL_LINK)"; \
+	fi
+
+relink-skills:
+	@$(MAKE) unlink-skills
+	@$(MAKE) link-skills

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 SKILL_NAME := pr-review-lab
-SKILL_SOURCE := $(CURDIR)/docs/skills/$(SKILL_NAME)
-AGENTS_SKILL_DIR := $(CURDIR)/.agents/skills
+SKILL_SOURCE := docs/skills/$(SKILL_NAME)
+AGENTS_SKILL_DIR := .agents/skills
 AGENTS_SKILL_LINK := $(AGENTS_SKILL_DIR)/$(SKILL_NAME)
+# symlink target relative to AGENTS_SKILL_DIR, so the link stays valid if the repo moves
+SKILL_LINK_TARGET := ../../$(SKILL_SOURCE)
 
-.PHONY:  init sync format proto unit bench clean build
+.PHONY:  init sync format proto unit bench clean build publish link-skills unlink-skills relink-skills
 
 init:
 	uv sync --all-extras
@@ -54,13 +56,11 @@ link-skills:
 		echo "Refusing to replace non-symlink: $(AGENTS_SKILL_LINK)"; \
 		exit 1; \
 	fi
-	@ln -sfn "$(SKILL_SOURCE)" "$(AGENTS_SKILL_LINK)"
+	@ln -sfn "$(SKILL_LINK_TARGET)" "$(AGENTS_SKILL_LINK)"
 
 unlink-skills:
 	@if [ -L "$(AGENTS_SKILL_LINK)" ]; then \
 		rm "$(AGENTS_SKILL_LINK)"; \
 	fi
 
-relink-skills:
-	@$(MAKE) unlink-skills
-	@$(MAKE) link-skills
+relink-skills: unlink-skills link-skills

--- a/docs/skills/pr-review-lab/SKILL.md
+++ b/docs/skills/pr-review-lab/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: pr-review-lab
+description: Use when reviewing SwanLab Python SDK PRs, running gh pr diff or gh pr review, checking public API/type stubs/run lifecycle/settings/API/CLI/transport/concurrency/integrations/media/protobuf/packaging/Python compatibility changes, or gating SDK merge readiness.
+---
+
+# PR 审核 (SwanLab)
+
+## 概述
+
+按照 SwanLab Python SDK 的仓库约定审核 Pull Request，并用 `gh` CLI 提交结构化结论。重点确认变更不引入公共 API、运行生命周期、数据上传、配置认证、跨平台兼容、安全、性能、构建和可维护性回归。
+
+技术栈：**Python 3.9-3.14**、**uv**、**Hatch**、**pytest**、**Ruff**、**basedpyright**、**Pydantic**、**requests**、**Protobuf**。
+
+适用：SwanLab SDK PR 合并前审核、`gh pr diff` / `gh pr review`、检查 SDK/API/CLI/集成/Proto/依赖/测试变更。
+
+不适用：SwanLab-Cloud 前端 PR、其他仓库 PR、无 PR 上下文的单文件编辑、只要求解释代码。
+
+## 审核流程
+
+1. 先确认 PR 意图、base 分支、head 分支、文件列表和 Actions 状态，再阅读实现。
+
+```bash
+gh pr view <PR>
+gh pr view <PR> --json files,additions,deletions,baseRefName,headRefName
+gh pr diff <PR>
+gh pr checks <PR>
+```
+
+2. 根据文件列表判断适用领域，并按“范围参考”读取相关契约。所有应用代码都要检查横切质量；涉及凭据、网络、文件或用户数据时额外检查安全与隐私。
+3. 对关键发现检查 head 分支中的完整文件和调用关系，不只依据 diff 片段。
+4. 对照仓库现有实现、测试和公开契约定级。个人风格偏好不能作为阻塞问题。
+5. 复杂 PR 可并行从“仓库约定与影响范围”和“正确性、安全、性能与验证”两个视角审核；小 PR 无需拆分。
+
+## 独立审核原则
+
+- 每次审核以当前 base、head、diff、实际文件和 PR Actions 为准。
+- 历史 review、评论和审批状态只作为线索，finding 必须在当前代码上重新验证。
+- 已修复的问题不重复提出；仍存在的问题按当前影响重新定级。
+- PR 作者和外部 reviewer 使用相同标准。平台不允许提交 `APPROVE` 或 `REQUEST_CHANGES` 时，使用 `COMMENT`，正文仍写明实际结论。
+
+## 范围参考
+
+详细规则位于 [`references/domain-contracts.md`](references/domain-contracts.md)。先读取 PR 文件列表，再按下表加载适用章节。
+
+| 变更路径或内容 | 读取章节 |
+|---|---|
+| `swanlab/__init__.py`、`swanlab/__init__.pyi`、`swanlab/sdk/__init__.py`、`swanlab/sdk/typings/**` | 公共 API 与类型兼容 |
+| `swanlab/sdk/cmd/**`、`swanlab/sdk/internal/run/**`、`context/**`、`bus/**` | Run 生命周期与运行时组件 |
+| `swanlab/sdk/internal/core_python/**`、`transport/**`、`store/**` | Record、Core 与传输 |
+| `swanlab/sdk/internal/settings/**`、`pkg/client/**`、`pkg/nrc/**` | 配置、认证与 HTTP 客户端 |
+| `swanlab/api/**`、`swanlab/cli/**` | Public API 与 CLI |
+| `swanlab/sdk/internal/run/transforms/**`、文件保存和媒体处理 | 媒体、转换与文件 |
+| `swanlab/integration/**`、`swanlab/converter/**`、`swanlab/plugin/**` | 集成、转换器与插件 |
+| `protos/**`、`swanlab/proto/**`、`core/proto/**` | Protobuf 与生成代码 |
+| `pyproject.toml`、`uv.lock`、`Makefile`、`.github/workflows/**` | 构建、依赖与发布 |
+| `tests/**` | 测试与验证 |
+| 所有 Python 代码、配置和依赖 | 横切质量与代码规范 |
+| 凭据、网络、日志、文件路径、用户数据 | 安全与隐私 |
+
+## 验证要求
+
+优先运行与改动直接相关的测试，再根据范围执行完整门禁：
+
+```bash
+uv run pytest <相关测试路径>
+uv run ruff check .
+uv run basedpyright
+uv run pytest
+```
+
+涉及打包、依赖或版本逻辑时补充：
+
+```bash
+uv build
+```
+
+涉及 `.proto` 时，确认源定义与 Python/Go 生成代码同步；具备完整工具链时在干净或临时工作区运行：
+
+```bash
+make proto
+```
+
+CI 覆盖 Ubuntu、Windows、macOS 和 Python 3.9-3.14。无法在本地覆盖的环境以 PR Actions 为准；Action 未运行或失败时必须如实记录，不能视为通过。
+
+## 严重性
+
+| 前缀 | 含义 | 示例 |
+|---|---|---|
+| **阻塞:** | 阻塞合并 | 凭据泄露、数据丢失、公共 API 严重破坏、发布产物不可用 |
+| **必须修改:** | 合并前必须处理 | 类型契约不同步、生命周期错误、竞态、兼容性回归、必要测试缺失 |
+| **建议:** | 值得改进但通常不阻塞 | 局部可维护性、命名、适度简化 |
+| **细节:** | 次要问题 | 小范围风格或文档问题 |
+| **说明:** | 信息记录，不要求行动 | 验证限制、后续风险或上下文 |
+
+每条 finding 必须使用显式前缀，并说明问题、影响和建议。不要用无前缀文本表达必须修改的问题。
+
+## 提交审核
+
+优先把可行动 finding 提交为 PR diff 上的 inline review comment。顶层 review body 只放总体结论、审核范围、验证结果和无法挂到 diff 行的问题，不重复 inline finding。
+
+### 选择提交方式
+
+- 无 finding 或只需总评：使用 `gh pr review --approve/--comment --body-file`。
+- 有可定位 finding：通过 Reviews API 在一次 review 中提交 `comments[]`。
+- 有阻塞或必须修改 finding：使用 `REQUEST_CHANGES`。
+- 只有建议、细节或说明：使用 `COMMENT`。
+- 无可行动 finding 且验证通过：使用 `APPROVE`。
+
+### 定位 inline comment
+
+```bash
+gh pr diff <PR> --patch --color=never
+```
+
+- 新增或修改后的代码使用 `side: "RIGHT"` 和新文件行号。
+- 删除导致的问题使用 `side: "LEFT"` 和旧文件行号。
+- 只评论 diff 中存在的行；跨文件问题或目标行不在 diff 时写入顶层正文。
+- 每条 inline comment 只包含一个 finding。
+
+### 提交 inline review
+
+```bash
+gh api --method POST repos/{owner}/{repo}/pulls/<PR>/reviews --input /tmp/pr-review.json
+```
+
+Review JSON 使用以下结构：
+
+```json
+{
+  "event": "REQUEST_CHANGES",
+  "body": "## 审核结论: 要求修改\n\n## 本次 PR 解决的问题\n<一句话概述>\n\n## 审核范围\n<范围清单>\n\n## 未挂行发现\n<没有则写：无>\n\n## 验证\n<命令与 Actions 状态>",
+  "comments": [
+    {
+      "path": "swanlab/path/file.py",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "**必须修改:** <问题>\n\n影响：<影响>\n\n建议：<建议>"
+    }
+  ]
+}
+```
+
+### 顶层正文结构
+
+```markdown
+## 审核结论: 通过 / 要求修改 / 评论
+
+## 本次 PR 解决的问题
+<一句话概述>
+
+## 审核范围
+- [x] 公共 API 与类型兼容: <详情>
+- [x] Run 生命周期与运行时: <详情>
+- [x] Record、Core 与传输: <详情>
+- [x] 配置、认证、API 与 CLI: <详情>
+- [x] 媒体、集成与插件: <详情>
+- [x] Protobuf、构建与依赖: <详情>
+- [x] 安全、性能与跨平台兼容: <详情>
+- [x] 测试与验证: <详情>
+
+## 未挂行发现
+<没有则写：无>
+
+## 验证
+- [ ] 相关测试
+- [ ] uv run ruff check .
+- [ ] uv run basedpyright
+- [ ] uv run pytest
+- [ ] PR Actions 已通过，或已记录未运行/失败状态
+```
+
+没有 inline finding 时使用正文文件提交：
+
+```bash
+gh pr review <PR> --request-changes --body-file /tmp/pr-review-body.md
+gh pr review <PR> --approve --body-file /tmp/pr-review-body.md
+gh pr review <PR> --comment --body-file /tmp/pr-review-body.md
+```
+
+## 完成验证
+
+- [ ] 当前 PR 意图、base、head 和文件范围已确认
+- [ ] 所有适用领域和横切质量已审核
+- [ ] 阻塞和必须修改 finding 已解决或明确记录
+- [ ] 本地验证结果和 PR Actions 状态已记录
+- [ ] 可定位 finding 已提交为 inline comments
+- [ ] 最终 review 已通过 Reviews API 或 `gh pr review` 提交

--- a/docs/skills/pr-review-lab/SKILL.md
+++ b/docs/skills/pr-review-lab/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review-lab
-description: Use when reviewing SwanLab Python SDK PRs, running gh pr diff or gh pr review, checking public API/type stubs/run lifecycle/settings/API/CLI/transport/concurrency/integrations/media/protobuf/packaging/Python compatibility changes, or gating SDK merge readiness.
+description: Use when reviewing SwanLab Python SDK PRs, running gh pr diff or gh pr review, checking public API/type stubs/run lifecycle/settings/API/CLI/transport/concurrency/integrations/media/probe/protobuf/packaging/Python compatibility changes, or gating SDK merge readiness. Reviews locally first and only posts to GitHub after the user confirms.
 ---
 
 # PR 审核 (SwanLab)
@@ -17,6 +17,10 @@ description: Use when reviewing SwanLab Python SDK PRs, running gh pr diff or gh
 
 ## 审核流程
 
+审核分为两个阶段，**默认只执行阶段一**。未获得用户明确确认前，不得向 GitHub 提交任何 review、comment 或审批状态。
+
+### 阶段一：审查（默认）
+
 1. 先确认 PR 意图、base 分支、head 分支、文件列表和 Actions 状态，再阅读实现。
 
 ```bash
@@ -26,10 +30,34 @@ gh pr diff <PR>
 gh pr checks <PR>
 ```
 
-2. 根据文件列表判断适用领域，并按“范围参考”读取相关契约。所有应用代码都要检查横切质量；涉及凭据、网络、文件或用户数据时额外检查安全与隐私。
-3. 对关键发现检查 head 分支中的完整文件和调用关系，不只依据 diff 片段。
-4. 对照仓库现有实现、测试和公开契约定级。个人风格偏好不能作为阻塞问题。
-5. 复杂 PR 可并行从“仓库约定与影响范围”和“正确性、安全、性能与验证”两个视角审核；小 PR 无需拆分。
+2. 把 head 分支拉到本地隔离工作区再审核，不要污染用户当前工作区：
+
+```bash
+git fetch origin pull/<PR>/head:pr-<PR>
+git worktree add ../swanlab-pr-<PR> pr-<PR>
+```
+
+无法建立 worktree 时可用 `gh pr checkout <PR>`，但必须先确认当前工作区干净，并在结束后切回原分支。
+
+3. 根据文件列表判断适用领域，并按“范围参考”读取相关契约。所有应用代码都要检查横切质量；涉及凭据、网络、文件或用户数据时额外检查安全与隐私。
+4. 对关键发现检查 head 分支中的完整文件和调用关系，不只依据 diff 片段。
+5. 对照仓库现有实现、测试和公开契约定级。个人风格偏好不能作为阻塞问题。
+6. 复杂 PR 可并行从“仓库约定与影响范围”和“正确性、安全、性能与验证”两个视角审核；小 PR 无需拆分。
+7. 在对话中输出完整审查意见草稿：结论、逐条 finding（含文件与行号）、验证结果。**到此停止**，明确告知用户尚未发布，并询问是否发布。
+
+### 阶段二：发布（需用户显式确认）
+
+仅当用户在阶段一之后明确要求发布（如“发布”“提交 review”“post”）时才执行“提交审核”一节的命令。
+
+- 用户只是要求审查、看意见或讨论时，一律停在阶段一。
+- 用户要求修改草稿时，更新草稿后重新征求确认，不要顺带发布。
+- 发布前把最终结论和 `event` 类型（`APPROVE` / `REQUEST_CHANGES` / `COMMENT`）复述给用户确认，避免审批状态与用户意图不符。
+- 发布后回报 review 链接，并清理临时 worktree 和本地分支：
+
+```bash
+git worktree remove ../swanlab-pr-<PR>
+git branch -D pr-<PR>
+```
 
 ## 独立审核原则
 
@@ -40,22 +68,27 @@ gh pr checks <PR>
 
 ## 范围参考
 
-详细规则位于 [`references/domain-contracts.md`](references/domain-contracts.md)。先读取 PR 文件列表，再按下表加载适用章节。
+详细规则位于 [`references/domain-contracts.md`](references/domain-contracts.md)。先读取 PR 文件列表，再按下表加载适用章节。路径一律写完整前缀；同一文件命中多行时，读取所有命中章节。
 
 | 变更路径或内容 | 读取章节 |
 |---|---|
-| `swanlab/__init__.py`、`swanlab/__init__.pyi`、`swanlab/sdk/__init__.py`、`swanlab/sdk/typings/**` | 公共 API 与类型兼容 |
-| `swanlab/sdk/cmd/**`、`swanlab/sdk/internal/run/**`、`context/**`、`bus/**` | Run 生命周期与运行时组件 |
-| `swanlab/sdk/internal/core_python/**`、`transport/**`、`store/**` | Record、Core 与传输 |
-| `swanlab/sdk/internal/settings/**`、`pkg/client/**`、`pkg/nrc/**` | 配置、认证与 HTTP 客户端 |
+| `swanlab/__init__.py`、`swanlab/__init__.pyi`、`swanlab/sdk/__init__.py`、`swanlab/sdk/typings/**`、`swanlab/sdk/protocol/**`、`swanlab/exceptions.py` | 公共 API 与类型兼容 |
+| `swanlab/sdk/cmd/**`、`swanlab/sdk/internal/run/**`、`swanlab/sdk/internal/context/**`、`swanlab/sdk/internal/bus/**`、`swanlab/sdk/internal/impl.py` | Run 生命周期与运行时组件 |
+| `swanlab/sdk/internal/core_python/**`（含 `transport/**`、`store/**`、`metrics/**`、`watcher/**`、`sync.py`） | Record、Core 与传输 |
+| `swanlab/sdk/internal/settings/**`、`swanlab/sdk/internal/pkg/client/**`、`swanlab/sdk/internal/pkg/nrc/**`、`swanlab/sdk/internal/core_python/client/**`、`swanlab/sdk/internal/core_python/api/**` | 配置、认证与 HTTP 客户端 |
 | `swanlab/api/**`、`swanlab/cli/**` | Public API 与 CLI |
 | `swanlab/sdk/internal/run/transforms/**`、文件保存和媒体处理 | 媒体、转换与文件 |
+| `swanlab/sdk/internal/probe_python/**`（含 `hardware_vendor/**`、`monitor/**`、`environment/**`）、`swanlab/vendor/**` | 硬件与环境探测 |
 | `swanlab/integration/**`、`swanlab/converter/**`、`swanlab/plugin/**` | 集成、转换器与插件 |
+| `swanlab/sdk/internal/pkg/**`（`safe/`、`fs/`、`console/`、`fork/`、`timer/`、`executor/`、`scope/`、`adapter/` 等）、`swanlab/utils/**` | 共享工具与内部 pkg |
 | `protos/**`、`swanlab/proto/**`、`core/proto/**` | Protobuf 与生成代码 |
-| `pyproject.toml`、`uv.lock`、`Makefile`、`.github/workflows/**` | 构建、依赖与发布 |
+| `pyproject.toml`、`uv.lock`、`Makefile`、`swanlab/package.json`、`.github/workflows/**` | 构建、依赖与发布 |
 | `tests/**` | 测试与验证 |
+| `swanlab/deprecated/**` | 公共 API 与类型兼容 + 横切质量与代码规范 |
 | 所有 Python 代码、配置和依赖 | 横切质量与代码规范 |
 | 凭据、网络、日志、文件路径、用户数据 | 安全与隐私 |
+
+上表未命中的路径仍需按“横切质量与代码规范”审核，并在 review 中说明该文件按通用标准处理。
 
 ## 验证要求
 
@@ -94,7 +127,9 @@ CI 覆盖 Ubuntu、Windows、macOS 和 Python 3.9-3.14。无法在本地覆盖�
 
 每条 finding 必须使用显式前缀，并说明问题、影响和建议。不要用无前缀文本表达必须修改的问题。
 
-## 提交审核
+## 提交审核（仅阶段二）
+
+本节所有命令都属于发布动作，**只有在用户明确确认后才执行**。阶段一只在对话中给出草稿。
 
 优先把可行动 finding 提交为 PR diff 上的 inline review comment。顶层 review body 只放总体结论、审核范围、验证结果和无法挂到 diff 行的问题，不重复 inline finding。
 
@@ -179,9 +214,18 @@ gh pr review <PR> --comment --body-file /tmp/pr-review-body.md
 
 ## 完成验证
 
+阶段一（审查）：
+
 - [ ] 当前 PR 意图、base、head 和文件范围已确认
+- [ ] head 分支已拉到本地隔离工作区，关键发现在完整文件上验证
 - [ ] 所有适用领域和横切质量已审核
 - [ ] 阻塞和必须修改 finding 已解决或明确记录
 - [ ] 本地验证结果和 PR Actions 状态已记录
+- [ ] 审查意见草稿已输出，并已明确告知用户尚未发布
+
+阶段二（发布，需用户确认）：
+
+- [ ] 用户已明确要求发布，且已确认 `event` 类型
 - [ ] 可定位 finding 已提交为 inline comments
 - [ ] 最终 review 已通过 Reviews API 或 `gh pr review` 提交
+- [ ] 临时 worktree 和本地分支已清理

--- a/docs/skills/pr-review-lab/references/domain-contracts.md
+++ b/docs/skills/pr-review-lab/references/domain-contracts.md
@@ -6,7 +6,7 @@
 
 ## 公共 API 与类型兼容
 
-适用路径：`swanlab/__init__.py`、`swanlab/__init__.pyi`、`swanlab/sdk/__init__.py`、`swanlab/sdk/typings/**` 及公开类和函数。
+适用路径：`swanlab/__init__.py`、`swanlab/__init__.pyi`、`swanlab/sdk/__init__.py`、`swanlab/sdk/typings/**`、`swanlab/sdk/protocol/**`、`swanlab/exceptions.py`、`swanlab/deprecated/**` 及公开类和函数。
 
 - 顶层运行时导出、`__all__` 和 `swanlab/__init__.pyi` 保持同步。
 - 新增或修改公开参数时检查默认值、返回值、异常、文档和类型签名是否一致。
@@ -16,7 +16,7 @@
 
 ## Run 生命周期与运行时组件
 
-适用路径：`swanlab/sdk/cmd/**`、`swanlab/sdk/internal/run/**`、`swanlab/sdk/internal/context/**`、`swanlab/sdk/internal/bus/**`。
+适用路径：`swanlab/sdk/cmd/**`、`swanlab/sdk/internal/run/**`、`swanlab/sdk/internal/context/**`、`swanlab/sdk/internal/bus/**`、`swanlab/sdk/internal/impl.py`。
 
 - `init`、`log`、`finish` 和 reinit 的状态转换清晰，失败路径不会遗留半初始化的全局状态。
 - `online`、`offline`、`local`、`disabled` 四种模式保持各自边界；disabled 模式不应产生不必要的网络或文件副作用。
@@ -39,7 +39,7 @@
 
 ## 配置、认证与 HTTP 客户端
 
-适用路径：`swanlab/sdk/internal/settings/**`、`swanlab/sdk/internal/pkg/client/**`、`swanlab/sdk/internal/pkg/nrc/**`。
+适用路径：`swanlab/sdk/internal/settings/**`、`swanlab/sdk/internal/pkg/client/**`、`swanlab/sdk/internal/pkg/nrc/**`、`swanlab/sdk/internal/core_python/client/**`、`swanlab/sdk/internal/core_python/api/**`。
 
 - 保持 Settings 声明的配置源优先级；有意调整时同步兼容测试和用户文档。
 - Settings 负责类型、格式和默认值；目录创建、网络请求等业务副作用留在初始化阶段。
@@ -68,6 +68,30 @@
 - 文件句柄、临时文件、watcher、线程和大对象有释放路径。
 - 大文件和批量媒体避免一次性读入内存，并遵守上传大小、分片和批次限制。
 - `save` 的 glob、base path、符号链接和跨平台路径不能越过预期边界或上传错误文件。
+
+## 硬件与环境探测
+
+适用路径：`swanlab/sdk/internal/probe_python/**`（含 `hardware_vendor/**`、`monitor/**`、`environment/**`、`protocol/**`）、`swanlab/vendor/**`。
+
+- 第三方厂商 SDK、驱动或命令行工具缺失时降级为“不可用”，不能让 `import swanlab` 或 `init` 失败。
+- 厂商探测按已有约定判定可用性；探测失败、超时和权限不足都走统一的失败路径，不打断 Run。
+- 监控线程有明确的启动、采样间隔和停止路径；Run finish 后不残留线程或子进程。
+- 采集结果的字段名、单位和数据类型保持稳定，避免破坏云端已有的硬件面板。
+- 探测调用外部命令时限制超时、不拼接不可信输入，且不在日志中输出完整命令输出。
+- 环境采集（git、conda、requirements、runtime）只收集产品需要的信息；参见“安全与隐私”。
+- 探测层直接调用 Core，不经事件总线；改动时确认写入时机仍在 Run 就绪之后。
+- 新增厂商时补充无依赖环境下的隔离测试，不依赖真实硬件。
+
+## 共享工具与内部 pkg
+
+适用路径：`swanlab/sdk/internal/pkg/**`（`safe/`、`fs/`、`console/`、`fork/`、`timer/`、`executor/`、`scope/`、`adapter/`、`constraints/`、`helper/` 等）、`swanlab/utils/**`。
+
+- 这些是被多层复用的公共工具，改动前确认全部调用点，评估影响范围而不只看本地语义。
+- `safe` 系列的错误吞噬边界保持明确；不要用它掩盖应当上抛的错误，也不要留空 catch。
+- 文件、路径和控制台工具保持 Windows/POSIX 与编码兼容，不假设 UTF-8 终端或 POSIX 路径分隔符。
+- 线程、executor、timer 和 scope 工具的资源在异常路径同样释放；不引入全局可变状态。
+- 工具函数保持无副作用和可测试；导入期不做网络、文件写入或线程启动。
+- 修改共享工具时同步更新既有单测，并覆盖调用方的关键路径。
 
 ## 集成、转换器与插件
 

--- a/docs/skills/pr-review-lab/references/domain-contracts.md
+++ b/docs/skills/pr-review-lab/references/domain-contracts.md
@@ -1,0 +1,134 @@
+# SwanLab 领域审核契约
+
+先根据 PR 文件列表判断适用范围，只读取与变更相关的章节。所有 Python 应用代码还需检查“横切质量与代码规范”；涉及凭据、网络、日志、文件路径或用户数据时，再检查“安全与隐私”。
+
+未命中具体章节的变更仍需结合调用关系、相邻模块和测试判断。本文没有定义的项目契约不得自行推断为硬性规则。
+
+## 公共 API 与类型兼容
+
+适用路径：`swanlab/__init__.py`、`swanlab/__init__.pyi`、`swanlab/sdk/__init__.py`、`swanlab/sdk/typings/**` 及公开类和函数。
+
+- 顶层运行时导出、`__all__` 和 `swanlab/__init__.pyi` 保持同步。
+- 新增或修改公开参数时检查默认值、返回值、异常、文档和类型签名是否一致。
+- 已发布 API 的删除、重命名或语义变化需要兼容或明确的弃用路径，不能静默破坏用户代码。
+- 保持 Python 3.9-3.14 可用，不引入只在单一 Python 版本成立的行为。
+- 修改 `swanlab.run`、`get_run()` 等动态属性时覆盖初始化前、运行中和结束后的行为。
+
+## Run 生命周期与运行时组件
+
+适用路径：`swanlab/sdk/cmd/**`、`swanlab/sdk/internal/run/**`、`swanlab/sdk/internal/context/**`、`swanlab/sdk/internal/bus/**`。
+
+- `init`、`log`、`finish` 和 reinit 的状态转换清晰，失败路径不会遗留半初始化的全局状态。
+- `online`、`offline`、`local`、`disabled` 四种模式保持各自边界；disabled 模式不应产生不必要的网络或文件副作用。
+- 运行时组件按依赖顺序启动、按反向顺序停止；停止时先完成异步任务和末尾事件，再关闭消费者。
+- terminal proxy、后台线程、executor、watcher、signal 和 atexit hook 都有确定的安装与清理路径。
+- 主线程、非主线程、fork/spawn、异常退出和重复 finish 场景不能死锁、重复上传或丢失数据。
+- 修改全局或上下文状态时检查多线程和 asyncio 隔离。
+
+## Record、Core 与传输
+
+适用路径：`swanlab/sdk/internal/core_python/**`、`transport/**`、`store/**`、Record builder 和 consumer。
+
+- Record 保持可顺序写入、读取、重放和断点续传；序号、批次和完成状态不能倒退或重复计数。
+- scalar、media、column、config、log、save 和生命周期记录的转换链路保持完整。
+- 上传重试责任不能在多层重复：上传 API 使用既定请求策略，sender 决定可重试错误，transport 负责批次重试。
+- 当前契约中 5xx/基础设施错误应允许 transport 重试，4xx 业务拒绝不应无界重试；不能用宽泛异常吞掉需要上抛的错误。
+- 成功、部分失败和最终失败时，tracker、buffer、落盘状态与实际上传结果一致。
+- 批处理、队列和并发上传应有边界，避免大数据量下无界内存、忙等、锁竞争或线程泄漏。
+- 文件与媒体上传检查 Windows/POSIX 路径、跨机器 sync、重复上传和幂等行为。
+
+## 配置、认证与 HTTP 客户端
+
+适用路径：`swanlab/sdk/internal/settings/**`、`swanlab/sdk/internal/pkg/client/**`、`swanlab/sdk/internal/pkg/nrc/**`。
+
+- 保持 Settings 声明的配置源优先级；有意调整时同步兼容测试和用户文档。
+- Settings 负责类型、格式和默认值；目录创建、网络请求等业务副作用留在初始化阶段。
+- `merge_settings` 只合并用户显式设置字段，嵌套配置不能被意外整块覆盖。
+- API host、web host、环境变量、YAML、Secret 和 netrc 的回退关系明确，切换 host 时不能复用错误凭据。
+- HTTP 请求设置合理的 timeout、retry 和错误映射；请求级上下文在成功和异常后都要恢复。
+- 日志和异常不能暴露 API key、认证 token、cookie、presigned URL 或完整敏感响应。
+
+## Public API 与 CLI
+
+适用路径：`swanlab/api/**`、`swanlab/cli/**`。
+
+- API 输入校验、分页、迭代器、空值、过滤条件和错误类型保持稳定。
+- API 与 CLI 复用统一的客户端、host 和认证逻辑，不在命令中复制请求实现。
+- CLI 的参数名、别名、默认值、帮助文本、输出和退出码保持兼容。
+- 非交互环境不能意外等待输入；密码和 API key 输入不得明文回显。
+- self-hosted 与默认云端地址的请求和展示链接不能混用。
+
+## 媒体、转换与文件
+
+适用路径：`swanlab/sdk/internal/run/transforms/**`、媒体类型、`save`、文件 watcher 和上传逻辑。
+
+- Image、Audio、Video、Text、Html、ECharts、Object3D、Molecule 的输入类型、输出文件和 Record 元数据一致。
+- 可选依赖应按需加载；未安装媒体或框架依赖时不能影响基础 `import swanlab`。
+- 文件名、扩展名、MIME、大小、hash、caption 和 step 在转换与上传链路中不丢失。
+- 文件句柄、临时文件、watcher、线程和大对象有释放路径。
+- 大文件和批量媒体避免一次性读入内存，并遵守上传大小、分片和批次限制。
+- `save` 的 glob、base path、符号链接和跨平台路径不能越过预期边界或上传错误文件。
+
+## 集成、转换器与插件
+
+适用路径：`swanlab/integration/**`、`swanlab/converter/**`、`swanlab/plugin/**`。
+
+- 第三方框架未安装时保持基础包可导入，并提供清晰错误而非导入期崩溃。
+- 框架 callback 只在正确进程或 rank 记录，避免重复初始化、重复 step 和重复 finish。
+- monkey patch 保留原库行为，重复调用尽量幂等，并明确安装时机和生命周期。
+- 第三方配置和指标转换保留关键字段、step、命名空间和数据类型。
+- callback 的异步任务在 Python shutdown 和 Run finish 时不会静默丢失。
+- 新增集成或插件时补充对应隔离测试，不依赖真实外部服务。
+
+## Protobuf 与生成代码
+
+适用路径：`protos/**`、`swanlab/proto/**`、`core/proto/**`、`scripts/generate_protos.py`。
+
+- `protos/**` 是协议源；变更后同步提交 Python 和 Go 生成代码。
+- 已发布 `v1` 消息保持向后兼容，不复用或改变已有字段号和枚举值语义。
+- Record 顶层信封和 append-only 日志保持旧记录可解析、可跳过未知字段。
+- 媒体和文件仍通过路径与元数据引用，不把大二进制意外内联进 Record。
+- 修改生成脚本时检查导入路径修复、`.pyi` 生成和 package `__init__.py`。
+
+## 构建、依赖与发布
+
+适用路径：`pyproject.toml`、`uv.lock`、`Makefile`、`swanlab/package.json`、`.github/workflows/**`。
+
+- 依赖变更同步 `pyproject.toml` 与 `uv.lock`，区分核心依赖、dev dependency 和 optional extra。
+- 基础安装不能强制引入只服务于单个媒体类型或第三方框架的重依赖。
+- wheel 包含公共 stub、Proto 和运行时所需资源；版本仍由既定单一来源读取。
+- 发布和构建修改检查 tag 解析、版本写入、wheel 产物和 PyPI/GitHub Release 流程。
+- 保持 Linux、Windows、macOS 与 Python 3.9-3.14 的语法、路径、编码和依赖兼容。
+
+## 测试与验证
+
+适用路径：`tests/**`、pytest 配置和 CI workflow。
+
+- 行为变更应在对应 `tests/unit` 路径增加回归测试，测试目录与源码模块尽量对应。
+- 默认使用 mock、`tmp_path` 和 disabled/local 模式隔离真实网络、用户凭据和全局文件。
+- 生命周期、并发、重试、跨平台路径和兼容性变更同时覆盖成功与失败路径。
+- 测试清理全局 Settings、Run、环境变量、线程、patch 和文件，避免依赖执行顺序。
+- 本地验证结果不能替代 CI 的操作系统和 Python 版本矩阵。
+
+## 横切质量与代码规范
+
+适用路径：所有 Python 代码、配置和依赖变更。
+
+- 从正确性、兼容性、可读性、架构、安全和性能判断具体回归，不以个人偏好提出 finding。
+- 以 `pyproject.toml` 中 Ruff、basedpyright 和 pytest 配置为准，不另造格式规则。
+- 新代码保持类型清晰；`Any`、`cast`、`type: ignore` 和宽泛异常必须有具体理由和最小作用域。
+- 避免导入期网络、文件写入、线程启动和重型可选依赖加载。
+- 资源获取与释放成对；异常路径不能跳过锁释放、context reset、线程停止或文件关闭。
+- 不新增调试输出、临时分支、无用 import 或由本次变更产生的死代码。
+- 复杂度是审查信号而非机械行数门禁；优先最小正确改动，不为单一用例增加抽象层。
+
+## 安全与隐私
+
+适用条件：凭据、认证、网络、日志、HTML、文件路径、上传、环境探测或用户数据发生变化。
+
+- API key、token、cookie、密码和 Secret 不写入日志、异常、测试快照或上传元数据。
+- netrc、配置文件和 Secret 文件遵守最小权限，不能写入错误用户目录或意外覆盖其他 host 凭据。
+- 自定义 host、webhook 和外部 URL 检查协议、凭据发送范围、重定向和 SSRF 风险。
+- HTML、终端日志、配置和第三方框架数据视为不可信输入，上传或展示前保持明确的安全边界。
+- `save`、sync 和解压/复制逻辑防止路径穿越、符号链接逃逸和任意文件覆盖。
+- 环境与硬件探测只采集产品需要的数据，不上传本地敏感路径、环境变量值或用户私有内容。


### PR DESCRIPTION
## Summary

本次变更新增了面向 SwanLab Python SDK 的 PR Review Skill，并修复了 CI workflow 中测试目录路径拼写错误。

## Changes

### 新增 PR Review Skill (`docs/skills/pr-review-lab/`)

- **SKILL.md**：定义完整的 PR 审核流程，包括适用范围、审核流程、领域路由、验证命令、严重性分级及 GitHub review 提交方式。覆盖 SwanLab Python SDK 特有的公共 API、Run 生命周期、Core/传输、配置认证、CLI、集成、Protobuf 等审核面。
- **references/domain-contracts.md**：按模块路径梳理领域审核契约，明确各层级的审核重点（类型兼容、组件生命周期、上传重试策略、配置安全、跨平台兼容等）。

### CI 修复

- `.github/workflows/test-python-pr.yml`：将 `paths` 中的 `test/**` 修正为 `tests/**`，确保测试代码变更能正确触发 CI。

### 开发工具

- `Makefile`：新增 `link-skills` / `unlink-skills` / `relink-skills` 目标，通过符号链接将 `docs/skills/pr-review-lab/` 关联到 OpenCode 自动发现的 skills 目录，方便本地开发使用。

## Testing

未运行测试。本次变更仅涉及文档、Makefile 目标及 CI 配置路径修正，不影响 Python 运行时行为。

## Notes

- Skill 依赖 `docs/skills` 目录通过 `skills.paths` 或符号链接方式注册到 OpenCode，否则不会被自动加载。
- 建议后续 PR 完善领域契约中的细节规则。