### PR TITLE
feat: add multi-platform release skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ dist/
 # testing & linting
 .pytest_cache/
 .ruff_cache/
+.uv-cache/
 .mypy_cache/
 .coverage
 htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ CODEBUDDY.md
 .grok/
 .reasonix/
 .mcp.json
+
+# go core binary
+swanlab/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 AGENTS_SKILL_DIR := .agents/skills
 SKILLS_DIR := docs/skills
 
-.PHONY: init sync format proto unit bench clean build publish backport link-skills unlink-skills relink-skills core-lint core-fmt core-test core-build core-tidy
+.PHONY: init sync format proto unit bench clean build publish backport link-skills unlink-skills relink-skills core-lint core-fmt core-test core-build core-tidy core-bin release-build release-verify
 
 # ----------------------------------
 # SKILL (docs/skills)
@@ -110,3 +110,19 @@ core-build:
 
 core-tidy:
 	cd core && go mod tidy
+
+# ----------------------------------
+# Release (scripts/build_release.sh)
+# ----------------------------------
+
+# 本机平台编译 swanlab-core 到 swanlab/bin/，供日常联调（复用发布构建参数）
+core-bin:
+	python3 core/hatch.py
+
+# 完整发布构建：sdist + any 兜底 wheel + 6 平台 wheel + 校验，全部进 dist/
+release-build:
+	bash scripts/build_release.sh $(VERSION)
+
+# 仅校验 dist/ 中已有产物（twine check + 结构完整性）
+release-verify:
+	bash scripts/build_release.sh --verify-only

