### PR TITLE
feat: add created at post request for ch cluster

### DIFF
--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -14,6 +14,7 @@ from swanlab.exceptions import AuthenticationError
 from swanlab.sdk.internal.pkg import scope
 from swanlab.sdk.internal.pkg.client import Client
 from swanlab.sdk.internal.settings import create_settings, resolve_hosts
+from swanlab.utils.time import parse_timestamp_s
 
 from .base import ApiClientContext, BaseEntity
 from .column import Column, Columns
@@ -277,12 +278,14 @@ class Api(BaseEntity):
         """
         validate_api_path(path, segments=3, label="run")
         query = PaginatedQuery(page=page, size=size, search=search, all=all)
+        exp = Experiment(self._ctx, path=path)
         return Columns(
             self._ctx,
             path=path,
             query=query,
             column_type=column_type,
             column_class=column_class,
+            exp_created_at=parse_timestamp_s(exp.created_at),
         )
 
     @deprecated("Use `series()` method instead.")
@@ -303,7 +306,15 @@ class Api(BaseEntity):
         """
         validate_api_path(path, segments=3, label="run")
         validate_non_empty_string(key, label="column key")
-        return Column(self._ctx, path=path, key=key, column_class=column_class, column_type=column_type)
+        exp = Experiment(self._ctx, path=path)
+        return Column(
+            self._ctx,
+            path=path,
+            key=key,
+            column_class=column_class,
+            column_type=column_type,
+            exp_created_at=parse_timestamp_s(exp.created_at),
+        )
 
     def series(
         self,

--- a/swanlab/api/column.py
+++ b/swanlab/api/column.py
@@ -64,7 +64,7 @@ class Column(BaseEntity):
         project_id_getter: Optional[Callable[[], str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        exp_created_at: int = 0,
+        exp_created_at: int,
     ) -> None:
         super().__init__(ctx)
         self._proj_path, self._run_slug = resolve_run_path(path=path)
@@ -244,7 +244,7 @@ class Columns(BaseEntity):
         project_id_getter: Optional[Callable[[], str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        exp_created_at: int = 0,
+        exp_created_at: int,
     ) -> None:
         super().__init__(ctx)
         self._run_path = path

--- a/swanlab/api/column.py
+++ b/swanlab/api/column.py
@@ -64,6 +64,7 @@ class Column(BaseEntity):
         project_id_getter: Optional[Callable[[], str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        exp_created_at: int = 0,
     ) -> None:
         super().__init__(ctx)
         self._proj_path, self._run_slug = resolve_run_path(path=path)
@@ -76,6 +77,7 @@ class Column(BaseEntity):
         self._project_id_getter = project_id_getter
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._exp_created_at = exp_created_at
 
     def _ensure_data(self) -> ApiColumnType:
         if self._data is None:
@@ -180,6 +182,7 @@ class Column(BaseEntity):
             media_step=media_step,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._exp_created_at,
         )
         return metric.json()
 
@@ -198,6 +201,7 @@ class Column(BaseEntity):
             metric_type=metric_type,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._exp_created_at,
         )
         return metric.export_csv()
 
@@ -240,6 +244,7 @@ class Columns(BaseEntity):
         project_id_getter: Optional[Callable[[], str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        exp_created_at: int = 0,
     ) -> None:
         super().__init__(ctx)
         self._run_path = path
@@ -250,6 +255,7 @@ class Columns(BaseEntity):
         self._query = query
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._exp_created_at = exp_created_at
         # 校验 column_type 和 column_class 的合法性
         validate_column_params(column_type=column_type, column_class=column_class)
         self._column_class = column_class
@@ -304,6 +310,7 @@ class Columns(BaseEntity):
                 project_id_getter=self._ensure_project_id,
                 root_pro_id=self._root_pro_id,
                 root_exp_id=self._root_exp_id,
+                exp_created_at=self._exp_created_at,
             )
 
     @property

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -31,7 +31,6 @@ from swanlab.api.typings.user import ApiUserType
 from swanlab.api.utils import (
     get_properties,
     parse_timestamp_ms,
-    parse_timestamp_s,
     resolve_run_path,
     validate_filter,
     validate_group,
@@ -39,6 +38,7 @@ from swanlab.api.utils import (
     validate_update_active,
 )
 from swanlab.sdk.internal.pkg import console
+from swanlab.utils.time import parse_timestamp_s
 
 if TYPE_CHECKING:
     from swanlab.api.series import Series
@@ -487,10 +487,11 @@ class Experiment(BaseEntity):
         # 克隆实验的数据存在根实验下，因此查询时直接用根实验的 ID。
         query_pro_id = root_pro_id or project_id
         query_exp_id = root_exp_id or run_id
-        experiment_ref: Dict[str, Any] = {"projectId": query_pro_id, "experimentId": query_exp_id}
-        created_at = parse_timestamp_s(self.created_at)
-        if created_at:
-            experiment_ref["createdAt"] = created_at
+        experiment_ref: Dict[str, Any] = {
+            "projectId": query_pro_id,
+            "experimentId": query_exp_id,
+            "createdAt": parse_timestamp_s(self.created_at),
+        }
         return Series(
             self._ctx,
             experiments=[experiment_ref],

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -31,6 +31,7 @@ from swanlab.api.typings.user import ApiUserType
 from swanlab.api.utils import (
     get_properties,
     parse_timestamp_ms,
+    parse_timestamp_s,
     resolve_run_path,
     validate_filter,
     validate_group,
@@ -205,6 +206,7 @@ class Experiment(BaseEntity):
             project_id_getter=lambda: self.project_id,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            exp_created_at=parse_timestamp_s(self.created_at),
         )
 
     def metrics(
@@ -316,6 +318,7 @@ class Experiment(BaseEntity):
             range_query=rq,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            created_at=parse_timestamp_s(self.created_at),
             experiment_name=self.name,
         ).json()
 
@@ -344,6 +347,7 @@ class Experiment(BaseEntity):
             keys=keys,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            created_at=parse_timestamp_s(self.created_at),
         ).json()
 
     def medias(
@@ -366,6 +370,7 @@ class Experiment(BaseEntity):
             all=all,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            created_at=parse_timestamp_s(self.created_at),
         ).json()
 
     def logs(
@@ -389,6 +394,7 @@ class Experiment(BaseEntity):
             ignore_timestamp=ignore_timestamp,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            created_at=parse_timestamp_s(self.created_at),
         )
         return logs.json()
 
@@ -415,6 +421,7 @@ class Experiment(BaseEntity):
             metric_type="LOG",
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            created_at=parse_timestamp_s(self.created_at),
         )
         return metric.export_logs(start=start, rows=rows)
 
@@ -453,6 +460,7 @@ class Experiment(BaseEntity):
             project_id_getter=lambda: self.project_id,
             root_pro_id=self.root_pro_id,
             root_exp_id=self.root_exp_id,
+            exp_created_at=parse_timestamp_s(self.created_at),
         )
 
     def series(
@@ -479,10 +487,13 @@ class Experiment(BaseEntity):
         # 克隆实验的数据存在根实验下，因此查询时直接用根实验的 ID。
         query_pro_id = root_pro_id or project_id
         query_exp_id = root_exp_id or run_id
-        experiments: List[Dict[str, str]] = [{"projectId": query_pro_id, "experimentId": query_exp_id}]
+        experiment_ref: Dict[str, Any] = {"projectId": query_pro_id, "experimentId": query_exp_id}
+        created_at = parse_timestamp_s(self.created_at)
+        if created_at:
+            experiment_ref["createdAt"] = created_at
         return Series(
             self._ctx,
-            experiments=experiments,
+            experiments=[experiment_ref],
             metric_type=metric_type,
             metric_class=metric_class,
             search=search,

--- a/swanlab/api/metric.py
+++ b/swanlab/api/metric.py
@@ -218,6 +218,7 @@ class Metric(BaseEntity):
         all: bool = False,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
         experiment_name: str = "",
     ) -> None:
         super().__init__(ctx)
@@ -239,6 +240,7 @@ class Metric(BaseEntity):
         self._all = all
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._created_at = created_at
         self._experiment_name = experiment_name
 
     # 类型 → 加载方法 的分发表，新增类型只需在此注册
@@ -319,12 +321,15 @@ class Metric(BaseEntity):
         key: str,
         root_pro_id: str = "",
         root_exp_id: str = "",
-    ) -> Dict[str, str]:
-        ref: Dict[str, str] = {"experimentId": experiment_id, "key": key}
+        created_at: int = 0,
+    ) -> Dict[str, Any]:
+        ref: Dict[str, Any] = {"experimentId": experiment_id, "key": key}
         if root_pro_id:
             ref["rootProId"] = root_pro_id
         if root_exp_id:
             ref["rootExpId"] = root_exp_id
+        if created_at:
+            ref["createdAt"] = created_at
         return ref
 
     @staticmethod
@@ -336,12 +341,13 @@ class Metric(BaseEntity):
         x_type: str = "step",
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
     ) -> Dict[str, Any]:
         return {
             "projectId": project_id,
             "xType": x_type,
             "range": [0, 0],
-            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id) for key in keys],
+            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id, created_at) for key in keys],
             "num": sample if sample <= 1500 else 1500,
         }
 
@@ -353,10 +359,11 @@ class Metric(BaseEntity):
         step: Optional[int] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "projectId": project_id,
-            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id) for key in keys],
+            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id, created_at) for key in keys],
         }
         if step is not None:
             payload["step"] = step
@@ -370,6 +377,7 @@ class Metric(BaseEntity):
         experiment_name: str = "",
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
     ) -> Dict[str, Any]:
         """Build payload for ``POST /house/metrics/scalar/export``.
 
@@ -378,13 +386,15 @@ class Metric(BaseEntity):
         when the real name is unavailable.
         """
         exp_name = experiment_name or run_id
-        columns: List[Dict[str, str]] = []
+        columns: List[Dict[str, Any]] = []
         for key in keys:
-            col: Dict[str, str] = {"experimentName": exp_name, "experimentId": run_id, "key": key}
+            col: Dict[str, Any] = {"experimentName": exp_name, "experimentId": run_id, "key": key}
             if root_pro_id:
                 col["rootProId"] = root_pro_id
             if root_exp_id:
                 col["rootExpId"] = root_exp_id
