### PR TITLE
chore: auto-create backport labels for release branches

### DIFF
--- a/.github/workflows/create-backport-label.yml
+++ b/.github/workflows/create-backport-label.yml
@@ -1,0 +1,25 @@
+name: Create backport label
+
+on:
+  create
+
+permissions:
+  issues: write # 创建 label 所需权限
+
+jobs:
+  create-label:
+    name: Create backport label for release branch
+    runs-on: ubuntu-latest
+    # create 事件在新建分支或 tag 时都会触发，这里只处理 release/v* 分支
+    if: startsWith(github.ref, 'refs/heads/release/v')
+    steps:
+      - name: Create label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          gh label create "backport ${BRANCH}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --color 0E8A16 \
+            --description "Merge 后自动 backport 此 PR 到 ${BRANCH}" \
+            || echo "Label backport ${BRANCH} already exists, skip"


### PR DESCRIPTION
## Summary

新增 GitHub Actions workflow，在创建 `release/v*` 分支时自动生成对应的 `backport release/vX.Y` label，补全 #1747 引入的 backport 机制的自动化闭环（此前 label 需手动创建）。

## Changes

- 新增 `.github/workflows/create-backport-label.yml`：监听 `create` 事件，通过 job 级 `if` 过滤仅处理 `refs/heads/release/v*` 分支；使用 `gh label create` 创建 label（颜色 `0E8A16`、描述与现有 `backport release/v0.8` 保持一致），label 已存在时静默跳过。

## Testing

- 未运行测试：本次改动仅涉及 CI workflow 配置，不涉及产品代码。
- workflow 需合入 main 后才可在真实分支创建时生效；可在 fork 上通过手动创建 `release/v*` 分支验证触发与 label 生成。

## Notes

- label 命名 `backport release/vX.Y` 与 `backport.yml`、`scripts/backport.sh` 的匹配规则一致，无需额外改动。
- `create` 事件不提供分支过滤器，新建 tag 时同样触发，故在 job 级用 `if` 过滤。