--- a/core/cmd/swanlab-core/main.go
+++ b/core/cmd/swanlab-core/main.go
@@ -1,0 +1,164 @@
+// Command swanlab-core 是 SwanLab Go core 的进程入口。
+//
+// 当前为发布脚手架阶段：仅建立进程生命周期骨架——版本上报（--version）、
+// 端点监听、父进程退出监控与信号处理；gRPC 服务端（CoreService /
+// CoreSyncService / ProbeService）在后续迭代中接入，届时替换 serve 循环。
+//
+// 端点约定：
+//
+//	--listen unix:///path/to/uds   Linux/macOS 进程内通信（默认路径由 Python SDK 分配）
+//	--listen tcp://127.0.0.1:port  Windows 回环地址（uds 不可用，named pipe 支持后续提供）
+//
+// 生命周期：父进程退出（process 包监控）或收到 SIGINT/SIGTERM 时优雅退出，
+// 防止 Python SDK 崩溃后 core 沦为孤儿进程。
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/swanhubx/swanlab/core/internal/pkg/console"
+	"github.com/swanhubx/swanlab/core/internal/pkg/process"
+)
+
+// version 与 commit 由构建管线通过 -ldflags -X 注入（见 core/hatch.py），
+// 缺省值仅供本地 go run / go build 使用。
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
+// 与命令行参数等价的环境变量，供 Python SDK spawn 时注入。
+const (
+	envListenAddr = "SWANLAB_CORE_LISTEN"
+	envParentPID  = "SWANLAB_CORE_PARENT_PID"
+)
+
+// 进程退出码约定：0 正常退出（含信号触发的优雅关闭）；2 用法错误；1 运行错误。
+const (
+	exitUsageError = 2
+	exitRunError   = 1
+)
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	fs := flag.NewFlagSet("swanlab-core", flag.ContinueOnError)
+	printVersion := fs.Bool("version", false, "打印版本信息后退出")
+	listenAddr := fs.String("listen", os.Getenv(envListenAddr),
+		"监听端点，格式 unix://<uds路径> 或 tcp://<地址:端口>；Windows 仅支持 tcp:// 回环地址")
+	parentPID := fs.Int("parent-pid", envInt(envParentPID),
+		"预期父进程 PID，父进程退出时 core 随之退出；未指定时取启动瞬间的实际父进程")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return exitUsageError
+	}
+
+	if *printVersion {
+		fmt.Printf("swanlab-core %s (commit %s)\n", version, commit)
+		return 0
+	}
+	if *listenAddr == "" {
+		console.Error("未指定监听端点：通过 --listen 或环境变量 " + envListenAddr + " 传入")
+		return exitUsageError
+	}
+
+	ln, err := listen(*listenAddr)
+	if err != nil {
+		console.Error("监听失败:", err)
+		return exitRunError
+	}
+	defer ln.Close()
+
+	// 父进程监控：显式传入的 PID 优先（Python SDK 启动约定），未传时回退为
+	// 监控启动瞬间的实际父进程（本地终端运行场景）。监控建立失败按约定终止启动。
+	pid := *parentPID
+	if pid <= 0 {
+		pid = os.Getppid()
+	}
+	parentExited, err := process.NotifyOnParentExit(pid)
+	if err != nil {
+		console.Error("父进程监控建立失败，终止启动:", err)
+		return exitRunError
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	console.Infof("swanlab-core %s listening on %s (parent pid %d)", version, *listenAddr, pid)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- serve(ln)
+	}()
+
+	select {
+	case <-ctx.Done():
+		console.Info("收到退出信号，正在关闭")
+	case <-parentExited:
+		console.Warning("父进程已退出，core 随之退出")
+	case err := <-serveErr:
+		if err != nil {
+			console.Error("监听异常退出:", err)
+			return exitRunError
+		}
+	}
+	return 0
+}
+
+// listen 按协议前缀创建监听器。uds 仅在非 Windows 平台可用；Windows 使用
+// TCP 回环地址兜底（named pipe 接入后在此分支扩展）。
+func listen(addr string) (net.Listener, error) {
+	scheme, rest, ok := strings.Cut(addr, "://")
+	if !ok {
+		return nil, fmt.Errorf("监听端点缺少协议前缀（unix:// 或 tcp://）: %s", addr)
+	}
+	switch scheme {
+	case "unix":
+		if runtime.GOOS == "windows" {
+			return nil, errors.New("windows 平台不支持 unix:// 端点，请使用 tcp://127.0.0.1:<端口>")
+		}
+		return net.Listen("unix", rest)
+	case "tcp":
+		return net.Listen("tcp", rest)
+	default:
+		return nil, fmt.Errorf("不支持的监听协议 %q（仅 unix:// 或 tcp://）", scheme)
+	}
+}
+
+// serve 接受连接后立即关闭。脚手架阶段仅验证端点连通性，
+// gRPC 服务端就绪后由此接入 serve 逻辑。
+func serve(ln net.Listener) error {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		_ = conn.Close()
+	}
+}
+
+// envInt 解析整型环境变量，缺失或非法时返回 0。
+func envInt(name string) int {
+	v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(name)))
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/core/hatch.py
+++ b/core/hatch.py
@@ -1,0 +1,106 @@
+"""swanlab-core Go 模块编译封装。
+
+供两处调用：
+
+- ``hatch_build.py`` 构建钩子（发布/平台 wheel 构建）
+- 直接执行 ``python3 core/hatch.py``（``make core-bin``，本机构建）
+
+职责单一：以 ``core/`` 为工作目录执行 ``go build``，将产物输出到仓库根的
+``swanlab/bin/swanlab-core(.exe)``，并注入版本号与 commit。
+
+注：``CGO_ENABLED=0`` 静态编译下，Go 内部链接器写入的 ELF ``.gnu.version`` /
+``.gnu.version_r`` section 会导致 auditwheel 崩溃。仅当未来引入 manylinux
+容器认证（cibuildwheel 路线）时，才需要在构建流程中用 objcopy 移除这两个
+section；当前自声明 manylinux tag 的构建不涉及 auditwheel，无需处理。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_CORE_DIR = _REPO_ROOT / "core"
+_ENTRY_PACKAGE = "./cmd/swanlab-core"
+
+
+def build_core(
+    go_binary: pathlib.Path,
+    output_path: pathlib.PurePath,
+    target_system: str | None = None,
+    target_arch: str | None = None,
+) -> None:
+    """编译 swanlab-core。
+
+    Args:
+        go_binary: go 可执行文件路径，必须存在。
+        output_path: 产物路径，相对仓库根（如 ``swanlab/bin/swanlab-core``）。
+        target_system: 目标 GOOS，``None`` 表示使用本机平台。
+        target_arch: 目标 GOARCH，``None`` 表示使用本机平台。
+    """
+    version = _package_version()
+    commit = _git_commit()
+    # -s -w 移除符号表与 DWARF 调试信息；-X 将版本信息注入 main 包变量
+    ldflags = f"-s -w -X main.version={version} -X main.commit={commit}"
+    # go build 以 core/ 为工作目录，因此输出路径需要相对 core/ 前移一级
+    output = pathlib.Path("..") / output_path
+
+    subprocess.check_call(
+        [
+            str(go_binary),
+            "build",
+            "-trimpath",
+            f"-ldflags={ldflags}",
+            "-o",
+            str(output),
+            _ENTRY_PACKAGE,
+        ],
+        cwd=str(_CORE_DIR),
+        env=_go_env(target_system, target_arch),
+    )
+
+    if not _is_windows_target(target_system):
+        # 显式设置可执行位：wheel 以 zip 外部属性记录权限，pip 解压时还原
+        os.chmod(_REPO_ROOT / output_path, 0o755)
+
+
+def _go_env(target_system: str | None, target_arch: str | None) -> dict[str, str]:
+    env = os.environ.copy()
+    if target_system:
+        env["GOOS"] = target_system
+    if target_arch:
+        env["GOARCH"] = target_arch
+    # 纯 Go 无 cgo：静态编译，保证全平台交叉编译无宿主依赖
+    env["CGO_ENABLED"] = "0"
+    return env
+
+
+def _is_windows_target(target_system: str | None) -> bool:
+    if target_system:
+        return target_system == "windows"
+    return os.name == "nt"
+
+
+def _package_version() -> str:
+    """从 swanlab/package.json 读取版本号，与 SDK 版本保持同源。"""
+    package_json = _REPO_ROOT / "swanlab" / "package.json"
+    version = json.loads(package_json.read_text(encoding="utf-8"))["version"]
+    return str(version)
+
+
+def _git_commit() -> str:
+    """返回当前 commit SHA；不在 git 仓库中或 git 不可用时返回 ``unknown``。"""
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(_REPO_ROOT), text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+if __name__ == "__main__":
+    # 本机构建入口（make core-bin），复用与发布构建一致的编译参数
+    exe = "swanlab-core.exe" if os.name == "nt" else "swanlab-core"
+    go = pathlib.Path(os.environ.get("GO", "go"))
+    build_core(go_binary=go, output_path=pathlib.PurePath("swanlab", "bin", exe))
+    print(f"swanlab/bin/{exe} built for host platform")

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,110 @@
+"""SwanLab wheel 自定义构建钩子（hatchling 插件）。
+
+由 ``SWANLAB_BUILD_PLATFORM`` 环境变量控制构建行为：
+
+- 未设置：不执行任何操作，产出纯 ``py3-none-any`` wheel。
+- 设置为平台 tag（如 ``manylinux_2_17_aarch64.manylinux2014_aarch64``、
+  ``win_arm64``、``macosx_12_0_arm64``）：交叉编译 Go core 内嵌进 wheel，
+  并将该平台 tag 写入 wheel 元数据。
+"""
+
+import os
+import pathlib
+import re
+import shutil
+import sys
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+_BUILD_PLATFORM_ENV = "SWANLAB_BUILD_PLATFORM"
+
+# 支持的平台 tag 形态示例（GOOS 由前缀判定，GOARCH 由结尾后缀判定）
+_SUPPORTED_TAG_EXAMPLES = (
+    "manylinux_2_17_x86_64.manylinux2014_x86_64",
+    "manylinux_2_17_aarch64.manylinux2014_aarch64",
+    "win_amd64",
+    "win_arm64",
+    "macosx_12_0_x86_64",
+    "macosx_12_0_arm64",
+)
+
+
+class CustomBuildHook(BuildHookInterface):
+    """按目标平台编译 Go core，并产出对应平台 tag 的 wheel。"""
+
+    def initialize(self, version, build_data):
+        if self.target_name == "wheel":
+            self._prepare_wheel(build_data)
+
+    def _prepare_wheel(self, build_data):
+        platform_tag = os.getenv(_BUILD_PLATFORM_ENV)
+        if not platform_tag:
+            return
+
+        goos, goarch = self._parse_target_platform(platform_tag)
+        output = self._build_core(goos, goarch)
+
+        build_data["tag"] = f"py3-none-{platform_tag}"
+        # hatchling 统一使用正斜杠路径，Windows 构建环境下亦然
+        build_data["artifacts"].append(output.as_posix())
+
+    def _parse_target_platform(self, platform_tag):
+        """从平台 tag 解析 (GOOS, GOARCH)，无法解析时中止构建。"""
+        tag = platform_tag.strip().lower()
+        if tag.startswith(("manylinux_", "musllinux_", "linux_")):
+            goos = "linux"
+        elif tag.startswith(("win_", "win-")):
+            goos = "windows"
+        elif tag.startswith(("macosx_", "macosx-")):
+            goos = "darwin"
+        else:
+            self.app.abort(
+                f"Unrecognized {_BUILD_PLATFORM_ENV}={platform_tag!r}: cannot determine OS prefix. "
+                f"Supported tags: {', '.join(_SUPPORTED_TAG_EXAMPLES)}",
+            )
+            raise AssertionError("unreachable")
+
+        arch_match = re.search(r"(?:-|_)(aarch64|arm64|x86_64|amd64)$", tag)
+        if not arch_match:
+            self.app.abort(
+                f"Cannot parse target architecture from {_BUILD_PLATFORM_ENV}={platform_tag!r} "
+                "(expected suffix _amd64 / _x86_64 / _arm64 / _aarch64)",
+            )
+            raise AssertionError("unreachable")
+
+        goarch = {"amd64": "amd64", "x86_64": "amd64", "arm64": "arm64", "aarch64": "arm64"}[arch_match.group(1)]
+        return goos, goarch
+
+    def _build_core(self, goos, goarch):
+        """编译 Go core 到 swanlab/bin/，返回产物路径（相对仓库根）。"""
+        go = shutil.which("go")
+        if not go:
+            self.app.abort(
+                f"{_BUILD_PLATFORM_ENV} is set but no Go toolchain found. "
+                "Install Go to build platform wheels: https://go.dev/doc/install",
+            )
+            raise AssertionError("unreachable")
+
+        output = pathlib.Path("swanlab", "bin", "swanlab-core")
+        if goos == "windows":
+            output = output.with_suffix(".exe")
+
+        self.app.display_waiting(f"Building swanlab-core ({goos}/{goarch})...")
+        try:
+            # 惰性导入：sdist 不携带 core/ 源码，仅平台构建时才需要该模块
+            sys.path.insert(0, str(pathlib.Path(__file__).parent))
+            from core import hatch as hatch_core
+        except ImportError:
+            self.app.abort(
+                f"{_BUILD_PLATFORM_ENV} is set but core/hatch.py is missing. "
+                "Platform wheels must be built from a git checkout; sdist does not include Go sources.",
+            )
+            raise AssertionError("unreachable")
+
+        hatch_core.build_core(
+            go_binary=pathlib.Path(go),
+            output_path=output,
+            target_system=goos,
+            target_arch=goarch,
+        )
+        return output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,9 +122,9 @@ build-backend = "hatchling.build"
 path = "hatch_build.py"
 
 # sdist 不携带 Go core：从 sdist 构建恒为纯 py3-none-any wheel（core_python）；
-# 含二进制的平台 wheel 需从 git checkout 进行构建
+# 含二进制的平台 wheel 需从 git checkout 进行构建。
 [tool.hatch.build.targets.sdist]
-exclude = ["core"]
+exclude = ["/core"]
 
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ s3 = [
 [dependency-groups]
 dev = [
     "build",
+    "hatchling>=1.18",
     "pytest",
     "pytest-mock",
     "pytest-benchmark",
@@ -112,8 +113,18 @@ swanlab = "swanlab.cli:cli"
 "Documentation" = "https://docs.swanlab.cn/zh/guide_cloud/general/what-is-swanlab.html"
 
 [build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme>=22.5.0"]
+# hatchling>=1.18 支持自定义构建 hooks 的最低兼容版本（含 tag/artifacts ）
+requires = ["hatchling>=1.18", "hatch-fancy-pypi-readme>=22.5.0"]
 build-backend = "hatchling.build"
+
+# 设置 SWANLAB_BUILD_PLATFORM 时交叉编译
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"
+
+# sdist 不携带 Go core：从 sdist 构建恒为纯 py3-none-any wheel（core_python）；
+# 含二进制的平台 wheel 需从 git checkout 进行构建
+[tool.hatch.build.targets.sdist]
+exclude = ["core"]
 
 
 [tool.hatch.version]

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -147,6 +147,24 @@ check(any(m.count("/") == 1 and m.endswith("/hatch_build.py") for m in members),
 check(not any(m.count("/") == 1 and m.split("/")[1] == "core" for m in members), "sdist 不含 core/ 源码")
 check(not any("/swanlab/bin/" in m for m in members), "sdist 不含二进制")
 
+
+def py_files(wheel):
+    with zipfile.ZipFile(wheel) as zf:
+        return {n for n in zf.namelist() if n.endswith(".py")}
+
+
+# sdist 可重建性：从 sdist 重建 wheel，.py 清单须与 checkout 直建的 any wheel 一致
+# （防止 sdist exclude 误伤嵌套同名目录）
+any_wheel = next(w for w in wheels if w.name.endswith("-py3-none-any.whl"))
+with tempfile.TemporaryDirectory() as td:
+    with tarfile.open(sdists[0]) as tf:
+        tf.extractall(td)
+    src = next(pathlib.Path(td).glob("swanlab-*/"))
+    subprocess.run(["uv", "build", "--wheel", "--out-dir", td], cwd=src, check=True, capture_output=True)
+    rebuilt = next(pathlib.Path(td).glob("*.whl"))
+    diff = sorted(py_files(any_wheel) ^ py_files(rebuilt))
+    check(not diff, f"sdist 重建 wheel 与 any wheel 的 .py 清单一致（差异 {len(diff)} 项: {diff[:5]}）")
+
 if failures:
     print(f"\n{len(failures)} 项校验失败", file=sys.stderr)
     sys.exit(1)

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# SwanLab 多平台 release 构建脚本。
+#
+# 产物：1 sdist + 1 any 兜底 wheel + 6 平台 wheel（内嵌交叉编译的 Go core）。
+# 交叉编译与平台 tag 写入由 hatch_build.py 构建钩子完成，
+# 本脚本负责切环境变量逐平台构建，以及产物完整性校验。
+#
+# 用法：
+#   bash scripts/build_release.sh [VERSION]      # 更新版本号并构建全部产物，随后校验
+#   bash scripts/build_release.sh                # 使用 swanlab/package.json 现有版本
+#   bash scripts/build_release.sh --verify-only  # 仅校验已有 dist/，不构建
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PLATFORMS=(
+  "manylinux_2_17_x86_64.manylinux2014_x86_64"   # linux/amd64
+  "manylinux_2_17_aarch64.manylinux2014_aarch64" # linux/arm64
+  "win_amd64"                                    # windows/amd64
+  "win_arm64"                                    # windows/arm64
+  "macosx_12_0_x86_64"                           # darwin/amd64
+  "macosx_12_0_arm64"                            # darwin/arm64
+)
+
+VERIFY_ONLY=false
+VERSION=""
+for arg in "$@"; do
+  case "$arg" in
+    --verify-only) VERIFY_ONLY=true ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) VERSION="$arg" ;;
+  esac
+done
+
+if [ "$VERIFY_ONLY" = false ]; then
+  # 0. 版本号（沿用 make build 的写回逻辑）
+  if [ -n "$VERSION" ]; then
+    python3 -c "import json; data=json.load(open('swanlab/package.json')); data['version']='$VERSION'; json.dump(data,open('swanlab/package.json','w'),indent=2)"
+    echo "==> Updated swanlab/package.json version to $VERSION"
+  fi
+
+  # 1. 清理旧产物
+  rm -rf dist swanlab/bin
+
+  # 2. sdist + any 兜底 wheel（不设 SWANLAB_BUILD_PLATFORM，钩子零动作）
+  echo "==> Building sdist + fallback any wheel"
+  uv build --sdist
+  uv build --wheel
+
+  # 3. 逐平台交叉编译（钩子内完成：go build + 原生平台 tag + artifacts 注入）
+  for TAG in "${PLATFORMS[@]}"; do
+    echo "==> Building platform wheel: $TAG"
+    SWANLAB_BUILD_PLATFORM="$TAG" uv build --wheel
+    rm -rf swanlab/bin # 清理，避免污染下一平台
+  done
+fi
+
+# 4. 校验
+echo "==> twine check"
+uvx twine check dist/*
+
+echo "==> 结构校验"
+python3 - <<'PY'
+import pathlib
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+DIST = pathlib.Path("dist")
+
+# tag -> (二进制文件名, file 输出需命中的关键词，任一命中即可)
+PLATFORMS = {
+    "manylinux_2_17_x86_64.manylinux2014_x86_64": ("swanlab-core", ["elf", "x86-64"]),
+    "manylinux_2_17_aarch64.manylinux2014_aarch64": ("swanlab-core", ["elf", "aarch64"]),
+    "win_amd64": ("swanlab-core.exe", ["pe32+", "x86-64", "x86_64"]),
+    "win_arm64": ("swanlab-core.exe", ["pe32+", "aarch64", "arm64"]),
+    "macosx_12_0_x86_64": ("swanlab-core", ["mach-o", "x86_64"]),
+    "macosx_12_0_arm64": ("swanlab-core", ["mach-o", "arm64"]),
+}
+
+failures = []
+
+
+def check(cond, msg):
+    print(("PASS  " if cond else "FAIL  ") + msg)
+    if not cond:
+        failures.append(msg)
+
+
+def wheel_version(name):
+    m = re.fullmatch(r"swanlab-(.+)-py3-none-(.+)\.whl", name)
+    return (m.group(1), m.group(2)) if m else None
+
+
+wheels = sorted(DIST.glob("swanlab-*-py3-none-*.whl"))
+sdists = sorted(DIST.glob("swanlab-*.tar.gz"))
+parsed = [wheel_version(w.name) for w in wheels]
+check(all(p is not None for p in parsed), "wheel 文件名均可解析")
+check(len(sdists) == 1, f"恰好 1 个 sdist（实际 {len(sdists)}）")
+
+# 版本一致性：所有产物（含 sdist）使用同一版本串
+versions = {p[0] for p in parsed if p} | {re.fullmatch(r"swanlab-(.+)\.tar\.gz", s.name).group(1) for s in sdists}
+check(len(versions) == 1, f"全部产物版本一致（实际 {versions}）")
+
+# 产物齐全：any 兜底 + 6 平台 wheel，无多余文件
+tags = {p[1] for p in parsed if p}
+check(tags == set(PLATFORMS) | {"any"}, f"wheel tag 齐全（多出: {sorted(tags - set(PLATFORMS) - {'any'})}, 缺少: {sorted(set(PLATFORMS) - tags)}）")
+
+for whl in wheels:
+    tag = wheel_version(whl.name)[1]
+    with zipfile.ZipFile(whl) as zf:
+        names = zf.namelist()
+        has_binary = any(n.startswith("swanlab/bin/") for n in names)
+
+        if tag == "any":
+            check(not has_binary, "any wheel 不含二进制")
+            continue
+
+        exe = PLATFORMS[tag][0]
+        entry = f"swanlab/bin/{exe}"
+        if entry not in names:
+            check(False, f"{tag}: 缺少 {entry}")
+            continue
+
+        mode = zf.getinfo(entry).external_attr >> 16
+        check(mode & 0o111 != 0, f"{tag}: 二进制含可执行位")
+
+        with tempfile.TemporaryDirectory() as td:
+            extracted = zf.extract(entry, td)
+            desc = subprocess.run(["file", "-b", str(extracted)], capture_output=True, text=True).stdout.lower()
+        check(any(k in desc for k in PLATFORMS[tag][1]), f"{tag}: file 架构匹配（{desc.strip()}）")
+
+        if tag.startswith("manylinux"):
+            # glibc tag 双写：WHEEL 元数据需逐条展开为多行 Tag:
+            meta_name = next(n for n in names if n.endswith(".dist-info/WHEEL"))
+            meta = zf.read(meta_name).decode()
+            lines = [ln.split(": ", 1)[1] for ln in meta.splitlines() if ln.startswith("Tag:")]
+            expected = {f"py3-none-{t}" for t in tag.split(".")}
+            check(expected <= set(lines), f"{tag}: WHEEL 元数据多行 Tag 展开（实际 {lines}）")
+
+# sdist：不含 core/ 源码与二进制，但必须携带构建钩子（保证从 sdist 重建 wheel 可行）
+with tarfile.open(sdists[0]) as tf:
+    members = tf.getnames()
+check(any(m.count("/") == 1 and m.endswith("/hatch_build.py") for m in members), "sdist 携带 hatch_build.py")
+check(not any(m.count("/") == 1 and m.split("/")[1] == "core" for m in members), "sdist 不含 core/ 源码")
+check(not any("/swanlab/bin/" in m for m in members), "sdist 不含二进制")
+
+if failures:
+    print(f"\n{len(failures)} 项校验失败", file=sys.stderr)
+    sys.exit(1)
+print("\nAll checks passed.")
+PY
+
+echo "==> Done"

--- a/uv.lock
+++ b/uv.lock
@@ -1274,6 +1274,59 @@ wheels = [
 ]
 
 [[package]]
+name = "hatchling"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10' and sys_platform == 'linux'",
+    "python_full_version < '3.10' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8a/cc1debe3514da292094f1c3a700e4ca25442489731ef7c0814358816bb03/hatchling-1.27.0.tar.gz", hash = "sha256:971c296d9819abb3811112fc52c7a9751c8d381898f36533bb16f9791e941fd6", size = 54983, upload-time = "2024-12-15T17:08:11.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/e7/ae38d7a6dfba0533684e0b2136817d667588ae3ec984c1a4e5df5eb88482/hatchling-1.27.0-py3-none-any.whl", hash = "sha256:d3a2f3567c4f926ea39849cdf924c7e99e6686c9c8e288ae1037c8fa2a5d937b", size = 75794, upload-time = "2024-12-15T17:08:10.364Z" },
+]
+
+[[package]]
+name = "hatchling"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'linux'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*' and sys_platform == 'linux'",
+    "python_full_version == '3.10.*' and sys_platform != 'linux'",
+]
+dependencies = [
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pluggy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+    { name = "trove-classifiers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/08/33331757185504aae48b8d9bd78cec03a76e3aecfb52e549d05a2347c0dd/hatchling-1.32.0.tar.gz", hash = "sha256:0bdbde4a52b06c37e3eca395f85a762bf0ef06fe374fd8ae429dc6be10230f5f", size = 57783, upload-time = "2026-08-11T05:03:44.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/84/1798b6d85ecde0e31546004efd25c5de1b1f49250644a60cce460e12593a/hatchling-1.32.0-py3-none-any.whl", hash = "sha256:0e17c9c3b9aa7c625acc8d0f5b622f107d5049af9ecf5ada4de1aada5be7cdbc", size = 78435, upload-time = "2026-08-11T05:03:42.644Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -3187,6 +3240,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -5227,6 +5289,8 @@ dev = [
     { name = "build" },
     { name = "freezegun" },
     { name = "grpcio-tools" },
+    { name = "hatchling", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "hatchling", version = "1.32.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ipykernel", version = "6.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ipykernel", version = "7.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -5300,6 +5364,7 @@ dev = [
     { name = "build" },
     { name = "freezegun" },
     { name = "grpcio-tools" },
+    { name = "hatchling", specifier = ">=1.18" },
     { name = "ipykernel" },
     { name = "ipython" },
     { name = "mmengine" },
@@ -5430,6 +5495,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]
@@ -5754,6 +5828,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概述

为 Go core 接入做准备，搭建多平台发包脚手架。**仅搭建 skeleton，SDK 运行时暂不接入 Go core**，待 core 开发完毕后再启用实际构建发布。

## 变更内容

- `core/cmd/swanlab-core/main.go`：进程入口骨架——`--version`（构建期 ldflags 注入 version/commit）、`unix://` / `tcp://` 端点监听、父进程退出监控 + SIGINT/SIGTERM 优雅退出（防孤儿进程）；gRPC 服务后续迭代接入
- `core/hatch.py`：Go 编译封装，`CGO_ENABLED=0` 静态交叉编译，产物输出至 `swanlab/bin/swanlab-core(.exe)`
- `hatch_build.py`：hatchling 构建钩子，由 `SWANLAB_BUILD_PLATFORM` 唯一驱动——未设置时零动作产出纯 any wheel；设置时交叉编译 Go core 并写入平台 tag + artifacts
- `scripts/build_release.sh`：一键发布构建 + 校验（twine check、二进制架构/可执行位、manylinux 双 tag 展开、sdist 可重建性）
- `Makefile`：新增 `core-bin`（本机联调）/ `release-build` / `release-verify`
- `pyproject.toml`：注册构建钩子，限定 `hatchling>=1.18`；sdist 排除根目录 `/core`（锚定写法，避免误伤嵌套同名目录）

## Release 产物形态

| 产物 | tag | 说明 |
|---|---|---|
| sdist | — | 不含 Go 源码，从 sdist 构建恒为纯 wheel（源码兜底） |
| 兜底 wheel | `py3-none-any` | 纯 Python 运行时（core_python），any 平台可用 |
| linux/amd64 | `py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64` | 内嵌 Go core |
| linux/arm64 | `py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64` | 内嵌 Go core |
| windows/amd64 | `py3-none-win_amd64` | 内嵌 Go core |
| windows/arm64 | `py3-none-win_arm64` | 内嵌 Go core |
| macos/x86_64 | `py3-none-macosx_12_0_x86_64` | 内嵌 Go core |
| macos/arm64 | `py3-none-macosx_12_0_arm64` | 内嵌 Go core |

安装优先级：平台 wheel → any 兜底 wheel → sdist 源码构建。musllinux 以 alhpine, slim 基础镜像的 linux 发行版暂不做支持（静态 Go 二进制实际可运行，hook 解析层保留前缀兼容）。

## 验证

- `bash scripts/build_release.sh` 全量构建：8 个产物齐全、版本一致，twine check 全 PASSED，19 项结构校验全 PASS（含可执行位、`file` 架构匹配、WHEEL 多行 Tag 展开、sdist 重建 wheel 与 checkout 直建 `.py` 清单一致）
- any wheel 在本地存在 `swanlab/bin/` 时无二进制泄漏
- `go vet` / `go test ./internal/pkg/process` / `ruff check` 通过；CI 全绿（Python 3.9–3.14 × 三平台 + Go lint）
