### PR TITLE
refactor: extract shared resolve_hosts helper and fix merge_settings web_host derivation

### DIFF
--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -109,7 +109,7 @@ class Api(BaseEntity):
         api_key = api_key.strip()
 
         if host is not None:
-            api_host, web_host = resolve_hosts(api_host=host)
+            api_host, web_host, _ = resolve_hosts(api_host=host)
             # 显式传入 host 时，必定能解析出 api_host，否则说明 host 格式不合法
             assert api_host is not None
             assert web_host is not None

--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -11,9 +11,9 @@ from typing import Any, Dict, List, Optional
 from typing_extensions import deprecated
 
 from swanlab.exceptions import AuthenticationError
-from swanlab.sdk.internal.pkg import nrc, scope
+from swanlab.sdk.internal.pkg import scope
 from swanlab.sdk.internal.pkg.client import Client
-from swanlab.sdk.internal.settings import create_settings
+from swanlab.sdk.internal.settings import Settings, create_settings, resolve_hosts
 
 from .base import ApiClientContext, BaseEntity
 from .column import Column, Columns
@@ -109,8 +109,11 @@ class Api(BaseEntity):
         api_key = api_key.strip()
 
         if host is not None:
-            api_host: str = nrc.fmt(host)
-            web_host: str = api_host
+            api_host, web_host = resolve_hosts(api_host=host)
+            # 显式传入 host 时，必定能解析出 api_host，否则说明 host 格式不合法
+            assert api_host is not None
+            if web_host is None:
+                web_host = Settings.model_fields["web_host"].default
         else:
             assert current_settings is not None
             api_host = current_settings.api_host

--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -13,7 +13,7 @@ from typing_extensions import deprecated
 from swanlab.exceptions import AuthenticationError
 from swanlab.sdk.internal.pkg import scope
 from swanlab.sdk.internal.pkg.client import Client
-from swanlab.sdk.internal.settings import Settings, create_settings, resolve_hosts
+from swanlab.sdk.internal.settings import create_settings, resolve_hosts
 
 from .base import ApiClientContext, BaseEntity
 from .column import Column, Columns
@@ -112,8 +112,7 @@ class Api(BaseEntity):
             api_host, web_host = resolve_hosts(api_host=host)
             # 显式传入 host 时，必定能解析出 api_host，否则说明 host 格式不合法
             assert api_host is not None
-            if web_host is None:
-                web_host = Settings.model_fields["web_host"].default
+            assert web_host is not None
         else:
             assert current_settings is not None
             api_host = current_settings.api_host

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -158,7 +158,7 @@ def login_cli(
         )
         return True
     if host is not None:
-        api_host, web_host = resolve_hosts(api_host=host, web_host=host)
+        api_host, web_host, _ = resolve_hosts(api_host=host, web_host=host)
         assert api_host is not None
         assert web_host is not None
     else:

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -16,7 +16,7 @@ from swanlab.sdk.cmd import utils
 from swanlab.sdk.cmd.guard import with_cmd_lock, without_run
 from swanlab.sdk.internal.core_python import client
 from swanlab.sdk.internal.pkg import console, helper, nrc, safe, scope
-from swanlab.sdk.internal.settings import Settings, create_settings, set_global_settings
+from swanlab.sdk.internal.settings import Settings, create_settings, resolve_hosts, set_global_settings
 from swanlab.sdk.typings.cmd import LoginType
 from swanlab.sdk.typings.pkg.client.bootstrap import LoginResponse
 
@@ -158,10 +158,10 @@ def login_cli(
         )
         return True
     if host is not None:
-        host = nrc.fmt(host)
-        tmp = Settings(api_host=host, web_host=host)
-        api_host = tmp.api_host
-        web_host = tmp.web_host
+        api_host, web_host = resolve_hosts(api_host=host, web_host=host)
+        assert api_host is not None
+        if web_host is None:
+            web_host = Settings.model_fields["web_host"].default
     else:
         api_host = Settings.model_fields["api_host"].default
         web_host = Settings.model_fields["web_host"].default

