### PR TITLE
chore: update deprecation messages to target v0.11 removal

### DIFF
--- a/swanlab/api/__init__.py
+++ b/swanlab/api/__init__.py
@@ -253,7 +253,7 @@ class Api(BaseEntity):
     def user(self) -> User:
         return User(self._ctx)
 
-    @deprecated("Use `series()` method instead.")
+    @deprecated("`columns()` is deprecated and will be removed in v0.11, use `series()` instead.")
     def columns(
         self,
         path: str,
@@ -287,7 +287,7 @@ class Api(BaseEntity):
             exp_created_at=exp.created_at_ts,
         )
 
-    @deprecated("Use `series()` method instead.")
+    @deprecated("`column()` is deprecated and will be removed in v0.11, use `series()` instead.")
     def column(
         self,
         path: str,

--- a/swanlab/api/experiment.py
+++ b/swanlab/api/experiment.py
@@ -202,7 +202,7 @@ class Experiment(BaseEntity):
                 data = self._data
         return cast(ApiExperimentProfileType, self._ensure_data().get("profile", {}))
 
-    @deprecated("Use `series()` method instead.")
+    @deprecated("`column()` is deprecated and will be removed in v0.11, use `series()` instead.")
     def column(
         self,
         key: str,
@@ -452,7 +452,7 @@ class Experiment(BaseEntity):
         )
         return metric.export_logs(start=start, rows=rows)
 
-    @deprecated("Use `series()` method instead.")
+    @deprecated("`columns()` is deprecated and will be removed in v0.11, use `series()` instead.")
     def columns(
         self,
         page: int = 1,

--- a/swanlab/deprecated/callbacks.py
+++ b/swanlab/deprecated/callbacks.py
@@ -10,10 +10,14 @@ from typing_extensions import deprecated
 from swanlab.sdk.cmd.merge_callbacks import merge_callbacks
 
 
-@deprecated("use `swanlab.merge_callbacks()` instead")
+@deprecated(
+    "`swanlab.register_callbacks()` is deprecated and will be removed in v0.11, "
+    "use `swanlab.merge_callbacks()` instead."
+)
 def register_callbacks(*args, **kwargs):
     warnings.warn(
-        "`swanlab.register_callbacks()` is deprecated, use `swanlab.merge_callbacks()` instead",
+        "`swanlab.register_callbacks()` is deprecated and will be removed in v0.11, "
+        "use `swanlab.merge_callbacks()` instead",
         FutureWarning,
         stacklevel=2,
     )

--- a/swanlab/deprecated/echarts.py
+++ b/swanlab/deprecated/echarts.py
@@ -10,29 +10,39 @@ from typing_extensions import deprecated
 from swanlab.sdk.internal.run.transforms import echarts
 
 
-@deprecated("use `swanlab.echarts.roc_curve()` instead")
+@deprecated(
+    "`swanlab.roc_curve()` is deprecated and will be removed in v0.11, use `swanlab.echarts.roc_curve()` instead."
+)
 def roc_curve(*args, **kwargs):
     warnings.warn(
-        "`swanlab.roc_curve()` is deprecated, use `swanlab.echarts.roc_curve()` instead",
+        "`swanlab.roc_curve()` is deprecated and will be removed in v0.11, use `swanlab.echarts.roc_curve()` instead",
         FutureWarning,
         stacklevel=2,
     )
     return echarts.roc_curve(*args, **kwargs)
 
 
-@deprecated("use `swanlab.echarts.pr_curve()` instead")
+@deprecated(
+    "`swanlab.pr_curve()` is deprecated and will be removed in v0.11, use `swanlab.echarts.pr_curve()` instead."
+)
 def pr_curve(*args, **kwargs):
     warnings.warn(
-        "`swanlab.pr_curve()` is deprecated, use `swanlab.echarts.pr_curve()` instead", FutureWarning, stacklevel=2
+        "`swanlab.pr_curve()` is deprecated and will be removed in v0.11, use `swanlab.echarts.pr_curve()` instead",
+        FutureWarning,
+        stacklevel=2,
     )
     return echarts.pr_curve(*args, **kwargs)
 
 
-@deprecated("use `swanlab.echarts.confusion_matrix()` instead")
+@deprecated(
+    "`swanlab.confusion_matrix()` is deprecated and will be removed in v0.11, "
+    "use `swanlab.echarts.confusion_matrix()` instead."
+)
 def confusion_matrix(*args, **kwargs):
     warnings.warn(
-        "`swanlab.confusion_matrix()` is deprecated, use `swanlab.echarts.confusion_matrix()` instead",
-        DeprecationWarning,
+        "`swanlab.confusion_matrix()` is deprecated and will be removed in v0.11, "
+        "use `swanlab.echarts.confusion_matrix()` instead",
+        FutureWarning,
         stacklevel=2,
     )
     return echarts.confusion_matrix(*args, **kwargs)

--- a/swanlab/deprecated/project.py
+++ b/swanlab/deprecated/project.py
@@ -11,7 +11,7 @@ from swanlab.exceptions import ApiError
 from swanlab.sdk.internal.core_python import client
 
 
-@deprecated("legacy projects without views will no longer be supported in v0.10.")
+@deprecated("legacy projects without views will no longer be supported in v0.11.")
 def get_or_create_old_project(*, data: dict):
     """
     旧接口创建、获取项目信息，主要用于兼容旧版本的项目创建接口
@@ -20,7 +20,7 @@ def get_or_create_old_project(*, data: dict):
     """
     warnings.warn(
         "You are accessing a legacy project that does not support views. "
-        "Legacy projects will no longer be supported in v0.10, scheduled for release on 2026-10-01. "
+        "Legacy projects will no longer be supported in v0.11 and will be removed soon. "
         "Please create a new project or upgrade this project in the web app.",
         FutureWarning,
         stacklevel=2,

--- a/swanlab/deprecated/sender.py
+++ b/swanlab/deprecated/sender.py
@@ -10,7 +10,7 @@ from swanlab.sdk.internal.pkg import adapter
 from swanlab.sdk.typings.core_python.api.upload import DeprecatedUploadColumn, DeprecatedUploadColumns
 
 
-@deprecated("legacy projects without views will no longer be supported in v0.10.")
+@deprecated("legacy projects without views will no longer be supported in v0.11.")
 class DeprecatedHttpRecordSender(HttpRecordSender):
     """
     DeprecatedHttpRecordSender 是一个过时的类，用于适应多视图版本前的列上传逻辑

--- a/swanlab/sdk/internal/core_python/transport/sender.py
+++ b/swanlab/sdk/internal/core_python/transport/sender.py
@@ -567,7 +567,7 @@ def encode_column(record: ColumnRecord) -> Optional[UploadColumn]:
     """
     将列记录编码为后端所需的格式（DTO）
     """
-    # TODO 在 v0.10.0 版本 精简一下 column 的类型定义
+    # TODO 在 v0.11 版本 精简一下 column 的类型定义
     column: UploadColumn = {"key": record.column_key, "type": adapter.column[record.column_type]}
     if record.column_class == ColumnClass.COLUMN_CLASS_SYSTEM:
         column["type"] = "SYSTEM"

--- a/swanlab/sdk/internal/core_python/transport/thread.py
+++ b/swanlab/sdk/internal/core_python/transport/thread.py
@@ -66,7 +66,7 @@ class Transport:
             return
 
         # 初始化sender，根据不同的项目版本选择不同的请求器，以兼容历史版本
-        # NOTE: 相关兼容逻辑将在v0.10.0版本后移除
+        # NOTE: 相关兼容逻辑将在v0.11版本后移除
         sender = self._sender
         if sender is None:
             sender = (


### PR DESCRIPTION
## Summary

统一并更新弃用提示文案，将移除版本从 v0.10 调整为 v0.11，移除精确发布日期，并为其余已弃用 API 补充移除版本信息。

## Changes

- `swanlab/deprecated/project.py`、`swanlab/deprecated/sender.py`：legacy projects 弃用提示由 `v0.10` 更新为 `v0.11`，移除 `scheduled for release on 2026-10-01` 精确日期，改为 `will be removed soon`
- `swanlab/deprecated/echarts.py`：`roc_curve` / `pr_curve` / `confusion_matrix` 的 `@deprecated` 与 `warnings.warn` 文案补充 `will be removed in v0.11`；`confusion_matrix` 警告类别由 `DeprecationWarning` 统一为 `FutureWarning`
- `swanlab/deprecated/callbacks.py`：`register_callbacks` 文案补充 `will be removed in v0.11`
- `swanlab/api/__init__.py`、`swanlab/api/experiment.py`：`column()` / `columns()` 的 `@deprecated` 文案补充 `will be removed in v0.11`

## Testing

- `uv run ruff check` 通过
- `uv run basedpyright` 通过
- `uv run pytest tests/unit`：1672 passed, 21 skipped

## Notes

- `confusion_matrix` 警告类别由 `DeprecationWarning` 改为 `FutureWarning`，属行为变更：此前用户默认看不到该警告，现在会显式看到弃用提示
- 相关移除项盘点见 issue #1753