### PR TITLE
chore: switch PR review skills from worktrees to direct checkout

### DIFF
--- a/docs/skills/pr-review-core/SKILL.md
+++ b/docs/skills/pr-review-core/SKILL.md
@@ -32,11 +32,11 @@ gh pr diff <PR>
 gh pr checks <PR>
 ```
 
-2. 把 head 分支拉到本地隔离工作区再审核，不要污染用户当前工作区：
+2. 直接在当前工作区 checkout 到 PR head 审核，不创建单独的 worktree 和分支。checkout 前确认当前工作区干净；存在未提交改动时停下来询问用户如何处理，不要继续：
 
 ```bash
-git fetch origin pull/<PR>/head:pr-<PR>
-git worktree add ../swanlab-pr-<PR> pr-<PR>
+git status
+gh pr checkout <PR>
 ```
 
 3. 根据文件列表判断适用领域，按下方"范围参考"读取 [`references/domain-contracts.md`](references/domain-contracts.md) 中对应章节。所有 Go 代码都要检查"Go core 横切质量与代码规范"；涉及凭据、网络、日志或文件路径时额外检查安全（同 `pr-review-lab` 的"安全与隐私"）。
@@ -48,11 +48,10 @@ git worktree add ../swanlab-pr-<PR> pr-<PR>
 
 仅当用户在阶段一之后明确要求发布时才执行。发布前把最终结论和 `event` 类型（`APPROVE` / `REQUEST_CHANGES` / `COMMENT`）复述给用户确认。inline comment 提交方式、Review JSON 结构和顶层正文模板见 [`pr-review-lab` "提交审核"](../pr-review-lab/SKILL.md) 一节——提交时把审核范围复选框替换为下方的 Go core 版本。
 
-发布后回报 review 链接，并清理临时 worktree 和本地分支：
+发布后回报 review 链接，并切回原分支：
 
 ```bash
-git worktree remove ../swanlab-pr-<PR>
-git branch -D pr-<PR>
+git checkout <原分支>
 ```
 
 ## 范围参考
@@ -130,7 +129,7 @@ CI 覆盖 Ubuntu、Windows、macOS，跨平台构建标签和 `go test -race`。
 阶段一（审查）：
 
 - [ ] 当前 PR 意图、base、head 和文件范围已确认
-- [ ] head 分支已拉到本地隔离工作区，关键发现在完整文件上验证
+- [ ] 已在当前工作区 checkout 到 PR head 分支，关键发现在完整文件上验证
 - [ ] 所有适用 Go core 领域和横切质量已审核
 - [ ] 跨语言变更已读取 `pr-review-lab` 并覆盖 Python 范围
 - [ ] 阻塞和必须修改 finding 已解决或明确记录
@@ -142,7 +141,7 @@ CI 覆盖 Ubuntu、Windows、macOS，跨平台构建标签和 `go test -race`。
 - [ ] 用户已明确要求发布，且已确认 `event` 类型
 - [ ] 可定位 finding 已提交为 inline comments
 - [ ] 最终 review 已通过 Reviews API 或 `gh pr review` 提交
-- [ ] 临时 worktree 和本地分支已清理
+- [ ] 已切回原分支
 
 ## 参考
 

--- a/docs/skills/pr-review-lab/SKILL.md
+++ b/docs/skills/pr-review-lab/SKILL.md
@@ -32,14 +32,12 @@ gh pr diff <PR>
 gh pr checks <PR>
 ```
 
-2. 把 head 分支拉到本地隔离工作区再审核，不要污染用户当前工作区：
+2. 直接在当前工作区 checkout 到 PR head 审核，不创建单独的 worktree 和分支。checkout 前确认当前工作区干净；存在未提交改动时停下来询问用户如何处理，不要继续：
 
 ```bash
-git fetch origin pull/<PR>/head:pr-<PR>
-git worktree add ../swanlab-pr-<PR> pr-<PR>
+git status
+gh pr checkout <PR>
 ```
-
-无法建立 worktree 时可用 `gh pr checkout <PR>`，但必须先确认当前工作区干净，并在结束后切回原分支。
 
 3. 根据文件列表判断适用领域，并按“范围参考”读取相关契约。所有应用代码都要检查横切质量；涉及凭据、网络、文件或用户数据时额外检查安全与隐私。
 4. 对关键发现检查 head 分支中的完整文件和调用关系，不只依据 diff 片段。
@@ -54,11 +52,10 @@ git worktree add ../swanlab-pr-<PR> pr-<PR>
 - 用户只是要求审查、看意见或讨论时，一律停在阶段一。
 - 用户要求修改草稿时，更新草稿后重新征求确认，不要顺带发布。
 - 发布前把最终结论和 `event` 类型（`APPROVE` / `REQUEST_CHANGES` / `COMMENT`）复述给用户确认，避免审批状态与用户意图不符。
-- 发布后回报 review 链接，并清理临时 worktree 和本地分支：
+- 发布后回报 review 链接，并切回原分支：
 
 ```bash
-git worktree remove ../swanlab-pr-<PR>
-git branch -D pr-<PR>
+git checkout <原分支>
 ```
 
 ## 独立审核原则
@@ -223,7 +220,7 @@ gh pr review <PR> --comment --body-file /tmp/pr-review-body.md
 阶段一（审查）：
 
 - [ ] 当前 PR 意图、base、head 和文件范围已确认
-- [ ] head 分支已拉到本地隔离工作区，关键发现在完整文件上验证
+- [ ] 已在当前工作区 checkout 到 PR head 分支，关键发现在完整文件上验证
 - [ ] 所有适用领域和横切质量已审核
 - [ ] 阻塞和必须修改 finding 已解决或明确记录
 - [ ] 本地验证结果和 PR Actions 状态已记录
@@ -234,7 +231,7 @@ gh pr review <PR> --comment --body-file /tmp/pr-review-body.md
 - [ ] 用户已明确要求发布，且已确认 `event` 类型
 - [ ] 可定位 finding 已提交为 inline comments
 - [ ] 最终 review 已通过 Reviews API 或 `gh pr review` 提交
-- [ ] 临时 worktree 和本地分支已清理
+- [ ] 已切回原分支
 
 ## 参考
 


### PR DESCRIPTION
## Summary

将 PR 审核流程从「创建隔离 worktree」改为「在当前工作区直接 `gh pr checkout`」，简化审核流程并减少临时分支/worktree 的维护成本。

## Changes

- `docs/skills/pr-review-core/SKILL.md`
  - 审核前用 `git status` 确认工作区干净，再用 `gh pr checkout <PR>` 直接切换，不再创建 worktree 和临时分支
  - 发布后从「清理临时 worktree 和本地分支」改为「切回原分支」
  - 同步更新阶段清单（checklist）对应条目
- `docs/skills/pr-review-lab/SKILL.md`
  - 直接 checkout 取代 worktree，删除「无法建立 worktree 时的备用方案」说明
  - 发布后切回原分支，并同步更新 checklist

## Testing

纯文档变更，未运行测试。

## Notes

- 不涉及代码行为变更，无兼容性风险
- 审核前需确认工作区干净；存在未提交改动时先停下来询问用户，安全检查与原流程保持一致