+            if created_at:
+                col["createdAt"] = created_at
             columns.append(col)
         return {"projectId": project_id, "columns": columns}
 
@@ -400,6 +410,8 @@ class Metric(BaseEntity):
             params["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             params["rootExpId"] = self._root_exp_id
+        if self._created_at:
+            params["createdAt"] = self._created_at
         return params
 
     # ------------------------------------------------------------------
@@ -419,6 +431,7 @@ class Metric(BaseEntity):
             self._sample,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
 
         # 1. 获取折线数据 — 使用 key-indexed lookup 保证对齐
@@ -497,6 +510,7 @@ class Metric(BaseEntity):
             step=self._media_step,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
@@ -534,6 +548,7 @@ class Metric(BaseEntity):
             [self.key],
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/f_media", data=payload)
         raw_data = self._extract_first(raw_resp)
@@ -584,6 +599,7 @@ class Metric(BaseEntity):
             experiment_name=self._experiment_name,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         resp = self._post("/house/metrics/scalar/export", data=payload)
         if not resp.ok or not resp.data:
@@ -611,6 +627,8 @@ class Metric(BaseEntity):
             data["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             data["rootExpId"] = self._root_exp_id
+        if self._created_at:
+            data["createdAt"] = self._created_at
         resp = self._post("/house/metrics/log/export", data=data)
         if not resp.ok or not resp.data:
             return resp
@@ -696,6 +714,7 @@ class Metrics(BaseEntity):
         range_query: Optional[RangeQuery] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
         experiment_name: str = "",
     ) -> None:
         super().__init__(ctx)
@@ -716,6 +735,7 @@ class Metrics(BaseEntity):
         self._range_query = range_query
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._created_at = created_at
         self._experiment_name = experiment_name
         self._page_info: Dict[str, Any] = {
             "keys": keys,
@@ -804,6 +824,7 @@ class Metrics(BaseEntity):
             all=self._all,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
             experiment_name=self._experiment_name,
         )
 
@@ -831,6 +852,7 @@ class Metrics(BaseEntity):
                         x_type=x_type,
                         root_pro_id=self._root_pro_id,
                         root_exp_id=self._root_exp_id,
+                        created_at=self._created_at,
                     )
                 },
             )
@@ -871,6 +893,7 @@ class Metrics(BaseEntity):
                         self._sample,
                         root_pro_id=self._root_pro_id,
                         root_exp_id=self._root_exp_id,
+                        created_at=self._created_at,
                     )
                 },
             ),
@@ -926,6 +949,7 @@ class Metrics(BaseEntity):
             experiment_name=self._experiment_name,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         requests.append((self._post, "/house/metrics/scalar/export", {"data": export_payload}))
 
@@ -992,6 +1016,7 @@ class Metrics(BaseEntity):
             step=self._media_step,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
@@ -1038,6 +1063,7 @@ class Metrics(BaseEntity):
             self._keys,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/f_media", data=payload)
         if not raw_resp.ok or not raw_resp.data:

--- a/swanlab/api/metric.py
+++ b/swanlab/api/metric.py
@@ -207,6 +207,7 @@ class Metric(BaseEntity):
         *,
         project_id: str,
         run_id: str,
+        created_at: int,
         key: Optional[str] = "",
         sample: int = 1000,
         log_offset: Optional[int] = 0,  # 标记第几个分片，仅对 Log metric_type 有效
@@ -218,7 +219,6 @@ class Metric(BaseEntity):
         all: bool = False,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
         experiment_name: str = "",
     ) -> None:
         super().__init__(ctx)
@@ -318,36 +318,35 @@ class Metric(BaseEntity):
     @staticmethod
     def _build_column_ref(
         experiment_id: str,
+        created_at: int,
         key: str,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
     ) -> Dict[str, Any]:
-        ref: Dict[str, Any] = {"experimentId": experiment_id, "key": key}
+        # createdAt 为 House 查询的数据入库时间下界，必传
+        ref: Dict[str, Any] = {"experimentId": experiment_id, "key": key, "createdAt": created_at}
         if root_pro_id:
             ref["rootProId"] = root_pro_id
         if root_exp_id:
             ref["rootExpId"] = root_exp_id
-        if created_at:
-            ref["createdAt"] = created_at
         return ref
 
     @staticmethod
     def _build_scalar_payload(
         project_id: str,
         run_id: str,
+        created_at: int,
         keys: List[str],
         sample: int = 1500,
         x_type: str = "step",
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
     ) -> Dict[str, Any]:
         return {
             "projectId": project_id,
             "xType": x_type,
             "range": [0, 0],
-            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id, created_at) for key in keys],
+            "columns": [Metric._build_column_ref(run_id, created_at, key, root_pro_id, root_exp_id) for key in keys],
             "num": sample if sample <= 1500 else 1500,
         }
 
@@ -355,15 +354,15 @@ class Metric(BaseEntity):
     def _build_media_payload(
         project_id: str,
         run_id: str,
+        created_at: int,
         keys: List[str],
         step: Optional[int] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "projectId": project_id,
-            "columns": [Metric._build_column_ref(run_id, key, root_pro_id, root_exp_id, created_at) for key in keys],
+            "columns": [Metric._build_column_ref(run_id, created_at, key, root_pro_id, root_exp_id) for key in keys],
         }
         if step is not None:
             payload["step"] = step
