### PR TITLE
feat: add public require() API for runtime backend selection

### DIFF
--- a/swanlab/__init__.py
+++ b/swanlab/__init__.py
@@ -35,6 +35,7 @@ from swanlab.sdk import (
     merge_settings,
     pkg,
     plot,
+    require,
     save,
     sync,
 )
@@ -50,6 +51,7 @@ __all__ = [
     # cmd
     "merge_callbacks",
     "merge_settings",
+    "require",
     "init",
     "finish",
     "login",

--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -297,6 +297,8 @@ def require(*requirements: str) -> List[str]:
 
     - ``"core"``: switch to the SwanLab Go core runtime (swanlab-core).
     - ``"probe"``: switch to the SwanLab Rust probe runtime.
+    - ``"core_python"``: explicitly use the built-in Python core.
+    - ``"probe_python"``: explicitly use the built-in Python probe.
 
     Equivalent to setting the ``SWANLAB_REQUIRE`` environment variable (comma-separated).
     Idempotent; unknown tokens raise ``ValueError``. This is a transitional API:

--- a/swanlab/__init__.pyi
+++ b/swanlab/__init__.pyi
@@ -49,6 +49,7 @@ __all__ = [
     # cmd
     "merge_callbacks",
     "merge_settings",
+    "require",
     "init",
     "finish",
     "login",
@@ -286,6 +287,37 @@ def merge_callbacks(callbacks: CallbacksType) -> None:
         ...         print("Run initialized!")
         >>> swanlab.merge_callbacks(MyCallback())
         >>> swanlab.init()
+    """
+    ...
+
+def require(*requirements: str) -> List[str]:
+    """Enable a transitional SwanLab runtime backend (process-global).
+
+    Must be called before ``swanlab.init()``. Currently supported requirements:
+
+    - ``"core"``: switch to the SwanLab Go core runtime (swanlab-core).
+    - ``"probe"``: switch to the SwanLab Rust probe runtime.
+
+    Equivalent to setting the ``SWANLAB_REQUIRE`` environment variable (comma-separated).
+    Idempotent; unknown tokens raise ``ValueError``. This is a transitional API:
+    once the new backends become the default, it will degrade to a no-op or be deprecated.
+
+    :param requirements: One or more requirement tokens, e.g. ``"core"``, ``"probe"``.
+    :return: The list of activated requirement tokens.
+    :raises ValueError: If a requirement token is unknown.
+    :raises RuntimeError: If called while a run is active.
+
+    Examples:
+
+        Switch to the Go core for a single run:
+
+        >>> import swanlab
+        >>> swanlab.require("core")
+        >>> swanlab.init()
+
+        Enable both core and probe via the environment variable instead:
+
+        >>> # SWANLAB_REQUIRE=core,probe python train.py
     """
     ...
 

--- a/swanlab/sdk/__init__.py
+++ b/swanlab/sdk/__init__.py
@@ -12,6 +12,7 @@ from .cmd.init import init
 from .cmd.login import login, login_cli
 from .cmd.merge_callbacks import merge_callbacks
 from .cmd.merge_settings import merge_settings
+from .cmd.require import require
 from .cmd.run import (
     async_log,
     define_scalar,
@@ -55,6 +56,7 @@ __all__ = [
     "sync",
     "merge_settings",
     "merge_callbacks",
+    "require",
     "cmd_utils",
     # run
     "has_run",

--- a/swanlab/sdk/cmd/require.py
+++ b/swanlab/sdk/cmd/require.py
@@ -6,7 +6,9 @@
 
 设计参考 wandb.require，属于中间过渡态 API：
 - 默认使用 Python 内置实现（CorePython / ProbePython）
-- 在 swanlab.init 之前调用 swanlab.require("core"|"probe") 切换到新后端
+- 在 swanlab.init 之前调用 swanlab.require(...) 切换后端实现：
+  - "core" / "probe"：切换到新后端（Go core / Rust probe）
+  - "core_python" / "probe_python"：显式切回 Python 内置实现
 - 也可通过环境变量 SWANLAB_REQUIRE=core,probe 在导入时生效（应用逻辑见 helper.impl）
 - 待新后端成为默认实现后，此 API 将退化为 no-op 或废弃
 """
@@ -28,6 +30,8 @@ def require(*requirements: str) -> List[str]:
 
     - ``"core"``: switch to the SwanLab Go core runtime (swanlab-core).
     - ``"probe"``: switch to the SwanLab Rust probe runtime.
+    - ``"core_python"``: explicitly use the built-in Python core.
+    - ``"probe_python"``: explicitly use the built-in Python probe.
 
     Equivalent to setting the ``SWANLAB_REQUIRE`` environment variable (comma-separated).
     Idempotent; unknown tokens raise ``ValueError``.

--- a/swanlab/sdk/cmd/require.py
+++ b/swanlab/sdk/cmd/require.py
@@ -1,0 +1,52 @@
+"""
+@author: cunyue
+@file: require.py
+@time: 2026/8/11
+@description: swanlab.require 方法，过渡态用于动态选择 core/probe 后端实现
+
+设计参考 wandb.require，属于中间过渡态 API：
+- 默认使用 Python 内置实现（CorePython / ProbePython）
+- 在 swanlab.init 之前调用 swanlab.require("core"|"probe") 切换到新后端
+- 也可通过环境变量 SWANLAB_REQUIRE=core,probe 在导入时生效（应用逻辑见 helper.impl）
+- 待新后端成为默认实现后，此 API 将退化为 no-op 或废弃
+"""
+
+from typing import List
+
+from swanlab.sdk.cmd.guard import with_cmd_lock, without_run
+from swanlab.sdk.internal.pkg import console, helper
+
+__all__ = ["require"]
+
+
+@with_cmd_lock
+@without_run("require")
+def require(*requirements: str) -> List[str]:
+    """Enable a transitional SwanLab runtime backend (process-global).
+
+    Must be called before ``swanlab.init()``. Currently supported requirements:
+
+    - ``"core"``: switch to the SwanLab Go core runtime (swanlab-core).
+    - ``"probe"``: switch to the SwanLab Rust probe runtime.
+
+    Equivalent to setting the ``SWANLAB_REQUIRE`` environment variable (comma-separated).
+    Idempotent; unknown tokens raise ``ValueError``.
+
+    :param requirements: One or more requirement tokens, e.g. ``"core"``, ``"probe"``.
+    :return: The list of activated requirement tokens.
+    :raises ValueError: If a requirement token is unknown.
+    :raises RuntimeError: If called while a run is active.
+
+    Examples:
+
+        >>> import swanlab
+        >>> swanlab.require("core")
+        >>> swanlab.init()
+    """
+    activated: List[str] = []
+    for raw in requirements:
+        token = raw.strip().lower()
+        label = helper.apply_requirement(token)
+        console.debug(f"require('{token}') -> {label}")
+        activated.append(token)
+    return activated

--- a/swanlab/sdk/internal/pkg/helper/__init__.py
+++ b/swanlab/sdk/internal/pkg/helper/__init__.py
@@ -8,7 +8,7 @@
 from pathlib import Path, PurePosixPath
 
 from .env import DEBUG, is_interactive, is_jupyter
-from .impl import get_core_impl, get_probe_impl
+from .impl import apply_requirement, get_core_impl, get_probe_impl, set_core_impl, set_probe_impl
 from .system import fmt_system_key, is_system_key
 from .version import get_swanlab_latest_version, get_swanlab_version
 
@@ -24,6 +24,9 @@ __all__ = [
     "get_swanlab_latest_version",
     "get_probe_impl",
     "get_core_impl",
+    "set_probe_impl",
+    "set_core_impl",
+    "apply_requirement",
     "mkdir_and_append_gitignore",
 ]
 

--- a/swanlab/sdk/internal/pkg/helper/impl.py
+++ b/swanlab/sdk/internal/pkg/helper/impl.py
@@ -52,10 +52,12 @@ def get_core_impl() -> Literal["python", "go"]:
 
 
 # requirement token -> (人类可读说明, 设置器)
-# 过渡态：通过 swanlab.require("core"|"probe") 或 SWANLAB_REQUIRE 环境变量切换后端实现
+# 过渡态：通过 swanlab.require(...) 或 SWANLAB_REQUIRE 环境变量切换后端实现
 REQUIREMENTS: Dict[str, Tuple[str, Callable[[], None]]] = {
     "core": ("SwanLab Go core (swanlab-core)", lambda: set_core_impl(CoreEnum.CORE)),
     "probe": ("SwanLab Rust probe", lambda: set_probe_impl(ProbeEnum.PROBE)),
+    "core_python": ("SwanLab Python core (built-in)", lambda: set_core_impl(CoreEnum.CORE_PYTHON)),
+    "probe_python": ("SwanLab Python probe (built-in)", lambda: set_probe_impl(ProbeEnum.PROBE_PYTHON)),
 }
 
 

--- a/swanlab/sdk/internal/pkg/helper/impl.py
+++ b/swanlab/sdk/internal/pkg/helper/impl.py
@@ -3,17 +3,32 @@
 @file: impl.py
 @time: 2026/5/17
 @description: SwanLab SDK component implementation helpers
+
+NOTE: this is a transition module.
 """
 
-from typing import Literal
+import os
+from typing import Callable, Dict, Literal, Optional, Tuple
 
 from swanlab.sdk.protocol import CoreEnum, ProbeEnum
 
-# TODO: 未来实现 probe 后，Python 版本依旧会有一段时间的共存期。后续实现一种机制，选择不同的 probe 实现
+require_env = os.environ.get("SWANLAB_REQUIRE", "")
+# probe/core 实现选择，进程级全局状态，默认 Python 实现
+# 过渡期通过 swanlab.require("core"|"probe") 或 SWANLAB_REQUIRE 环境变量切换
 _probe_impl: ProbeEnum = ProbeEnum.PROBE_PYTHON
-
-# TODO: 未来实现 core 后，Python 版本依旧会有一段时间的共存期。后续实现一种机制，选择不同的 core 实现
 _core_impl: CoreEnum = CoreEnum.CORE_PYTHON
+
+
+def set_probe_impl(impl: ProbeEnum) -> None:
+    """设置当前 probe 实现类型（进程级，需在 swanlab.init 之前调用）。"""
+    global _probe_impl
+    _probe_impl = impl
+
+
+def set_core_impl(impl: CoreEnum) -> None:
+    """设置当前 core 实现类型（进程级，需在 swanlab.init 之前调用）。"""
+    global _core_impl
+    _core_impl = impl
 
 
 def get_probe_impl() -> Literal["python", "rust"]:
@@ -34,3 +49,34 @@ def get_core_impl() -> Literal["python", "go"]:
         return "go"
     else:
         raise ValueError(f"Unknown core impl: {_core_impl}")
+
+
+# requirement token -> (人类可读说明, 设置器)
+# 过渡态：通过 swanlab.require("core"|"probe") 或 SWANLAB_REQUIRE 环境变量切换后端实现
+REQUIREMENTS: Dict[str, Tuple[str, Callable[[], None]]] = {
+    "core": ("SwanLab Go core (swanlab-core)", lambda: set_core_impl(CoreEnum.CORE)),
+    "probe": ("SwanLab Rust probe", lambda: set_probe_impl(ProbeEnum.PROBE)),
+}
+
+
+def _try_apply(token: str) -> Optional[str]:
+    """已知 token 则执行设置器并返回说明；未知返回 None（静默跳过）。"""
+    entry = REQUIREMENTS.get(token)
+    if entry is None:
+        return None
+    label, setter = entry
+    setter()
+    return label
+
+
+# 导入时读取 SWANLAB_REQUIRE 环境变量并静默应用，逗号分隔
+for _t in (_x.strip().lower() for _x in require_env.split(",") if _x.strip()):
+    _try_apply(_t)
+
+
+def apply_requirement(token: str) -> str:
+    """应用单个 requirement token，返回人类可读说明；未知 token 抛 ValueError。"""
+    label = _try_apply(token)
+    if label is None:
+        raise ValueError(f"Unknown requirement: {token!r}. Available: {sorted(REQUIREMENTS)}")
+    return label


### PR DESCRIPTION
## Summary

新增 `swanlab.require()` 公共 API，支持在 `swanlab.init()` 前动态选择 core/probe 后端实现，也可通过 `SWANLAB_REQUIRE` 环境变量在导入时生效。设计参考 `wandb.require`，属于过渡态 API。

for: #1063 

## Changes

- **新增 `swanlab/sdk/cmd/require.py`**：`require()` 函数实现，通过装饰器 `@with_cmd_lock` / `@without_run` 保证调用约束
- **`swanlab/sdk/internal/pkg/helper/impl.py`**：新增 `set_probe_impl` / `set_core_impl` 设置器、`apply_requirement()` 以及 `REQUIREMENTS` 映射表；模块导入时读取 `SWANLAB_REQUIRE` 环境变量并静默应用
- **`swanlab/__init__.py` / `swanlab/sdk/__init__.py`**：导出 `require` 符号
- **`swanlab/__init__.pyi`**：添加 `require` 的类型签名与文档

### 支持的 requirement token

| Token | 说明 |
| --- | --- |
| `"core"` | 切换到 SwanLab Go core (swanlab-core) |
| `"probe"` | 切换到 SwanLab Rust probe |
| `"core_python"` | 显式使用 Python 内置 core（当前默认） |
| `"probe_python"` | 显式使用 Python 内置 probe（当前默认） |

## Testing

未运行测试。新增的 `require()` 逻辑较简单（token → setter 映射），建议后续补充单元测试覆盖：合法 token 设置、未知 token 抛 ValueError、Run 活跃时抛 RuntimeError、`SWANLAB_REQUIRE` 环境变量在导入时生效。

## Notes

- 此 API 为过渡态设计，新后端成为默认后将退化为 no-op 或废弃
- 未知 token 抛出 `ValueError`，额外 token 可安全扩展到 `REQUIREMENTS` 映射表中
- 分支与当前 `main` 存在 `login.py` 的独立演进差异（`main` 上后续 commit `f86de8a7` 移除了 `validate_host`），合并时可能有轻微冲突需手动处理