### PR TITLE
chore: add docs/plans directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ GEMINI.md
 QWEN.md
 .omx/
 .opencode/
+docs/plans
 CODEBUDDY.md
 .codegraph/
 .mimocode/


### PR DESCRIPTION
## Summary

在 `.gitignore` 中新增 `docs/plans` 目录，用于忽略本地文档规划文件，避免其被纳入版本控制。

## Changes

- `.gitignore`：新增 `docs/plans` 条目

## Testing

未运行测试（仅涉及 `.gitignore` 变更，不影响代码逻辑）。

## Notes

无