@@ -373,11 +372,11 @@ class Metric(BaseEntity):
     def _build_export_payload(
         project_id: str,
         run_id: str,
+        created_at: int,
         keys: List[str],
         experiment_name: str = "",
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
     ) -> Dict[str, Any]:
         """Build payload for ``POST /house/metrics/scalar/export``.
 
@@ -388,13 +387,17 @@ class Metric(BaseEntity):
         exp_name = experiment_name or run_id
         columns: List[Dict[str, Any]] = []
         for key in keys:
-            col: Dict[str, Any] = {"experimentName": exp_name, "experimentId": run_id, "key": key}
+            # createdAt 为 House 查询的数据入库时间下界，必传
+            col: Dict[str, Any] = {
+                "experimentName": exp_name,
+                "experimentId": run_id,
+                "key": key,
+                "createdAt": created_at,
+            }
             if root_pro_id:
                 col["rootProId"] = root_pro_id
             if root_exp_id:
                 col["rootExpId"] = root_exp_id
-            if created_at:
-                col["createdAt"] = created_at
             columns.append(col)
         return {"projectId": project_id, "columns": columns}
 
@@ -410,8 +413,8 @@ class Metric(BaseEntity):
             params["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             params["rootExpId"] = self._root_exp_id
-        if self._created_at:
-            params["createdAt"] = self._created_at
+        # createdAt 为 House 查询的数据入库时间下界，必传
+        params["createdAt"] = self._created_at
         return params
 
     # ------------------------------------------------------------------
@@ -427,11 +430,11 @@ class Metric(BaseEntity):
         payload = self._build_scalar_payload(
             self.project_id,
             self.run_id,
+            self._created_at,
             [self.key],
             self._sample,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
 
         # 1. 获取折线数据 — 使用 key-indexed lookup 保证对齐
@@ -506,11 +509,11 @@ class Metric(BaseEntity):
         payload = self._build_media_payload(
             self.project_id,
             self.run_id,
+            self._created_at,
             [self.key],
             step=self._media_step,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
@@ -545,10 +548,10 @@ class Metric(BaseEntity):
         payload = self._build_media_payload(
             self.project_id,
             self.run_id,
+            self._created_at,
             [self.key],
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/f_media", data=payload)
         raw_data = self._extract_first(raw_resp)
@@ -595,11 +598,11 @@ class Metric(BaseEntity):
         payload = Metric._build_export_payload(
             self._project_id,
             self._run_id,
+            self._created_at,
             [self.key],
             experiment_name=self._experiment_name,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
         resp = self._post("/house/metrics/scalar/export", data=payload)
         if not resp.ok or not resp.data:
@@ -627,8 +630,8 @@ class Metric(BaseEntity):
             data["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             data["rootExpId"] = self._root_exp_id
-        if self._created_at:
-            data["createdAt"] = self._created_at
+        # createdAt 为 House 查询的数据入库时间下界，必传
+        data["createdAt"] = self._created_at
         resp = self._post("/house/metrics/log/export", data=data)
         if not resp.ok or not resp.data:
             return resp
@@ -714,7 +717,7 @@ class Metrics(BaseEntity):
         range_query: Optional[RangeQuery] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
+        created_at: int,
         experiment_name: str = "",
     ) -> None:
         super().__init__(ctx)
@@ -847,12 +850,12 @@ class Metrics(BaseEntity):
                     "data": Metric._build_scalar_payload(
                         self._project_id,
                         self._run_id,
+                        self._created_at,
                         keys,
                         self._sample,
                         x_type=x_type,
                         root_pro_id=self._root_pro_id,
                         root_exp_id=self._root_exp_id,
-                        created_at=self._created_at,
                     )
                 },
             )
@@ -889,11 +892,11 @@ class Metrics(BaseEntity):
                     "data": Metric._build_scalar_payload(
                         self._project_id,
                         self._run_id,
+                        self._created_at,
                         keys,
                         self._sample,
                         root_pro_id=self._root_pro_id,
                         root_exp_id=self._root_exp_id,
-                        created_at=self._created_at,
                     )
                 },
             ),
@@ -945,11 +948,11 @@ class Metrics(BaseEntity):
         export_payload = Metric._build_export_payload(
             self._project_id,
             self._run_id,
+            self._created_at,
             keys,
             experiment_name=self._experiment_name,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
         requests.append((self._post, "/house/metrics/scalar/export", {"data": export_payload}))
 
@@ -1012,11 +1015,11 @@ class Metrics(BaseEntity):
         payload = Metric._build_media_payload(
             self._project_id,
             self._run_id,
+            self._created_at,
             self._keys,
             step=self._media_step,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/media", data=payload)
         if not raw_resp.ok or not raw_resp.data:
@@ -1060,10 +1063,10 @@ class Metrics(BaseEntity):
         payload = Metric._build_media_payload(
             self._project_id,
             self._run_id,
+            self._created_at,
             self._keys,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
-            created_at=self._created_at,
         )
         raw_resp = self._post("/house/metrics/f_media", data=payload)
         if not raw_resp.ok or not raw_resp.data:

--- a/swanlab/api/series.py
+++ b/swanlab/api/series.py
@@ -37,7 +37,7 @@ class Key(BaseEntity):
         experiment_name_getter: Optional[Callable[[], str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
+        created_at: int,
     ) -> None:
         super().__init__(ctx)
         self._project_id = project_id
@@ -111,6 +111,7 @@ class Key(BaseEntity):
             all=all,
             root_pro_id=self._root_pro_id,
             root_exp_id=self._root_exp_id,
+            created_at=self._created_at,
         )
         return metric.json()
 
@@ -127,9 +128,11 @@ class Key(BaseEntity):
 
         experiment_name = self._resolve_experiment_name()
 
+        # createdAt 为 House 查询的数据入库时间下界，必传
         export_column: Dict[str, Any] = {
             "experimentId": self._run_id,
             "key": self._key,
+            "createdAt": self._created_at,
         }
         if experiment_name:
             export_column["experimentName"] = experiment_name
@@ -137,8 +140,6 @@ class Key(BaseEntity):
             export_column["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             export_column["rootExpId"] = self._root_exp_id
-        if self._created_at:
-            export_column["createdAt"] = self._created_at
 
         resp = self._post(
             "/house/metrics/scalar/export",
@@ -197,6 +198,10 @@ class Series(BaseEntity):
             raise ValueError(f"Invalid metric_class: {metric_class!r}, expected 'CUSTOM' or 'SYSTEM'")
         if not isinstance(experiments, list) or not experiments:
             raise ValueError("experiments must be a non-empty list of dicts")
+        # createdAt 为 House 查询的数据入库时间下界，必须携带；缺失时报错而非静默降级为无下界查询（慢查询）
+        for experiment_ref in experiments:
+            if not experiment_ref.get("createdAt"):
+                raise ValueError("each experiment ref must carry a non-zero 'createdAt' (Unix seconds)")
 
         self._experiments = experiments
         self._metric_type: ApiMetricKeyTypeLiteral = metric_type
@@ -276,7 +281,8 @@ class Series(BaseEntity):
                 experiment_name_getter=self._experiment_name_getter,
                 root_pro_id=self._root_pro_id,
                 root_exp_id=self._root_exp_id,
-                created_at=self._experiments[0].get("createdAt", 0),
+                # __init__ 已校验必携带 createdAt，直接取第一个实验的值（当前 series 仅由单实验构造）
+                created_at=self._experiments[0]["createdAt"],
             )
             for key_str in self._filtered_keys()
         ]

--- a/swanlab/api/series.py
+++ b/swanlab/api/series.py
@@ -37,6 +37,7 @@ class Key(BaseEntity):
         experiment_name_getter: Optional[Callable[[], str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
     ) -> None:
         super().__init__(ctx)
         self._project_id = project_id
@@ -47,6 +48,7 @@ class Key(BaseEntity):
         self._cached_experiment_name: Optional[str] = None
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._created_at = created_at
 
     def _resolve_experiment_name(self) -> str:
         if self._cached_experiment_name is not None:
@@ -125,7 +127,7 @@ class Key(BaseEntity):
 
         experiment_name = self._resolve_experiment_name()
 
-        export_column: Dict[str, str] = {
+        export_column: Dict[str, Any] = {
             "experimentId": self._run_id,
             "key": self._key,
         }
@@ -135,6 +137,8 @@ class Key(BaseEntity):
             export_column["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             export_column["rootExpId"] = self._root_exp_id
+        if self._created_at:
+            export_column["createdAt"] = self._created_at
 
         resp = self._post(
             "/house/metrics/scalar/export",
@@ -176,7 +180,7 @@ class Series(BaseEntity):
         self,
         ctx: ApiClientContext,
         *,
-        experiments: List[Dict[str, str]],
+        experiments: List[Dict[str, Any]],
         metric_type: ApiMetricKeyTypeLiteral = "SCALAR",
         metric_class: ApiMetricKeyClassLiteral = "CUSTOM",
         search: str = "",
@@ -272,6 +276,7 @@ class Series(BaseEntity):
                 experiment_name_getter=self._experiment_name_getter,
                 root_pro_id=self._root_pro_id,
                 root_exp_id=self._root_exp_id,
+                created_at=self._experiments[0].get("createdAt", 0),
             )
             for key_str in self._filtered_keys()
         ]

--- a/swanlab/api/summary.py
+++ b/swanlab/api/summary.py
@@ -23,7 +23,7 @@ class Summary(BaseEntity):
         keys: Optional[List[str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
-        created_at: int = 0,
+        created_at: int,
     ) -> None:
         super().__init__(ctx)
         self._project_id = project_id
@@ -35,16 +35,16 @@ class Summary(BaseEntity):
         self._data: Optional[Dict[str, Any]] = None
 
     def _build_experiment_ref(self) -> Dict[str, Any]:
+        # createdAt 为 House 查询的数据入库时间下界，必传
         ref: Dict[str, Any] = {
             "projectId": self._project_id,
             "experimentId": self._experiment_id,
+            "createdAt": self._created_at,
         }
         if self._root_pro_id:
             ref["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             ref["rootExpId"] = self._root_exp_id
-        if self._created_at:
-            ref["createdAt"] = self._created_at
         return ref
 
     def _ensure_data(self) -> Dict[str, ApiScalarSummaryItemType]:

--- a/swanlab/api/summary.py
+++ b/swanlab/api/summary.py
@@ -23,6 +23,7 @@ class Summary(BaseEntity):
         keys: Optional[List[str]] = None,
         root_pro_id: str = "",
         root_exp_id: str = "",
+        created_at: int = 0,
     ) -> None:
         super().__init__(ctx)
         self._project_id = project_id
@@ -30,10 +31,11 @@ class Summary(BaseEntity):
         self._keys = keys
         self._root_pro_id = root_pro_id
         self._root_exp_id = root_exp_id
+        self._created_at = created_at
         self._data: Optional[Dict[str, Any]] = None
 
-    def _build_experiment_ref(self) -> Dict[str, str]:
-        ref: Dict[str, str] = {
+    def _build_experiment_ref(self) -> Dict[str, Any]:
+        ref: Dict[str, Any] = {
             "projectId": self._project_id,
             "experimentId": self._experiment_id,
         }
@@ -41,6 +43,8 @@ class Summary(BaseEntity):
             ref["rootProId"] = self._root_pro_id
         if self._root_exp_id:
             ref["rootExpId"] = self._root_exp_id
+        if self._created_at:
+            ref["createdAt"] = self._created_at
         return ref
 
     def _ensure_data(self) -> Dict[str, ApiScalarSummaryItemType]:

--- a/swanlab/api/typings/experiment.py
+++ b/swanlab/api/typings/experiment.py
@@ -95,3 +95,5 @@ class ApiExperimentType(TypedDict, total=False):
     user: ApiUserType
     rootProId: str
     rootExpId: str
+    # 实验创建时间，ISO 8601 字符串
+    createdAt: str

--- a/swanlab/api/utils.py
+++ b/swanlab/api/utils.py
@@ -6,7 +6,6 @@
 """
 
 import re
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union, get_args, get_type_hints
 
 from swanlab.api.typings.common import (
@@ -233,36 +232,6 @@ def parse_timestamp_ms(value: Union[int, str]) -> int:
         while v < 1_000_000_000_000:
             v *= 10
     return v
-
-
-def parse_timestamp_s(value: Union[int, str, None]) -> int:
-    """将时间统一转换为秒级 Unix 时间戳（10 位），用于 House 查询接口的 ``createdAt`` 参数。
-
-    支持格式：
-    - int / 数字字符串：秒（10 位）或毫秒（13 位）级时间戳，自动归一化为秒
-    - ISO 8601 字符串：如 ``"2024-08-01T00:00:00Z"``、``"2024-08-01T08:00:00+08:00"``，无时区时按 UTC 解析
-    - None / 空字符串 / 无法解析：返回 0
-    """
-    if value is None:
-        return 0
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return 0
-        if not text.isdigit():
-            try:
-                dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
-            except ValueError:
-                return 0
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return int(dt.timestamp())
-        value = int(text)
-    if not isinstance(value, int) or value <= 0:
-        return 0
-    while value > 9_999_999_999:
-        value //= 1000
-    return value
 
 
 # ---------------------------------------------------------------------------

--- a/swanlab/api/utils.py
+++ b/swanlab/api/utils.py
@@ -6,6 +6,7 @@
 """
 
 import re
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union, get_args, get_type_hints
 
 from swanlab.api.typings.common import (
@@ -232,6 +233,36 @@ def parse_timestamp_ms(value: Union[int, str]) -> int:
         while v < 1_000_000_000_000:
             v *= 10
     return v
+
+
+def parse_timestamp_s(value: Union[int, str, None]) -> int:
+    """将时间统一转换为秒级 Unix 时间戳（10 位），用于 House 查询接口的 ``createdAt`` 参数。
+
+    支持格式：
+    - int / 数字字符串：秒（10 位）或毫秒（13 位）级时间戳，自动归一化为秒
+    - ISO 8601 字符串：如 ``"2024-08-01T00:00:00Z"``、``"2024-08-01T08:00:00+08:00"``，无时区时按 UTC 解析
+    - None / 空字符串 / 无法解析：返回 0
+    """
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 0
+        if not text.isdigit():
+            try:
+                dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except ValueError:
+                return 0
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        value = int(text)
+    if not isinstance(value, int) or value <= 0:
+        return 0
+    while value > 9_999_999_999:
+        value //= 1000
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -7,7 +7,6 @@ from swanlab.api import Api
 from swanlab.api.metric import Metric, Metrics
 from swanlab.api.summary import Summary
 from swanlab.api.typings.common import RangeQuery
-from swanlab.api.utils import parse_timestamp_s
 from swanlab.cli.api.helper import (
     COLUMN_CLASS_TYPE,
     COLUMN_DATA_TYPE,
@@ -21,6 +20,7 @@ from swanlab.cli.api.helper import (
     validate_filter_query,
     with_custom_host,
 )
+from swanlab.utils.time import parse_timestamp_s
 
 
 @click.group("run")

--- a/swanlab/cli/api/experiment.py
+++ b/swanlab/cli/api/experiment.py
@@ -7,6 +7,7 @@ from swanlab.api import Api
 from swanlab.api.metric import Metric, Metrics
 from swanlab.api.summary import Summary
 from swanlab.api.typings.common import RangeQuery
+from swanlab.api.utils import parse_timestamp_s
 from swanlab.cli.api.helper import (
     COLUMN_CLASS_TYPE,
     COLUMN_DATA_TYPE,
@@ -356,6 +357,7 @@ def get_experiment_metrics(
         range_query=rq,
         root_pro_id=experiment.root_pro_id,
         root_exp_id=experiment.root_exp_id,
+        created_at=parse_timestamp_s(experiment.created_at),
     )
     resp = metrics.wrapper()
     payload = format_output(resp)
@@ -393,6 +395,7 @@ def get_experiment_summary(path: str, keys: Optional[str], save_name: str, api: 
         keys=key_list,
         root_pro_id=experiment.root_pro_id,
         root_exp_id=experiment.root_exp_id,
+        created_at=parse_timestamp_s(experiment.created_at),
     )
     resp = summary.wrapper()
     payload = format_output(resp)
@@ -502,6 +505,7 @@ def get_experiment_medias(
         all=fetch_all,
         root_pro_id=experiment.root_pro_id,
         root_exp_id=experiment.root_exp_id,
+        created_at=parse_timestamp_s(experiment.created_at),
     )
     resp = metrics.wrapper()
     payload = format_output(resp)
@@ -564,6 +568,7 @@ def get_experiment_logs(
         ignore_timestamp=ignore_timestamp,
         root_pro_id=experiment.root_pro_id,
         root_exp_id=experiment.root_exp_id,
+        created_at=parse_timestamp_s(experiment.created_at),
     )
     resp = metric.wrapper()
     payload = format_output(resp)

--- a/swanlab/sdk/internal/core_python/api/experiment.py
+++ b/swanlab/sdk/internal/core_python/api/experiment.py
@@ -71,13 +71,21 @@ def create_or_resume_experiment(
     resp = client.post(f"/project/{username}/{project}/experiment", helper.strip_none(body, strip_empty_str=True))
     # 200代表实验已存在，开启更新模式
     # 201代表实验不存在，新建实验
+    # NOTE: 后端返回值没有携带createdAt字段，如果实验不存在则使用前端传入的createdAt字段作为实验创建时间，否则再请求一次获取实验创建时间
+    experiment: InitExperimentType = resp.data
+    is_new_experiment = resp.raw.status_code == 201
+    if is_new_experiment:
+        experiment["createdAt"] = created_at.ToDatetime().isoformat() + "Z"
+    else:
+        exp_resp = client.get(f"/project/{username}/{project}/runs/{experiment['cuid']}")
+        experiment["createdAt"] = exp_resp.data["createdAt"]
     return resp.data, resp.raw.status_code == 201
 
 
 def get_experiment_summary(
     project_id: str,
     experiment_id: str,
-    created_at: Union[int, str, None],
+    created_at: Union[int, str],
 ) -> ResumeExperimentSummaryType:
     """
     获取实验摘要

--- a/swanlab/sdk/internal/core_python/api/experiment.py
+++ b/swanlab/sdk/internal/core_python/api/experiment.py
@@ -5,7 +5,8 @@
 @description: SwanLab 运行时实验API
 """
 
-from typing import List, Literal, Optional, Tuple
+from datetime import datetime, timezone
+from typing import List, Literal, Optional, Tuple, Union
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -13,8 +14,43 @@ from swanlab.exceptions import ApiError
 from swanlab.proto.swanlab.run.v1.run_pb2 import RUN_STATE_ABORTED, RUN_STATE_CRASHED, RunState
 from swanlab.sdk.internal.core_python import client
 from swanlab.sdk.internal.pkg import helper
-from swanlab.sdk.typings.core_python.api.experiment import InitExperimentType, ResumeExperimentSummaryType
+from swanlab.sdk.typings.core_python.api.experiment import (
+    CREATED_AT_MAX,
+    CREATED_AT_MIN,
+    InitExperimentType,
+    ResumeExperimentSummaryType,
+)
 from swanlab.sdk.typings.run import ResumeType
+
+
+def parse_timestamp_s(value: Union[int, str, None]) -> int:
+    """将时间统一转换为秒级 Unix 时间戳（10 位），用于 House 查询接口的 ``createdAt`` 参数。
+
+    支持格式：
+    - int / 数字字符串：秒（10 位）或毫秒（13 位）级时间戳，自动归一化为秒
+    - ISO 8601 字符串：如 ``"2024-08-01T00:00:00Z"``、``"2024-08-01T08:00:00+08:00"``，无时区时按 UTC 解析
+    - None / 空字符串 / 无法解析：返回 0
+    """
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return 0
+        if not text.isdigit():
+            try:
+                dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except ValueError:
+                return 0
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        value = int(text)
+    if not isinstance(value, int) or value <= 0:
+        return 0
+    while value > 9_999_999_999:
+        value //= 1000
+    return value
 
 
 def create_or_resume_experiment(
@@ -70,13 +106,22 @@ def create_or_resume_experiment(
     return resp.data, resp.raw.status_code == 201
 
 
-def get_experiment_summary(project_id: str, experiment_id: str) -> ResumeExperimentSummaryType:
+def get_experiment_summary(
+    project_id: str,
+    experiment_id: str,
+    created_at: Union[int, str, None] = None,
+) -> ResumeExperimentSummaryType:
     """
     获取实验摘要
     :param project_id: 所属项目ID
     :param experiment_id: 所属实验ID
+    :param created_at: 实验创建时间（ISO 8601 字符串或秒/毫秒时间戳），作为数据入库时间的查询下界；
+        无法解析时回退到下界值（全历史扫描）以保证查询正确性
     """
-    resp = client.get(f"/house/metrics/summaries/{project_id}/{experiment_id}", {"all": True})
+    ts = parse_timestamp_s(created_at)
+    if not CREATED_AT_MIN <= ts <= CREATED_AT_MAX:
+        ts = CREATED_AT_MIN
+    resp = client.get(f"/house/metrics/summaries/{project_id}/{experiment_id}", {"all": True, "createdAt": ts})
     return resp.data
 
 

--- a/swanlab/sdk/internal/core_python/api/experiment.py
+++ b/swanlab/sdk/internal/core_python/api/experiment.py
@@ -77,9 +77,15 @@ def create_or_resume_experiment(
     is_new_experiment = resp.raw.status_code == 201
     if is_new_experiment:
         experiment["createdAt"] = created_at_for_request
-    else:
+    elif not experiment.get("createdAt"):
+        # 旧后端 POST 响应未携带 createdAt，回退到 GET 获取
         exp_resp = client.get(f"/project/{username}/{project}/runs/{experiment['cuid']}")
-        experiment["createdAt"] = exp_resp.data["createdAt"]
+        created_at_for_response = exp_resp.data.get("createdAt", "")
+        if not created_at_for_response:
+            raise ValueError(
+                f"Backend did not return createdAt for experiment {experiment['cuid']}; please upgrade swanlab-server"
+            )
+        experiment["createdAt"] = created_at_for_response
     return resp.data, resp.raw.status_code == 201
 
 

--- a/swanlab/sdk/internal/core_python/api/experiment.py
+++ b/swanlab/sdk/internal/core_python/api/experiment.py
@@ -58,10 +58,11 @@ def create_or_resume_experiment(
             if e.response.status_code == 404 and e.response.reason == "Not Found":
                 raise RuntimeError(f"Experiment {run_id} does not exist in project {project}")
     labels = [{"name": tag} for tag in tags] if tags else []
+    created_at_for_request = created_at.ToDatetime().isoformat() + "Z"
     body = {
         "name": name,
         "description": description,
-        "createdAt": created_at.ToDatetime().isoformat() + "Z",
+        "createdAt": created_at_for_request,
         "colors": [color, color],
         "labels": labels if len(labels) else None,
         "job": job_type,
@@ -75,7 +76,7 @@ def create_or_resume_experiment(
     experiment: InitExperimentType = resp.data
     is_new_experiment = resp.raw.status_code == 201
     if is_new_experiment:
-        experiment["createdAt"] = created_at.ToDatetime().isoformat() + "Z"
+        experiment["createdAt"] = created_at_for_request
     else:
         exp_resp = client.get(f"/project/{username}/{project}/runs/{experiment['cuid']}")
         experiment["createdAt"] = exp_resp.data["createdAt"]

--- a/swanlab/sdk/internal/core_python/api/experiment.py
+++ b/swanlab/sdk/internal/core_python/api/experiment.py
@@ -5,7 +5,6 @@
 @description: SwanLab 运行时实验API
 """
 
-from datetime import datetime, timezone
 from typing import List, Literal, Optional, Tuple, Union
 
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -15,42 +14,11 @@ from swanlab.proto.swanlab.run.v1.run_pb2 import RUN_STATE_ABORTED, RUN_STATE_CR
 from swanlab.sdk.internal.core_python import client
 from swanlab.sdk.internal.pkg import helper
 from swanlab.sdk.typings.core_python.api.experiment import (
-    CREATED_AT_MAX,
-    CREATED_AT_MIN,
     InitExperimentType,
     ResumeExperimentSummaryType,
 )
 from swanlab.sdk.typings.run import ResumeType
-
-
-def parse_timestamp_s(value: Union[int, str, None]) -> int:
-    """将时间统一转换为秒级 Unix 时间戳（10 位），用于 House 查询接口的 ``createdAt`` 参数。
-
-    支持格式：
-    - int / 数字字符串：秒（10 位）或毫秒（13 位）级时间戳，自动归一化为秒
-    - ISO 8601 字符串：如 ``"2024-08-01T00:00:00Z"``、``"2024-08-01T08:00:00+08:00"``，无时区时按 UTC 解析
-    - None / 空字符串 / 无法解析：返回 0
-    """
-    if value is None:
-        return 0
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return 0
-        if not text.isdigit():
-            try:
-                dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
-            except ValueError:
-                return 0
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return int(dt.timestamp())
-        value = int(text)
-    if not isinstance(value, int) or value <= 0:
-        return 0
-    while value > 9_999_999_999:
-        value //= 1000
-    return value
+from swanlab.utils.time import parse_timestamp_s
 
 
 def create_or_resume_experiment(
@@ -109,18 +77,16 @@ def create_or_resume_experiment(
 def get_experiment_summary(
     project_id: str,
     experiment_id: str,
-    created_at: Union[int, str, None] = None,
+    created_at: Union[int, str, None],
 ) -> ResumeExperimentSummaryType:
     """
     获取实验摘要
     :param project_id: 所属项目ID
     :param experiment_id: 所属实验ID
-    :param created_at: 实验创建时间（ISO 8601 字符串或秒/毫秒时间戳），作为数据入库时间的查询下界；
-        无法解析时回退到下界值（全历史扫描）以保证查询正确性
+    :param created_at: 实验创建时间（ISO 8601 字符串或秒/毫秒时间戳），作为数据入库时间的查询下界
+    :raises ValueError: created_at 缺失或无法解析时抛出，避免回退到全历史扫描导致慢查询
     """
     ts = parse_timestamp_s(created_at)
-    if not CREATED_AT_MIN <= ts <= CREATED_AT_MAX:
-        ts = CREATED_AT_MIN
     resp = client.get(f"/house/metrics/summaries/{project_id}/{experiment_id}", {"all": True, "createdAt": ts})
     return resp.data
 

--- a/swanlab/sdk/internal/core_python/core.py
+++ b/swanlab/sdk/internal/core_python/core.py
@@ -160,7 +160,11 @@ class CorePython(CoreProtocol):
         # 3. resume 时，向后端获取数据
         summary: Optional[ResumeExperimentSummaryType] = None
         if not run_info.new_experiment:
-            summary = get_experiment_summary(self._ctx.project_id, self._ctx.experiment_id)
+            summary = get_experiment_summary(
+                self._ctx.project_id,
+                self._ctx.experiment_id,
+                created_at=run_info.experiment.get("createdAt"),
+            )
         self._metrics, console_epoch, global_step, global_system_step = RunMetrics.new(summary, ctx=self._ctx)
         self._epoch.reset(console_epoch)
         # 4. 构建记录

--- a/swanlab/sdk/internal/core_python/core.py
+++ b/swanlab/sdk/internal/core_python/core.py
@@ -163,7 +163,7 @@ class CorePython(CoreProtocol):
             summary = get_experiment_summary(
                 self._ctx.project_id,
                 self._ctx.experiment_id,
-                created_at=run_info.experiment.get("createdAt"),
+                created_at=run_info.experiment["createdAt"],
             )
         self._metrics, console_epoch, global_step, global_system_step = RunMetrics.new(summary, ctx=self._ctx)
         self._epoch.reset(console_epoch)

--- a/swanlab/sdk/internal/core_python/sync.py
+++ b/swanlab/sdk/internal/core_python/sync.py
@@ -139,7 +139,7 @@ class CoreSyncPython(CoreSyncProtocol):
                 summary = get_experiment_summary(
                     self._ctx.project_id,
                     self._ctx.experiment_id,
-                    created_at=result.experiment.get("createdAt"),
+                    created_at=result.experiment["createdAt"],
                 )
             self._metrics, self._epoch, _, _ = RunMetrics.new(summary, ctx=self._ctx)
             metrics_ready = True

--- a/swanlab/sdk/internal/core_python/sync.py
+++ b/swanlab/sdk/internal/core_python/sync.py
@@ -136,7 +136,11 @@ class CoreSyncPython(CoreSyncProtocol):
             # 2. 如果是旧实验，向后端请求实验摘要
             summary: Optional[ResumeExperimentSummaryType] = None
             if not result.new_experiment:
-                summary = get_experiment_summary(self._ctx.project_id, self._ctx.experiment_id)
+                summary = get_experiment_summary(
+                    self._ctx.project_id,
+                    self._ctx.experiment_id,
+                    created_at=result.experiment.get("createdAt"),
+                )
             self._metrics, self._epoch, _, _ = RunMetrics.new(summary, ctx=self._ctx)
             metrics_ready = True
 

--- a/swanlab/sdk/typings/core_python/api/experiment.py
+++ b/swanlab/sdk/typings/core_python/api/experiment.py
@@ -9,10 +9,6 @@ from typing import List, Optional, TypedDict
 
 from typing_extensions import NotRequired
 
-# createdAt 参数的合法区间（10 位 Unix Timestamp）
-CREATED_AT_MIN = 1_000_000_000
-CREATED_AT_MAX = 9_999_999_999
-
 
 class InitExperimentType(TypedDict):
     # 实验cuid

--- a/swanlab/sdk/typings/core_python/api/experiment.py
+++ b/swanlab/sdk/typings/core_python/api/experiment.py
@@ -7,6 +7,8 @@
 
 from typing import List, Optional, TypedDict
 
+from typing_extensions import NotRequired
+
 # createdAt 参数的合法区间（10 位 Unix Timestamp）
 CREATED_AT_MIN = 1_000_000_000
 CREATED_AT_MAX = 9_999_999_999
@@ -20,7 +22,7 @@ class InitExperimentType(TypedDict):
     # 实验名称
     name: str
     # 实验创建时间，ISO 8601 字符串，resume 时作为 House 查询的 createdAt 下界
-    createdAt: Optional[str]
+    createdAt: NotRequired[str]
 
 
 _ColumnSummary = TypedDict("_ColumnSummary", {"key": str, "step": int})

--- a/swanlab/sdk/typings/core_python/api/experiment.py
+++ b/swanlab/sdk/typings/core_python/api/experiment.py
@@ -7,6 +7,10 @@
 
 from typing import List, Optional, TypedDict
 
+# createdAt 参数的合法区间（10 位 Unix Timestamp）
+CREATED_AT_MIN = 1_000_000_000
+CREATED_AT_MAX = 9_999_999_999
+
 
 class InitExperimentType(TypedDict):
     # 实验cuid
@@ -15,6 +19,8 @@ class InitExperimentType(TypedDict):
     slug: Optional[str]
     # 实验名称
     name: str
+    # 实验创建时间，ISO 8601 字符串，resume 时作为 House 查询的 createdAt 下界
+    createdAt: Optional[str]
 
 
 _ColumnSummary = TypedDict("_ColumnSummary", {"key": str, "step": int})

--- a/swanlab/sdk/typings/core_python/api/experiment.py
+++ b/swanlab/sdk/typings/core_python/api/experiment.py
@@ -7,8 +7,6 @@
 
 from typing import List, Optional, TypedDict
 
-from typing_extensions import NotRequired
-
 
 class InitExperimentType(TypedDict):
     # 实验cuid
@@ -18,7 +16,7 @@ class InitExperimentType(TypedDict):
     # 实验名称
     name: str
     # 实验创建时间，ISO 8601 字符串，resume 时作为 House 查询的 createdAt 下界
-    createdAt: NotRequired[str]
+    createdAt: str
 
 
 _ColumnSummary = TypedDict("_ColumnSummary", {"key": str, "step": int})

--- a/swanlab/utils/time/__init__.py
+++ b/swanlab/utils/time/__init__.py
@@ -1,0 +1,50 @@
+"""
+@author: cunyue
+@file: __init__.py
+@time: 2026/8/18
+@description: 时间戳解析辅助函数，供 API 查询 lane 与运行时 SDK lane 共用
+"""
+
+from datetime import datetime, timezone
+from typing import Union
+
+__all__ = ["TIMESTAMP_S_MAX", "TIMESTAMP_S_MIN", "parse_timestamp_s"]
+
+# 秒级 Unix 时间戳的合法区间（10 位）
+TIMESTAMP_S_MIN = 1_000_000_000
+TIMESTAMP_S_MAX = 9_999_999_999
+
+
+def parse_timestamp_s(value: Union[int, str, None]) -> int:
+    """将时间统一转换为秒级 Unix 时间戳（10 位），用于 House 查询接口的 ``createdAt`` 参数。
+
+    支持格式：
+    - int / 数字字符串：秒（10 位）或毫秒（13 位）级时间戳，自动归一化为秒
+    - ISO 8601 字符串：如 ``"2024-08-01T00:00:00Z"``、``"2024-08-01T08:00:00+08:00"``，无时区时按 UTC 解析
+
+    :raises ValueError: ``value`` 为 None、空字符串、无法解析、非正数或越出合法区间时抛出；
+        不做默认值回退，避免 House 退化为全历史扫描（慢查询）
+    """
+    if value is None:
+        raise ValueError("timestamp value is required, got None")
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            raise ValueError("timestamp value must not be an empty string")
+        if not text.isdigit():
+            try:
+                dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError(f"Invalid ISO 8601 timestamp: {text!r}") from exc
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            value = int(dt.timestamp())
+        else:
+            value = int(text)
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Expected positive int timestamp, got {value!r}")
+    while value > TIMESTAMP_S_MAX:
+        value //= 1000
+    if not TIMESTAMP_S_MIN <= value <= TIMESTAMP_S_MAX:
+        raise ValueError(f"Timestamp {value} out of range [{TIMESTAMP_S_MIN}, {TIMESTAMP_S_MAX}]")
+    return value

--- a/swanlab/utils/time/__init__.py
+++ b/swanlab/utils/time/__init__.py
@@ -15,7 +15,7 @@ TIMESTAMP_S_MIN = 1_000_000_000
 TIMESTAMP_S_MAX = 9_999_999_999
 
 
-def parse_timestamp_s(value: Union[int, str, None]) -> int:
+def parse_timestamp_s(value: Union[int, str]) -> int:
     """将时间统一转换为秒级 Unix 时间戳（10 位），用于 House 查询接口的 ``createdAt`` 参数。
 
     支持格式：

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -422,6 +422,152 @@ class TestMetricValidation:
 
 
 # ---------------------------------------------------------------------------
+# createdAt — 类型与精度兼容 + payload 注入
+# ---------------------------------------------------------------------------
+class TestCreatedAt:
+    def test_parse_timestamp_s_variants(self):
+        from swanlab.api.utils import parse_timestamp_s
+
+        assert parse_timestamp_s(None) == 0
+        assert parse_timestamp_s("") == 0
+        assert parse_timestamp_s("   ") == 0
+        assert parse_timestamp_s("not-a-date") == 0
+        assert parse_timestamp_s(0) == 0
+        assert parse_timestamp_s(-100) == 0
+        assert parse_timestamp_s(1722470400) == 1722470400
+        assert parse_timestamp_s("1722470400") == 1722470400
+        assert parse_timestamp_s(1722470400000) == 1722470400
+        assert parse_timestamp_s("1722470400000") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00Z") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00.123Z") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00+00:00") == 1722470400
+        assert parse_timestamp_s("2024-08-01T08:00:00+08:00") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00") == 1722470400
+
+    def test_parse_timestamp_s_mirror_implementations_are_identical(self):
+        """api 与 core_python 两 lane 各自实现了 parse_timestamp_s，除 docstring 外必须逐行相同。"""
+        import ast
+        import inspect
+
+        from swanlab.api.utils import parse_timestamp_s as api_impl
+        from swanlab.sdk.internal.core_python.api.experiment import parse_timestamp_s as core_impl
+
+        def normalized_source(func) -> ast.AST:
+            tree = ast.parse(inspect.getsource(func))
+            tree.body[0].body = [node for node in tree.body[0].body if not isinstance(node, ast.Expr)]
+            return tree
+
+        assert ast.dump(normalized_source(api_impl)) == ast.dump(normalized_source(core_impl))
+
+    def test_metrics_payload_contains_created_at(self, ctx):
+        ctx.client.get.side_effect = [
+            _api_response(
+                {
+                    "cuid": "run-cuid",
+                    "slug": "run-slug",
+                    "name": "test-run",
+                    "project_id": "project-cuid",
+                    "createdAt": "2024-08-01T00:00:00.000Z",
+                }
+            )
+        ]
+        ctx.client.post.return_value = _api_response([{"key": "loss", "metrics": []}, {"key": "loss", "latest": {}}])
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.metrics(keys=["loss"])
+
+        scalar_calls = [c for c in ctx.client.post.call_args_list if c.args[0] == "/house/metrics/scalar"]
+        assert len(scalar_calls) == 1
+        assert scalar_calls[0].kwargs["data"]["columns"] == [
+            {"experimentId": "run-cuid", "key": "loss", "createdAt": 1722470400}
+        ]
+
+    def test_logs_params_contain_created_at(self, ctx):
+        def get(path, **kwargs):
+            if path == "/project/user/proj/runs/run-slug":
+                return _api_response(
+                    {
+                        "cuid": "run-cuid",
+                        "slug": "run-slug",
+                        "name": "test-run",
+                        "project_id": "project-cuid",
+                        "createdAt": "2024-08-01T00:00:00Z",
+                    }
+                )
+            if path == "/house/metrics/log":
+                return _api_response({"logs": [{"message": "ready"}], "count": 1})
+            raise AssertionError(f"unexpected GET {path}")
+
+        ctx.client.get.side_effect = get
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.logs()
+
+        _, kwargs = ctx.client.get.call_args_list[-1]
+        assert kwargs["params"]["createdAt"] == 1722470400
+
+    def test_summary_payload_contains_created_at(self, ctx):
+        ctx.client.get.side_effect = [
+            _api_response(
+                {
+                    "cuid": "run-cuid",
+                    "slug": "run-slug",
+                    "name": "test-run",
+                    "project_id": "project-cuid",
+                    "createdAt": "2024-08-01T00:00:00Z",
+                }
+            )
+        ]
+        ctx.client.post.return_value = _api_response({"run-cuid": {"loss": {"latest": {"value": 1.0}}}})
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.summary()
+
+        payload = ctx.client.post.call_args_list[0].kwargs["data"]
+        assert payload["experiments"] == [
+            {
+                "projectId": "project-cuid",
+                "experimentId": "run-cuid",
+                "createdAt": 1722470400,
+            }
+        ]
+
+    def test_payload_omits_created_at_when_missing(self, ctx):
+        ctx.client.get.side_effect = [
+            _api_response({"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"})
+        ]
+        ctx.client.post.return_value = _api_response({"run-cuid": {}})
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        exp.summary()
+
+        payload = ctx.client.post.call_args_list[0].kwargs["data"]
+        assert "createdAt" not in payload["experiments"][0]
+
+    def test_series_requests_contain_created_at(self, ctx):
+        ctx.client.get.side_effect = [
+            _api_response(
+                {
+                    "cuid": "run-cuid",
+                    "slug": "run-slug",
+                    "name": "test-run",
+                    "project_id": "project-cuid",
+                    "createdAt": "2024-08-01T00:00:00Z",
+                }
+            )
+        ]
+        ctx.client.post.return_value = _api_response({"keys": ["loss"], "hasMore": False, "nextCursor": ""})
+        exp = Experiment(ctx, path="user/proj/run-slug")
+
+        list(exp.series())
+
+        keys_payload = ctx.client.post.call_args_list[0].kwargs["data"]
+        assert keys_payload["experiments"] == [
+            {"projectId": "project-cuid", "experimentId": "run-cuid", "createdAt": 1722470400}
+        ]
+
+
+# ---------------------------------------------------------------------------
 # Experiments POST 过滤 — 校验
 # ---------------------------------------------------------------------------
 class TestExperimentsFilterValidation:

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -19,6 +19,7 @@ from swanlab.api.experiment import Experiment, Experiments
 from swanlab.api.metric import Metric, Metrics
 from swanlab.api.project import Project
 from swanlab.api.self_hosted import SelfHosted
+from swanlab.api.series import Series
 from swanlab.api.typings.common import PaginatedQuery
 from swanlab.api.typings.selfhosted import ApiSelfHostedInfoType
 from swanlab.api.workspace import Workspace
@@ -115,7 +116,10 @@ class TestApiEntryValidation:
             api.column("testuser/project/run1", key="")
 
     @pytest.mark.parametrize("column_type", ["STRING", "IMAGE"])
-    def test_columns_accept_documented_column_types(self, api, column_type):
+    def test_columns_accept_documented_column_types(self, ctx, api, column_type):
+        ctx.client.get.return_value = _api_response(
+            {"cuid": "run-cuid", "slug": "run1", "name": "test-run", "createdAt": "2024-08-01T00:00:00Z"}
+        )
         columns = api.columns("testuser/project/run1", column_type=column_type)
         assert isinstance(columns, Columns)
 
@@ -353,11 +357,11 @@ class TestExperimentRunIdResolution:
 class TestColumnValidation:
     def test_columns_invalid_type_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid column_type"):
-            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_type="INVALID")  # type: ignore
+            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_type="INVALID", exp_created_at=1)  # type: ignore
 
     def test_columns_invalid_class_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid column_class"):
-            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_class="INVALID")  # type: ignore
+            Columns(ctx, path="user/proj/run1", query=PaginatedQuery(), column_class="INVALID", exp_created_at=1)  # type: ignore
 
     def test_iterated_columns_resolve_run_cuid_once_for_local_fields(self, ctx):
         ctx.client.get.side_effect = [
@@ -374,7 +378,7 @@ class TestColumnValidation:
             ),
         ]
 
-        columns = Columns(ctx, path="user/proj/run-slug", query=PaginatedQuery())
+        columns = Columns(ctx, path="user/proj/run-slug", query=PaginatedQuery(), exp_created_at=1722470400)
 
         assert [column.name for column in columns] == ["loss", "acc"]
         assert [call.args[0] for call in ctx.client.get.call_args_list] == [
@@ -394,7 +398,7 @@ class TestColumnValidation:
             ),
         ]
 
-        col = Column(ctx, path="user/proj/run-slug", key="loss")
+        col = Column(ctx, path="user/proj/run-slug", key="loss", exp_created_at=1722470400)
 
         assert col.name == "loss"
         assert col.run_id == "run-cuid"
@@ -405,7 +409,7 @@ class TestColumnValidation:
 
     def test_column_project_id_fetches_project_lazily(self, ctx):
         item = {"key": "loss", "name": "loss", "type": "FLOAT", "class": "CUSTOM"}
-        col = Column(ctx, path="user/proj/run1", key="loss", data=cast(Any, item))
+        col = Column(ctx, path="user/proj/run1", key="loss", data=cast(Any, item), exp_created_at=1722470400)
         ctx.client.get.return_value = _api_response({"cuid": "project-cuid"})
 
         assert col.project_id == "project-cuid"
@@ -418,28 +422,28 @@ class TestColumnValidation:
 class TestMetricValidation:
     def test_metric_invalid_type_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid metric_type"):
-            Metric(ctx, project_id="p1", run_id="r1", key="loss", metric_type="INVALID")
+            Metric(ctx, project_id="p1", run_id="r1", key="loss", metric_type="INVALID", created_at=1)
 
     def test_metric_invalid_log_level_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid metric log level"):
-            Metric(ctx, project_id="p1", run_id="r1", key="LOG", metric_type="LOG", log_level="VERBOSE")  # type: ignore
+            Metric(ctx, project_id="p1", run_id="r1", key="LOG", metric_type="LOG", log_level="VERBOSE", created_at=1)  # type: ignore
 
     def test_metric_scalar_no_key_raises(self, ctx):
         with pytest.raises(ValueError, match="key is required"):
-            Metric(ctx, project_id="p1", run_id="r1", key="", metric_type="SCALAR")
+            Metric(ctx, project_id="p1", run_id="r1", key="", metric_type="SCALAR", created_at=1)
 
     def test_metrics_empty_keys_raises(self, ctx):
         with pytest.raises(ValueError, match="non-empty"):
-            Metrics(ctx, project_id="p1", run_id="r1", keys=[], metric_type="SCALAR")
+            Metrics(ctx, project_id="p1", run_id="r1", keys=[], metric_type="SCALAR", created_at=1)
 
     def test_metrics_invalid_type_raises(self, ctx):
         with pytest.raises(ValueError, match="Invalid metric_type"):
-            Metrics(ctx, project_id="p1", run_id="r1", keys=["loss"], metric_type=cast(Any, "INVALID"))
+            Metrics(ctx, project_id="p1", run_id="r1", keys=["loss"], metric_type=cast(Any, "INVALID"), created_at=1)
 
     @pytest.mark.parametrize("keys", ["loss", [""], None])
     def test_metrics_invalid_keys_raises(self, ctx, keys):
         with pytest.raises(ValueError, match="keys must be a non-empty list"):
-            Metrics(ctx, project_id="p1", run_id="r1", keys=cast(List[str], keys), metric_type="SCALAR")
+            Metrics(ctx, project_id="p1", run_id="r1", keys=cast(List[str], keys), metric_type="SCALAR", created_at=1)
 
 
 # ---------------------------------------------------------------------------
@@ -550,6 +554,16 @@ class TestCreatedAt:
         assert keys_payload["experiments"] == [
             {"projectId": "project-cuid", "experimentId": "run-cuid", "createdAt": 1722470400}
         ]
+
+    def test_series_raises_when_created_at_missing(self, ctx):
+        ctx.client.post.return_value = _api_response({"keys": ["loss"], "hasMore": False, "nextCursor": ""})
+
+        # experiment ref 缺失 createdAt 时必须强制报错，禁止静默降级为无下界查询（慢查询）
+        with pytest.raises(ValueError, match="createdAt"):
+            Series(
+                ctx.client,
+                experiments=[{"projectId": "project-cuid", "experimentId": "run-cuid"}],
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -251,7 +251,9 @@ class TestExperimentRunIdResolution:
 
     def test_column_created_from_experiment_uses_run_cuid(self, ctx):
         ctx.client.get.side_effect = [
-            _api_response({"cuid": "run-cuid", "slug": "run-slug", "name": "test-run"}),
+            _api_response(
+                {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "createdAt": "2024-08-01T00:00:00Z"}
+            ),
         ]
         exp = Experiment(ctx, path="user/proj/run-slug")
 
@@ -263,7 +265,13 @@ class TestExperimentRunIdResolution:
         def get(path, **kwargs):
             if path == "/project/user/proj/runs/run-slug":
                 return _api_response(
-                    {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"}
+                    {
+                        "cuid": "run-cuid",
+                        "slug": "run-slug",
+                        "name": "test-run",
+                        "project_id": "project-cuid",
+                        "createdAt": "2024-08-01T00:00:00Z",
+                    }
                 )
             raise AssertionError(f"unexpected GET {path}")
 
@@ -279,13 +287,19 @@ class TestExperimentRunIdResolution:
         payload = ctx.client.post.call_args_list[0].kwargs["data"]
         assert [call.args[0] for call in ctx.client.get.call_args_list] == ["/project/user/proj/runs/run-slug"]
         assert payload["projectId"] == "project-cuid"
-        assert payload["columns"] == [{"experimentId": "run-cuid", "key": "loss"}]
+        assert payload["columns"] == [{"experimentId": "run-cuid", "key": "loss", "createdAt": 1722470400}]
 
     def test_medias_uses_run_cuid_for_metric_payload(self, ctx):
         def get(path, **kwargs):
             if path == "/project/user/proj/runs/run-slug":
                 return _api_response(
-                    {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"}
+                    {
+                        "cuid": "run-cuid",
+                        "slug": "run-slug",
+                        "name": "test-run",
+                        "project_id": "project-cuid",
+                        "createdAt": "2024-08-01T00:00:00Z",
+                    }
                 )
             raise AssertionError(f"unexpected GET {path}")
 
@@ -300,13 +314,19 @@ class TestExperimentRunIdResolution:
         payload = ctx.client.post.call_args_list[0].kwargs["data"]
         assert [call.args[0] for call in ctx.client.get.call_args_list] == ["/project/user/proj/runs/run-slug"]
         assert payload["projectId"] == "project-cuid"
-        assert payload["columns"] == [{"experimentId": "run-cuid", "key": "image"}]
+        assert payload["columns"] == [{"experimentId": "run-cuid", "key": "image", "createdAt": 1722470400}]
 
     def test_logs_uses_run_cuid_for_log_params(self, ctx):
         def get(path, **kwargs):
             if path == "/project/user/proj/runs/run-slug":
                 return _api_response(
-                    {"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"}
+                    {
+                        "cuid": "run-cuid",
+                        "slug": "run-slug",
+                        "name": "test-run",
+                        "project_id": "project-cuid",
+                        "createdAt": "2024-08-01T00:00:00Z",
+                    }
                 )
             if path == "/house/metrics/log":
                 return _api_response({"logs": [{"message": "ready"}], "count": 1})
@@ -324,6 +344,7 @@ class TestExperimentRunIdResolution:
         ]
         assert kwargs["params"]["projectId"] == "project-cuid"
         assert kwargs["params"]["experimentId"] == "run-cuid"
+        assert kwargs["params"]["createdAt"] == 1722470400
 
 
 # ---------------------------------------------------------------------------
@@ -425,23 +446,6 @@ class TestMetricValidation:
 # createdAt — 类型与精度兼容 + payload 注入
 # ---------------------------------------------------------------------------
 class TestCreatedAt:
-    def test_parse_timestamp_s_variants(self):
-        from swanlab.api.utils import parse_timestamp_s
-
-        assert parse_timestamp_s(None) == 0
-        assert parse_timestamp_s("") == 0
-        assert parse_timestamp_s("   ") == 0
-        assert parse_timestamp_s("not-a-date") == 0
-        assert parse_timestamp_s(0) == 0
-        assert parse_timestamp_s(-100) == 0
-        assert parse_timestamp_s(1722470400) == 1722470400
-        assert parse_timestamp_s("1722470400000") == 1722470400
-        assert parse_timestamp_s("2024-08-01T00:00:00Z") == 1722470400
-        assert parse_timestamp_s("2024-08-01T00:00:00.123Z") == 1722470400
-        assert parse_timestamp_s("2024-08-01T00:00:00+00:00") == 1722470400
-        assert parse_timestamp_s("2024-08-01T08:00:00+08:00") == 1722470400
-        assert parse_timestamp_s("2024-08-01T00:00:00") == 1722470400
-
     def test_metrics_payload_contains_created_at(self, ctx):
         ctx.client.get.side_effect = [
             _api_response(
@@ -515,17 +519,15 @@ class TestCreatedAt:
             }
         ]
 
-    def test_payload_omits_created_at_when_missing(self, ctx):
+    def test_payload_raises_when_created_at_missing(self, ctx):
         ctx.client.get.side_effect = [
             _api_response({"cuid": "run-cuid", "slug": "run-slug", "name": "test-run", "project_id": "project-cuid"})
         ]
-        ctx.client.post.return_value = _api_response({"run-cuid": {}})
         exp = Experiment(ctx, path="user/proj/run-slug")
 
-        exp.summary()
-
-        payload = ctx.client.post.call_args_list[0].kwargs["data"]
-        assert "createdAt" not in payload["experiments"][0]
+        # createdAt 缺失时必须强制报错，禁止静默降级为无下界查询（慢查询）
+        with pytest.raises(ValueError, match="timestamp"):
+            exp.summary()
 
     def test_series_requests_contain_created_at(self, ctx):
         ctx.client.get.side_effect = [

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -435,29 +435,12 @@ class TestCreatedAt:
         assert parse_timestamp_s(0) == 0
         assert parse_timestamp_s(-100) == 0
         assert parse_timestamp_s(1722470400) == 1722470400
-        assert parse_timestamp_s("1722470400") == 1722470400
-        assert parse_timestamp_s(1722470400000) == 1722470400
         assert parse_timestamp_s("1722470400000") == 1722470400
         assert parse_timestamp_s("2024-08-01T00:00:00Z") == 1722470400
         assert parse_timestamp_s("2024-08-01T00:00:00.123Z") == 1722470400
         assert parse_timestamp_s("2024-08-01T00:00:00+00:00") == 1722470400
         assert parse_timestamp_s("2024-08-01T08:00:00+08:00") == 1722470400
         assert parse_timestamp_s("2024-08-01T00:00:00") == 1722470400
-
-    def test_parse_timestamp_s_mirror_implementations_are_identical(self):
-        """api 与 core_python 两 lane 各自实现了 parse_timestamp_s，除 docstring 外必须逐行相同。"""
-        import ast
-        import inspect
-
-        from swanlab.api.utils import parse_timestamp_s as api_impl
-        from swanlab.sdk.internal.core_python.api.experiment import parse_timestamp_s as core_impl
-
-        def normalized_source(func) -> ast.AST:
-            tree = ast.parse(inspect.getsource(func))
-            tree.body[0].body = [node for node in tree.body[0].body if not isinstance(node, ast.Expr)]
-            return tree
-
-        assert ast.dump(normalized_source(api_impl)) == ast.dump(normalized_source(core_impl))
 
     def test_metrics_payload_contains_created_at(self, ctx):
         ctx.client.get.side_effect = [

--- a/tests/unit/sdk/cmd/sync/test_sync_e2e.py
+++ b/tests/unit/sdk/cmd/sync/test_sync_e2e.py
@@ -69,7 +69,12 @@ def make_prepare_result(new_experiment: bool = True) -> PrepareExperimentStartRe
             "visibility": "PRIVATE",
             "_count": {"experiments": 0, "contributors": 0, "collaborators": 0, "clones": 0},
         },
-        experiment={"cuid": "experiment-id", "slug": "sync-e2e-run", "name": "sync-e2e-run"},
+        experiment={
+            "cuid": "experiment-id",
+            "slug": "sync-e2e-run",
+            "name": "sync-e2e-run",
+            "createdAt": "2024-08-01T00:00:00Z",
+        },
         new_experiment=new_experiment,
         name="sync-e2e-run",
         color="#abcdef",

--- a/tests/unit/sdk/cmd/sync/test_sync_e2e.py
+++ b/tests/unit/sdk/cmd/sync/test_sync_e2e.py
@@ -254,7 +254,7 @@ def test_e2e_sync_skips_records_already_in_remote_summary(monkeypatch):
     )
     monkeypatch.setattr(
         "swanlab.sdk.internal.core_python.sync.get_experiment_summary",
-        lambda project_id, experiment_id: {
+        lambda project_id, experiment_id, created_at=None: {
             "log": None,
             "media": None,
             "scalar": [{"key": "loss", "step": 1}, {"key": "acc", "step": 1}],

--- a/tests/unit/sdk/internal/core_python/api/test_experiment.py
+++ b/tests/unit/sdk/internal/core_python/api/test_experiment.py
@@ -1,0 +1,95 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from swanlab.sdk.internal.core_python.api import experiment as experiment_api
+
+
+def _created_at() -> Timestamp:
+    ts = Timestamp()
+    ts.FromDatetime(datetime(2024, 8, 1))
+    return ts
+
+
+def _post_resp(data: dict, status_code: int) -> SimpleNamespace:
+    return SimpleNamespace(data=data, raw=SimpleNamespace(status_code=status_code))
+
+
+def _experiment_data(**extra) -> dict:
+    data = {"cuid": "experiment-id", "slug": "run-id", "name": "test-run"}
+    data.update(extra)
+    return data
+
+
+def _call_create_or_resume():
+    return experiment_api.create_or_resume_experiment(
+        "alice",
+        "demo",
+        name="test-run",
+        resume="allow",
+        color="#abcdef",
+        description=None,
+        job_type=None,
+        group=None,
+        tags=None,
+        created_at=_created_at(),
+    )
+
+
+def test_create_new_experiment_uses_local_created_at(monkeypatch):
+    post = MagicMock(return_value=_post_resp(_experiment_data(), 201))
+    get = MagicMock()
+    monkeypatch.setattr(experiment_api.client, "post", post)
+    monkeypatch.setattr(experiment_api.client, "get", get)
+
+    experiment, is_new = _call_create_or_resume()
+
+    assert is_new is True
+    assert experiment["createdAt"] == "2024-08-01T00:00:00Z"
+    # 新建实验直接复用请求中的 createdAt，不做额外请求
+    get.assert_not_called()
+    assert post.call_args.args[0] == "/project/alice/demo/experiment"
+    assert post.call_args.args[1]["createdAt"] == "2024-08-01T00:00:00Z"
+
+
+def test_resume_skips_get_when_post_response_contains_created_at(monkeypatch):
+    # 后端已按 SwanLab-Server#1090 在 POST 响应中携带 createdAt
+    post = MagicMock(return_value=_post_resp(_experiment_data(createdAt="2024-07-01T00:00:00Z"), 200))
+    get = MagicMock()
+    monkeypatch.setattr(experiment_api.client, "post", post)
+    monkeypatch.setattr(experiment_api.client, "get", get)
+
+    experiment, is_new = _call_create_or_resume()
+
+    assert is_new is False
+    assert experiment["createdAt"] == "2024-07-01T00:00:00Z"
+    get.assert_not_called()
+
+
+def test_resume_falls_back_to_get_when_created_at_missing(monkeypatch):
+    # 旧后端 POST 响应未携带 createdAt，回退到 GET 获取
+    post = MagicMock(return_value=_post_resp(_experiment_data(), 200))
+    get = MagicMock(return_value=SimpleNamespace(data=_experiment_data(createdAt="2024-07-01T00:00:00Z")))
+    monkeypatch.setattr(experiment_api.client, "post", post)
+    monkeypatch.setattr(experiment_api.client, "get", get)
+
+    experiment, is_new = _call_create_or_resume()
+
+    assert is_new is False
+    assert experiment["createdAt"] == "2024-07-01T00:00:00Z"
+    get.assert_called_once_with("/project/alice/demo/runs/experiment-id")
+
+
+def test_resume_raises_when_get_also_missing_created_at(monkeypatch):
+    post = MagicMock(return_value=_post_resp(_experiment_data(), 200))
+    get = MagicMock(return_value=SimpleNamespace(data=_experiment_data()))
+    monkeypatch.setattr(experiment_api.client, "post", post)
+    monkeypatch.setattr(experiment_api.client, "get", get)
+
+    with pytest.raises(ValueError, match="upgrade swanlab-server"):
+        _call_create_or_resume()
+
+    get.assert_called_once_with("/project/alice/demo/runs/experiment-id")

--- a/tests/unit/sdk/internal/core_python/test_core_sync.py
+++ b/tests/unit/sdk/internal/core_python/test_core_sync.py
@@ -348,7 +348,7 @@ def test_deliver_sync_flush_fetches_summary_for_existing_experiment(tmp_path: Pa
     resp = core.deliver_sync_flush()
 
     assert resp.success is True
-    get_summary.assert_called_once_with("project-id", "experiment-id")
+    get_summary.assert_called_once_with("project-id", "experiment-id", created_at=None)
 
 
 def test_deliver_sync_flush_returns_failure_when_prepare_fails(tmp_path: Path, monkeypatch):

--- a/tests/unit/sdk/internal/core_python/test_core_sync.py
+++ b/tests/unit/sdk/internal/core_python/test_core_sync.py
@@ -81,7 +81,12 @@ def make_prepare_result(new_experiment: bool = True) -> PrepareExperimentStartRe
             "visibility": "PRIVATE",
             "_count": {"experiments": 1, "contributors": 0, "collaborators": 0, "clones": 0},
         },
-        experiment={"cuid": "experiment-id", "slug": "sync-run-id", "name": "synced-run"},
+        experiment={
+            "cuid": "experiment-id",
+            "slug": "sync-run-id",
+            "name": "synced-run",
+            "createdAt": "2024-08-01T00:00:00Z",
+        },
         new_experiment=new_experiment,
         name="synced-run",
         color="#abcdef",
@@ -348,7 +353,7 @@ def test_deliver_sync_flush_fetches_summary_for_existing_experiment(tmp_path: Pa
     resp = core.deliver_sync_flush()
 
     assert resp.success is True
-    get_summary.assert_called_once_with("project-id", "experiment-id", created_at=None)
+    get_summary.assert_called_once_with("project-id", "experiment-id", created_at="2024-08-01T00:00:00Z")
 
 
 def test_deliver_sync_flush_returns_failure_when_prepare_fails(tmp_path: Path, monkeypatch):

--- a/tests/unit/utils/time/test_utils_time.py
+++ b/tests/unit/utils/time/test_utils_time.py
@@ -1,0 +1,32 @@
+import pytest
+
+from swanlab.utils.time import TIMESTAMP_S_MAX, TIMESTAMP_S_MIN, parse_timestamp_s
+
+
+class TestParseTimestampS:
+    def test_valid_variants(self):
+        """测试秒/毫秒时间戳与 ISO 8601 字符串的归一化"""
+        assert parse_timestamp_s(1722470400) == 1722470400
+        assert parse_timestamp_s("1722470400") == 1722470400
+        assert parse_timestamp_s(1722470400000) == 1722470400
+        assert parse_timestamp_s("1722470400000") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00Z") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00.123Z") == 1722470400
+        assert parse_timestamp_s("2024-08-01T00:00:00+00:00") == 1722470400
+        assert parse_timestamp_s("2024-08-01T08:00:00+08:00") == 1722470400
+        # 无时区时按 UTC 解析
+        assert parse_timestamp_s("2024-08-01T00:00:00") == 1722470400
+
+    def test_valid_boundaries(self):
+        """测试合法区间边界值"""
+        assert parse_timestamp_s(TIMESTAMP_S_MIN) == TIMESTAMP_S_MIN
+        assert parse_timestamp_s(TIMESTAMP_S_MAX) == TIMESTAMP_S_MAX
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, "", "   ", "not-a-date", 0, -100, "0", "-100", 100, "999999999", "1970-01-01T00:00:00Z"],
+    )
+    def test_invalid_raises(self, value):
+        """缺失 / 空值 / 无法解析 / 非正数 / 越界必须抛错，禁止回退默认值导致慢查询"""
+        with pytest.raises(ValueError):
+            parse_timestamp_s(value)


### PR DESCRIPTION
## Description

House 指标查询接口现在要求必须携带实验的 `createdAt`（10 位 Unix 秒时间戳），并以 `createdAt >= toDateTime(<createdAt>)` 作为 ClickHouse 数据入库时间的包含式单边下界，用于裁剪扫描范围、避免每次查询重复扫描冷层数据。

## Changes

**新增工具模块 `swanlab/utils/time`**（查询 API lane 与运行时 SDK lane 共用）：

- `parse_timestamp_s()`：将 ISO 8601 字符串（含/不含时区）、秒级（10 位）/毫秒级（13 位）时间戳统一归一化为 10 位 Unix 秒
- `None` / 空串 / 无法解析 / 非正数 / 越界时抛出 `ValueError`，**不做默认值回退**，避免 House 退化为全历史扫描（慢查询）

**查询 lane（`swanlab/api/**`、`swanlab/cli/api/**`）**：

- `Metric` / `Metrics` / `Summary` / `Key` / `Column` / `Columns` 构造参数 `created_at` 必传（无默认值）
- 所有 House 查询 payload（scalar / media / f_media / log / summaries / scalar/export / log/export）无条件携带 `createdAt`
- `Series` 构造时校验每个 experiment ref 必须携带非零 `createdAt`，缺失即抛错

**运行时 lane（`swanlab/sdk/internal/core_python/**`）**：

- `create_or_resume_experiment()` 确保 `createdAt` 总是被填充：
  - 201（新建实验）：直接复用请求中的本地值，零额外请求
  - 200（已存在）且 POST 响应已携带 `createdAt`：直接使用（对接 SwanHubX/SwanLab-Server#1090）
  - 200 且响应未携带（旧后端）：回退一次 `GET /runs/{cuid}` 获取
  - GET 仍无法获取：抛出 `ValueError`（提示升级 swanlab-server）
- resume / sync 时 `get_experiment_summary()` 以 `createdAt` 作为查询下界

## Notes

- SDK 端 `createdAt` 为强制携带：后端未返回该字段时显式报错，而非静默降级为无下界查询
- 服务端在 POST 响应中补充 `createdAt` 后可消除 resume 场景的额外 GET：SwanHubX/SwanLab-Server#1090
