### PR TITLE
feat: raise tag string limit to 512 chars and cap tag count at 30

### DIFF
--- a/swanlab/sdk/internal/pkg/constraints/__init__.py
+++ b/swanlab/sdk/internal/pkg/constraints/__init__.py
@@ -82,8 +82,8 @@ Description = Annotated[
 ]
 """Description: 1-1024 chars."""
 
-TagString = Annotated[str, Field(max_length=20)]
-"""Single tag string: up to 20 chars."""
+TagString = Annotated[str, Field(max_length=512)]
+"""Single tag string: up to 512 chars."""
 
 Group = Annotated[str, Field(min_length=1, max_length=512)]
 """Experiment group: 1-512 chars."""

--- a/swanlab/sdk/internal/settings/experiment.py
+++ b/swanlab/sdk/internal/settings/experiment.py
@@ -91,7 +91,7 @@ def experiment_job_type_factory() -> Optional[str]:
     return os.environ.get("SWANLAB_JOB_TYPE", None)
 
 
-Tags = Field(default_factory=experiment_tags_factory, max_length=50, validate_default=True)
+Tags = Field(default_factory=experiment_tags_factory, max_length=30, validate_default=True)
 
 
 class ExperimentSettings(BaseModel):

--- a/tests/unit/sdk/internal/pkg/constraints/test_pkg_constraints.py
+++ b/tests/unit/sdk/internal/pkg/constraints/test_pkg_constraints.py
@@ -168,11 +168,11 @@ class TestTagString:
 
     def test_valid(self):
         assert self.adapter.validate_python("tag") == "tag"
-        assert self.adapter.validate_python("t" * 20) == "t" * 20
+        assert self.adapter.validate_python("t" * 512) == "t" * 512
 
     def test_too_long(self):
         with pytest.raises(ValidationError):
-            self.adapter.validate_python("t" * 21)
+            self.adapter.validate_python("t" * 513)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/internal/settings/test_settings_experiment.py
+++ b/tests/unit/sdk/internal/settings/test_settings_experiment.py
@@ -6,6 +6,7 @@
 """
 
 import pytest
+from pydantic import ValidationError
 
 from swanlab.sdk.internal.settings import Settings
 from swanlab.sdk.internal.settings.experiment import map_resume_value
@@ -38,6 +39,18 @@ def test_experiment_tags_parse(monkeypatch):
     # 6. model_validator 异常
     with pytest.raises(ValueError, match="tags must be a list, dict, or string"):
         Settings.model_validate({"experiment": {"tags": 123}})
+
+
+def test_experiment_tags_count_limit():
+    """
+    测试 tags 数量上限为 30
+    """
+    # 30 条 tag：通过
+    s = Settings.model_validate({"experiment": {"tags": [f"t{i}" for i in range(30)]}})
+    assert len(s.experiment.tags) == 30
+    # 31 条 tag：触发 ValidationError
+    with pytest.raises(ValidationError):
+        Settings.model_validate({"experiment": {"tags": [f"t{i}" for i in range(31)]}})
 
 
 def test_run_resume_parse(monkeypatch):


### PR DESCRIPTION
## Summary

调整实验标签（tags）的约束规则：单条 tag 字符串上限从 20 字符放宽到 512 字符，同时将标签数量上限从 50 条收紧到 30 条。

## Changes

- **`swanlab/sdk/internal/pkg/constraints/__init__.py`** — `TagString` max_length 从 20 改为 512
- **`swanlab/sdk/internal/settings/experiment.py`** — `Tags` 列表 max_length 从 50 改为 30
- **`tests/unit/sdk/internal/pkg/constraints/test_pkg_constraints.py`** — `TestTagString` 边界值同步更新
- **`tests/unit/sdk/internal/settings/test_settings_experiment.py`** — 新增 `test_experiment_tags_count_limit`，覆盖 30 条通过 / 31 条报错的场景

## Testing

```
uv run pytest tests/unit/sdk/internal/pkg/constraints/ \
             tests/unit/sdk/internal/settings/ -q
# 171 passed

uv run ruff check [changed files]
# All checks passed

uv run basedpyright [source files]
# 0 errors, 0 warnings
```

## Notes

- `TagString` 20 → 512 是向后兼容的放宽，不会影响现有存储数据。
- `Tags` 50 → 30 是收紧约束，已有超过 30 条 tag 的实验在再次写入时可能触发 ValidationError。当前线上 tag 数极少超过此阈值。