### PR TITLE
chore: update author emails in project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Python library for streamlined tracking and management of AI trai
 requires-python = ">=3.9"
 authors = [
     { name = "Cunyue", email = "kang.li@emotionmachine.cn" },
-    { name ="CaddiesNew", email = "shaobo.niu@emotionmachine.cn" },
+    { name = "CaddiesNew", email = "shaobo.niu@emotionmachine.cn" },
     { name = "ZeYi Lin", email = "zeyi.lin@emotionmachine.cn" },
     { name = "Kaikaikaifang", email = "kaifang.ji@emotionmachine.cn" },
     { name = "Feudalman", email = "zirui.cai@emotionmachine.cn" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ license = "Apache-2.0"
 description = "Python library for streamlined tracking and management of AI training processes."
 requires-python = ">=3.9"
 authors = [
-    { name = "Cunyue", email = "team@swanhub.co" },
-    { name = "ZeYi Lin", email = "team@swanhub.co" },
-    { name = "Kaikaikaifang", email = "team@swanhub.co" },
-    { name = "Feudalman", email = "team@swanhub.co" },
+    { name = "Cunyue", email = "kang.li@emotionmachine.cn" },
+    { name ="CaddiesNew", email = "shaobo.niu@emotionmachine.cn" },
+    { name = "ZeYi Lin", email = "zeyi.lin@emotionmachine.cn" },
+    { name = "Kaikaikaifang", email = "kaifang.ji@emotionmachine.cn" },
+    { name = "Feudalman", email = "zirui.cai@emotionmachine.cn" },
 ]
 keywords = [
     "machine learning",


### PR DESCRIPTION
## Summary

更新 `pyproject.toml` 中的作者元数据，将统一的团队邮箱 `team@swanhub.co` 替换为各作者的个人邮箱，并新增作者 `CaddiesNew`。

## Changes

- 更新 `Cunyue`、`ZeYi Lin`、`Kaikaikaifang`、`Feudalman` 的作者邮箱为个人邮箱
- 新增作者 `CaddiesNew`（`shaobo.niu@emotionmachine.cn`）
- 修正新增作者条目 `name` 与 `=` 之间的空格格式

## Testing

未运行测试（纯元数据变更，不影响代码运行）。

## Notes

- 仅涉及 `pyproject.toml` 的 `[project].authors` 字段，无代码行为变更。
- 邮箱域名由 `team@swanhub.co` 变更为 `@emotionmachine.cn`，请确认是否符合预期。