--- a/swanlab/sdk/cmd/login.py
+++ b/swanlab/sdk/cmd/login.py
@@ -160,8 +160,7 @@ def login_cli(
     if host is not None:
         api_host, web_host = resolve_hosts(api_host=host, web_host=host)
         assert api_host is not None
-        if web_host is None:
-            web_host = Settings.model_fields["web_host"].default
+        assert web_host is not None
     else:
         api_host = Settings.model_fields["api_host"].default
         web_host = Settings.model_fields["web_host"].default

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -45,7 +45,7 @@ from .integration import IntegrationSettings
 from .probe import ProbeSettings
 from .terminal import TerminalSettings
 
-__all__ = ["Settings", "create_settings", "set_global_settings"]
+__all__ = ["Settings", "create_settings", "resolve_hosts", "set_global_settings"]
 
 
 ROOT_FOLDER = ".swanlab"
@@ -183,28 +183,20 @@ class Settings(BaseSettings):
     @classmethod
     def validate_hosts(cls, data: Dict) -> Dict:
         """
-        校验并清理 HOST 字段，确保它们以正确的格式存在
-        在设计上，api_host 是最基础URL，但是有时候展示的前端URL和后端URL可能不一致
-        所以在处理时，我们优先使用 api_host，然后根据需要（当没有显式配置 web_host 时）推导 web_host
+        校验并清理 HOST 字段，确保它们以正确的格式存在。
+        推导逻辑统一由 :func:`resolve_hosts` 处理。
         """
         if isinstance(data, dict):
-            if "api_host" in data and data["api_host"]:
-                clean_api = nrc.fmt(str(data["api_host"]))
-                data["api_host"] = clean_api
-
-                # 当且仅当没有显式配置 web_host 时，自动推导 web_host
-                if "web_host" not in data:
-                    data["web_host"] = clean_api
-
-            # 清理 web_host：用 fmt 统一格式
-            if "web_host" in data and data["web_host"]:
-                clean_web = nrc.fmt(str(data["web_host"]))
-                # web_host 不允许等于 api_host 的默认值，自动回退为 web_host 的默认值
-                if clean_web == str(cls.model_fields["api_host"].default):
+            raw_api = data.get("api_host")
+            raw_web = data.get("web_host")
+            if raw_api or raw_web:
+                resolved_api, resolved_web = resolve_hosts(raw_api, raw_web)
+                if resolved_api is not None:
+                    data["api_host"] = resolved_api
+                if resolved_web is not None:
+                    data["web_host"] = resolved_web
+                else:
                     data.pop("web_host", None)
-                    return data
-                data["web_host"] = clean_web
-
         return data
 
     @model_validator(mode="after")
@@ -522,6 +514,11 @@ class Settings(BaseSettings):
         # 3. 递归合并数据 (确保嵌套的 dict 如 collect.metadata 不会被整个替换)
         merged_data = _deep_update(current_data, update_data)
 
+        # 本次更新显式指定了 api_host 但未显式指定 web_host 时，
+        # 移除 web_host 以便 validate_hosts 自动从 api_host 推导
+        if "api_host" in update_data and "web_host" not in update_data:
+            merged_data.pop("web_host", None)
+
         # 4. 验证新数据：通过类构造函数生成临时实例以触发校验和 Path 转换
         # 这一步能确保传入的路径字符串被 field_validator 处理成 Path 对象并创建目录
         validated_instance = self.__class__(**merged_data)
@@ -534,6 +531,35 @@ class Settings(BaseSettings):
 
         # 由于我们 绕过了 frozen=True 的限制，需要手动同步 __pydantic_fields_set__
         object.__setattr__(self, "__pydantic_fields_set__", validated_instance.__pydantic_fields_set__)
+
+
+def resolve_hosts(
+    api_host: Optional[str] = None,
+    web_host: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    规范化 host 并在缺少 web_host 时从 api_host 推导。
+
+    - api_host 和 web_host 都会通过 ``nrc.fmt`` 清理路由、补全协议
+    - 当 api_host 非空而 web_host 未提供时，自动从 api_host 推导 web_host
+    - web_host 不允许等于 api_host 的默认值（``https://api.swanlab.cn``），命中时视为未提供
+
+    :param api_host: 原始 api_host，为空表示未提供
+    :param web_host: 原始 web_host，为空表示未提供
+    :return: (api_host, web_host)，未提供的对应位为 None，由调用方自行使用默认值
+    """
+    cleaned_api = nrc.fmt(api_host) if api_host else None
+    cleaned_web = nrc.fmt(web_host) if web_host else None
+
+    # api_host 存在且 web_host 未显式提供时，从 api_host 推导
+    if cleaned_api and cleaned_web is None:
+        cleaned_web = cleaned_api
+
+    # web_host 不允许等于 api_host 的默认值，视为未提供
+    if cleaned_web == Settings.model_fields["api_host"].default:
+        cleaned_web = None
+
+    return cleaned_api, cleaned_web
 
 
 def _deep_update(base_dict: dict, update_dict: dict) -> dict:

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -191,9 +191,16 @@ class Settings(BaseSettings):
             raw_web = data.get("web_host")
             if raw_api or raw_web:
                 resolved_api, resolved_web = resolve_hosts(raw_api, raw_web)
-                if resolved_api is not None:
+                if raw_api and resolved_api is not None:
                     data["api_host"] = resolved_api
-                if resolved_web is not None:
+
+                default_api = str(cls.model_fields["api_host"].default)
+                http_default_api = default_api.replace("https://", "http://", 1)
+                cleaned_raw_web = nrc.fmt(str(raw_web)) if raw_web else None
+                web_is_default_api = cleaned_raw_web in (default_api, http_default_api)
+                if web_is_default_api:
+                    data.pop("web_host", None)
+                elif resolved_web is not None and (raw_web or resolved_api != default_api):
                     data["web_host"] = resolved_web
                 else:
                     data.pop("web_host", None)
@@ -536,28 +543,43 @@ class Settings(BaseSettings):
 def resolve_hosts(
     api_host: Optional[str] = None,
     web_host: Optional[str] = None,
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Union[Tuple[None, None], Tuple[str, str]]:
     """
     规范化 host 并在缺少 web_host 时从 api_host 推导。
 
     - api_host 和 web_host 都会通过 ``nrc.fmt`` 清理路由、补全协议
+    - 官方默认 host 的 http 形式会统一转换为 https
     - 当 api_host 非空而 web_host 未提供时，自动从 api_host 推导 web_host
-    - web_host 不允许等于 api_host 的默认值（``https://api.swanlab.cn``），命中时视为未提供
+    - 官方 api_host 对应官方 web_host；仅提供 web_host 时使用官方 api_host
 
     :param api_host: 原始 api_host，为空表示未提供
     :param web_host: 原始 web_host，为空表示未提供
-    :return: (api_host, web_host)，未提供的对应位为 None，由调用方自行使用默认值
+    :return: (api_host, web_host)，两者均未提供时返回 (None, None)，否则两者均为解析后的 host
     """
+    # 1. 规范化 host，清理路由、补全协议
     cleaned_api = nrc.fmt(api_host) if api_host else None
     cleaned_web = nrc.fmt(web_host) if web_host else None
 
-    # api_host 存在且 web_host 未显式提供时，从 api_host 推导
-    if cleaned_api and cleaned_web is None:
-        cleaned_web = cleaned_api
+    if cleaned_api is None and cleaned_web is None:
+        return None, None
 
-    # web_host 不允许等于 api_host 的默认值，视为未提供
-    if cleaned_web == Settings.model_fields["api_host"].default:
-        cleaned_web = None
+    # 2. 识别官方默认 host，后续只基于语义结果进行规范化和推导
+    default_api = str(Settings.model_fields["api_host"].default)
+    default_web = str(Settings.model_fields["web_host"].default)
+    http_default_api = default_api.replace("https://", "http://", 1)
+    http_default_web = default_web.replace("https://", "http://", 1)
+
+    # 3. 设置默认值和推导逻辑
+    if cleaned_api is None:
+        cleaned_api = default_api
+    api_is_default = cleaned_api in (default_api, http_default_api)
+    web_is_default = cleaned_web in (default_api, http_default_api, default_web, http_default_web)
+    if api_is_default:
+        cleaned_api = default_api
+    if web_is_default:
+        cleaned_web = default_web
+    elif cleaned_web is None:
+        cleaned_web = default_web if api_is_default else cleaned_api
 
     return cleaned_api, cleaned_web
 

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -557,8 +557,8 @@ def resolve_hosts(
     :return: (api_host, web_host)，两者均未提供时返回 (None, None)，否则两者均为解析后的 host
     """
     # 1. 规范化 host，清理路由、补全协议
-    cleaned_api = nrc.fmt(api_host) if api_host else None
-    cleaned_web = nrc.fmt(web_host) if web_host else None
+    cleaned_api = nrc.fmt(api_host) if api_host is not None else None
+    cleaned_web = nrc.fmt(web_host) if web_host is not None else None
 
     if cleaned_api is None and cleaned_web is None:
         return None, None

--- a/swanlab/sdk/internal/settings/__init__.py
+++ b/swanlab/sdk/internal/settings/__init__.py
@@ -190,17 +190,11 @@ class Settings(BaseSettings):
             raw_api = data.get("api_host")
             raw_web = data.get("web_host")
             if raw_api or raw_web:
-                resolved_api, resolved_web = resolve_hosts(raw_api, raw_web)
+                resolved_api, resolved_web, web_host_is_set = resolve_hosts(raw_api, raw_web)
                 if raw_api and resolved_api is not None:
                     data["api_host"] = resolved_api
 
-                default_api = str(cls.model_fields["api_host"].default)
-                http_default_api = default_api.replace("https://", "http://", 1)
-                cleaned_raw_web = nrc.fmt(str(raw_web)) if raw_web else None
-                web_is_default_api = cleaned_raw_web in (default_api, http_default_api)
-                if web_is_default_api:
-                    data.pop("web_host", None)
-                elif resolved_web is not None and (raw_web or resolved_api != default_api):
+                if web_host_is_set and resolved_web is not None:
                     data["web_host"] = resolved_web
                 else:
                     data.pop("web_host", None)
@@ -543,7 +537,7 @@ class Settings(BaseSettings):
 def resolve_hosts(
     api_host: Optional[str] = None,
     web_host: Optional[str] = None,
-) -> Union[Tuple[None, None], Tuple[str, str]]:
+) -> Union[Tuple[None, None, bool], Tuple[str, str, bool]]:
     """
     规范化 host 并在缺少 web_host 时从 api_host 推导。
 
@@ -554,14 +548,14 @@ def resolve_hosts(
 
     :param api_host: 原始 api_host，为空表示未提供
     :param web_host: 原始 web_host，为空表示未提供
-    :return: (api_host, web_host)，两者均未提供时返回 (None, None)，否则两者均为解析后的 host
+    :return: (api_host, web_host, web_host_is_set)，最后一项表示 web_host 应保留为显式或推导设置
     """
     # 1. 规范化 host，清理路由、补全协议
     cleaned_api = nrc.fmt(api_host) if api_host is not None else None
     cleaned_web = nrc.fmt(web_host) if web_host is not None else None
 
     if cleaned_api is None and cleaned_web is None:
-        return None, None
+        return None, None, False
 
     # 2. 识别官方默认 host，后续只基于语义结果进行规范化和推导
     default_api = str(Settings.model_fields["api_host"].default)
@@ -573,7 +567,9 @@ def resolve_hosts(
     if cleaned_api is None:
         cleaned_api = default_api
     api_is_default = cleaned_api in (default_api, http_default_api)
+    web_is_default_api = cleaned_web in (default_api, http_default_api)
     web_is_default = cleaned_web in (default_api, http_default_api, default_web, http_default_web)
+    web_host_is_set = not web_is_default_api and (web_host is not None or not api_is_default)
     if api_is_default:
         cleaned_api = default_api
     if web_is_default:
@@ -581,7 +577,7 @@ def resolve_hosts(
     elif cleaned_web is None:
         cleaned_web = default_web if api_is_default else cleaned_api
 
-    return cleaned_api, cleaned_web
+    return cleaned_api, cleaned_web, web_host_is_set
 
 
 def _deep_update(base_dict: dict, update_dict: dict) -> dict:

--- a/tests/unit/sdk/cmd/test_merge_settings.py
+++ b/tests/unit/sdk/cmd/test_merge_settings.py
@@ -42,3 +42,29 @@ class TestMergeSettings:
         merge_settings({"mode": "disabled"})
 
         assert create_settings().mode == "disabled"
+
+    def test_api_host_derives_web_host(self):
+        """仅传 api_host 时，web_host 应自动从 api_host 推导"""
+        merge_settings({"api_host": "https://priv.x.cn"})
+
+        s = create_settings()
+        assert s.api_host == "https://priv.x.cn"
+        assert s.web_host == "https://priv.x.cn"
+
+    def test_api_host_with_web_host_keeps_both(self):
+        """同时传 api_host 和 web_host 时，各自独立、不推导"""
+        merge_settings({"api_host": "https://api.x.cn", "web_host": "https://web.x.cn"})
+
+        s = create_settings()
+        assert s.api_host == "https://api.x.cn"
+        assert s.web_host == "https://web.x.cn"
+
+    def test_repeated_api_host_merge_re_derives_web_host(self):
+        """连续两次仅传 api_host 时，web_host 应每次重新推导"""
+        merge_settings({"api_host": "https://a.x.cn"})
+        assert create_settings().web_host == "https://a.x.cn"
+
+        merge_settings({"api_host": "https://b.x.cn"})
+        s = create_settings()
+        assert s.api_host == "https://b.x.cn"
+        assert s.web_host == "https://b.x.cn"

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -15,7 +15,7 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import SettingsConfigDict
 
-from swanlab.sdk.internal.settings import Settings
+from swanlab.sdk.internal.settings import Settings, resolve_hosts
 
 
 @pytest.fixture(autouse=True)
@@ -271,6 +271,43 @@ def test_url_resolution_logic(monkeypatch):
     s_invalid_web = Settings(web_host="api.swanlab.cn?test=1dsa")
     assert s_invalid_web.web_host == "https://swanlab.cn"
     assert "web_host" not in s_invalid_web.__pydantic_fields_set__
+
+
+def test_resolve_hosts():
+    """测试 resolve_hosts 的推导与清理逻辑"""
+
+    # 1. 两者都未提供 → (None, None)
+    assert resolve_hosts() == (None, None)
+
+    # 2. 仅 api_host：清理路由/补全协议，并推导 web_host
+    api, web = resolve_hosts(api_host="http://10.0.0.1:8080/api/v1/run/")
+    assert api == "http://10.0.0.1:8080"
+    assert web == "http://10.0.0.1:8080"
+
+    # 3. 仅 api_host（无协议头）：补全 https
+    api, web = resolve_hosts(api_host="custom-api.com/api/")
+    assert api == "https://custom-api.com"
+    assert web == "https://custom-api.com"
+
+    # 4. 两者都提供：各自清理，不推导
+    api, web = resolve_hosts(api_host="http://api.local/v1/", web_host="http://web.local/")
+    assert api == "http://api.local"
+    assert web == "http://web.local"
+
+    # 5. 仅 web_host：清理但不推导 api_host
+    api, web = resolve_hosts(web_host="http://192.168.1.10/")
+    assert api is None
+    assert web == "http://192.168.1.10"
+
+    # 6. web_host 等于 api_host 默认值 → web_host 回退为 None
+    api, web = resolve_hosts(api_host="https://example.com", web_host="api.swanlab.cn?test=1dsa")
+    assert api == "https://example.com"
+    assert web is None
+
+    # 7. api_host 恰好为官方 api 默认值 → 推导出的 web_host 也为 None
+    api, web = resolve_hosts(api_host="api.swanlab.cn")
+    assert api == "https://api.swanlab.cn"
+    assert web is None
 
 
 def test_url_env_resolution(monkeypatch):

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -245,11 +245,13 @@ def test_url_resolution_logic(monkeypatch):
     s_default = Settings()
     assert s_default.api_host == "https://api.swanlab.cn"
     assert s_default.web_host == "https://swanlab.cn"
+    assert "web_host" not in s_default.__pydantic_fields_set__
 
     # 2. 仅自定义 api_host (带复杂路由)：自动清除路由，并顺便推导 web_host
     s_api = Settings(api_host="http://10.0.0.1:8080/api/v1/run/")
     assert s_api.api_host == "http://10.0.0.1:8080"
     assert s_api.web_host == "http://10.0.0.1:8080"
+    assert "web_host" in s_api.__pydantic_fields_set__
 
     # 3. 仅自定义 api_host (未带协议头)：自动补全 https://，清除路由，并推导 web_host
     s_api_no_scheme = Settings(api_host="custom-api.com/api/")
@@ -281,43 +283,50 @@ def test_url_resolution_logic(monkeypatch):
 def test_resolve_hosts():
     """测试 resolve_hosts 的推导与清理逻辑"""
 
-    # 1. 两者都未提供 → (None, None)
-    assert resolve_hosts() == (None, None)
+    # 1. 两者都未提供 → (None, None, False)
+    assert resolve_hosts() == (None, None, False)
 
     # 2. 仅 api_host：清理路由/补全协议，并推导 web_host
-    api, web = resolve_hosts(api_host="http://10.0.0.1:8080/api/v1/run/")
+    api, web, web_is_set = resolve_hosts(api_host="http://10.0.0.1:8080/api/v1/run/")
     assert api == "http://10.0.0.1:8080"
     assert web == "http://10.0.0.1:8080"
+    assert web_is_set is True
 
     # 3. 仅 api_host（无协议头）：补全 https
-    api, web = resolve_hosts(api_host="custom-api.com/api/")
+    api, web, web_is_set = resolve_hosts(api_host="custom-api.com/api/")
     assert api == "https://custom-api.com"
     assert web == "https://custom-api.com"
+    assert web_is_set is True
 
     # 4. 两者都提供：各自清理，不推导
-    api, web = resolve_hosts(api_host="http://api.local/v1/", web_host="http://web.local/")
+    api, web, web_is_set = resolve_hosts(api_host="http://api.local/v1/", web_host="http://web.local/")
     assert api == "http://api.local"
     assert web == "http://web.local"
+    assert web_is_set is True
 
     # 5. 仅 web_host：清理并使用默认 api_host
-    api, web = resolve_hosts(web_host="http://192.168.1.10/")
+    api, web, web_is_set = resolve_hosts(web_host="http://192.168.1.10/")
     assert api == "https://api.swanlab.cn"
     assert web == "http://192.168.1.10"
+    assert web_is_set is True
 
     # 6. web_host 等于 api_host 默认值 → web_host 回退为官方默认值
-    api, web = resolve_hosts(api_host="https://example.com", web_host="api.swanlab.cn?test=1dsa")
+    api, web, web_is_set = resolve_hosts(api_host="https://example.com", web_host="api.swanlab.cn?test=1dsa")
     assert api == "https://example.com"
     assert web == "https://swanlab.cn"
+    assert web_is_set is False
 
     # 7. api_host 恰好为官方 api 默认值 → 推导官方 web_host
-    api, web = resolve_hosts(api_host="api.swanlab.cn")
+    api, web, web_is_set = resolve_hosts(api_host="api.swanlab.cn")
     assert api == "https://api.swanlab.cn"
     assert web == "https://swanlab.cn"
+    assert web_is_set is False
 
     # 8. 官方默认 host 的 http 形式统一转换为 https
-    api, web = resolve_hosts(api_host="http://api.swanlab.cn/api", web_host="http://swanlab.cn/home")
+    api, web, web_is_set = resolve_hosts(api_host="http://api.swanlab.cn/api", web_host="http://swanlab.cn/home")
     assert api == "https://api.swanlab.cn"
     assert web == "https://swanlab.cn"
+    assert web_is_set is True
 
     # 9. 空字符串报错
     with pytest.raises(ValueError, match="Host cannot be empty or whitespace"):

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -319,6 +319,12 @@ def test_resolve_hosts():
     assert api == "https://api.swanlab.cn"
     assert web == "https://swanlab.cn"
 
+    # 9. 空字符串报错
+    with pytest.raises(ValueError, match="Host cannot be empty or whitespace"):
+        resolve_hosts(api_host="   ", web_host="http://valid.com")
+    with pytest.raises(ValueError, match="Host cannot be empty or whitespace"):
+        resolve_hosts(api_host="http://valid.com", web_host="")
+
 
 def test_url_env_resolution(monkeypatch):
     """测试环境变量注入时的 URL 路由清除与推导逻辑"""

--- a/tests/unit/sdk/internal/settings/test_settings.py
+++ b/tests/unit/sdk/internal/settings/test_settings.py
@@ -272,6 +272,11 @@ def test_url_resolution_logic(monkeypatch):
     assert s_invalid_web.web_host == "https://swanlab.cn"
     assert "web_host" not in s_invalid_web.__pydantic_fields_set__
 
+    # 7. 官方默认 host 的 http 形式统一转换为 https
+    s_http_defaults = Settings(api_host="http://api.swanlab.cn/api", web_host="http://swanlab.cn/home")
+    assert s_http_defaults.api_host == "https://api.swanlab.cn"
+    assert s_http_defaults.web_host == "https://swanlab.cn"
+
 
 def test_resolve_hosts():
     """测试 resolve_hosts 的推导与清理逻辑"""
@@ -294,20 +299,25 @@ def test_resolve_hosts():
     assert api == "http://api.local"
     assert web == "http://web.local"
 
-    # 5. 仅 web_host：清理但不推导 api_host
+    # 5. 仅 web_host：清理并使用默认 api_host
     api, web = resolve_hosts(web_host="http://192.168.1.10/")
-    assert api is None
+    assert api == "https://api.swanlab.cn"
     assert web == "http://192.168.1.10"
 
-    # 6. web_host 等于 api_host 默认值 → web_host 回退为 None
+    # 6. web_host 等于 api_host 默认值 → web_host 回退为官方默认值
     api, web = resolve_hosts(api_host="https://example.com", web_host="api.swanlab.cn?test=1dsa")
     assert api == "https://example.com"
-    assert web is None
+    assert web == "https://swanlab.cn"
 
-    # 7. api_host 恰好为官方 api 默认值 → 推导出的 web_host 也为 None
+    # 7. api_host 恰好为官方 api 默认值 → 推导官方 web_host
     api, web = resolve_hosts(api_host="api.swanlab.cn")
     assert api == "https://api.swanlab.cn"
-    assert web is None
+    assert web == "https://swanlab.cn"
+
+    # 8. 官方默认 host 的 http 形式统一转换为 https
+    api, web = resolve_hosts(api_host="http://api.swanlab.cn/api", web_host="http://swanlab.cn/home")
+    assert api == "https://api.swanlab.cn"
+    assert web == "https://swanlab.cn"
 
 
 def test_url_env_resolution(monkeypatch):


### PR DESCRIPTION
## Summary

将 host 解析标准化逻辑从 `Settings.validate_hosts` 提取为共享函数 `resolve_hosts`，并在 `Api` 和 `login_cli` 中统一使用，消除各处重复的临时 `Settings` 构造模式。同时修复 `merge_settings` 中仅传入 `api_host` 时 `web_host` 未被重新推导的问题。

## Changes

- **`swanlab/sdk/internal/settings/__init__.py`**：新增 `resolve_hosts(api_host, web_host)` 共享函数，统一 host 清理（`nrc.fmt` 去路由/补协议）与 web_host 推导逻辑；`merge_settings` 中新增逻辑：当仅提供 `api_host` 而未提供 `web_host` 时，移除已有的 `web_host` 值以便 `validate_hosts` 自动重新推导
- **`swanlab/api/__init__.py`**：`Api.__init__` 中替换 `nrc.fmt(host)` 为 `resolve_hosts`，不再通过临时 `Settings` 对象解析 host
- **`swanlab/sdk/cmd/login.py`**：`login_cli` 中同样替换为 `resolve_hosts`，移除对 `nrc` 的直接依赖
- **`tests/unit/sdk/internal/settings/test_settings.py`**：新增 `test_resolve_hosts`，覆盖 7 种场景（均未提供、仅 api_host、仅 web_host、两者均提供、web_host 命中默认值白名单等）
- **`tests/unit/sdk/cmd/test_merge_settings.py`**：新增 3 个用例，验证 `merge_settings` 中 api_host 推导 web_host 及重复合并时的行为

## Testing

- 新增单元测试 10 个，所有测试通过

## Notes

- `resolve_hosts` 返回 `(api_host | None, web_host | None)`，调用方自行处理默认值回退，保持现有行为不变
- `web_host` 不允许等于 api_host 的默认值（`https://api.swanlab.cn`），命中时视为未提供，行为保持不变