### PR TITLE
chore: deprecate unused fmt validators

### DIFF
--- a/swanlab/deprecated/fmt.py
+++ b/swanlab/deprecated/fmt.py
@@ -1,0 +1,52 @@
+"""
+@author: caddiesnew
+@description: run.fmt 中随 define_scalar 移除而失去调用方的校验函数，v0.11 删除
+"""
+
+import warnings
+
+from typing_extensions import deprecated
+
+from swanlab.sdk.internal.pkg import constraints
+
+
+@deprecated("`safe_validate_chart_name()` has no callers and will be removed in v0.11.")
+def safe_validate_chart_name(name):
+    """
+    检查并清洗图表名称，如果出现非法字符或长度超过限制，返回 None。
+
+    :param name: 待检查的图表名称
+    :return: 清洗后的图表名称或 None
+    """
+    warnings.warn(
+        "`safe_validate_chart_name()` has no callers and will be removed in v0.11.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    if name is None:
+        return None
+    try:
+        return constraints.ta_chart_name.validate_python(name)
+    except Exception:
+        return None
+
+
+@deprecated("`safe_validate_color()` has no callers and will be removed in v0.11.")
+def safe_validate_color(color):
+    """
+    检查并清洗颜色字符串格式，必须是#开头的十六进制颜色代码
+
+    :param color: 待检查的颜色字符串
+    :return: 清洗后的颜色字符串或 None
+    """
+    warnings.warn(
+        "`safe_validate_color()` has no callers and will be removed in v0.11.",
+        FutureWarning,
+        stacklevel=2,
+    )
+    if color is None:
+        return None
+    try:
+        return constraints.ta_hex_color.validate_python(color)
+    except Exception:
+        return None

--- a/swanlab/sdk/internal/run/components/consumer/resolver/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/resolver/__init__.py
@@ -133,12 +133,11 @@ class DefinitionResolver:
     # ── concrete 解析 ──────────────────────────────────────────
 
     def resolve_concrete(self, key: str, metric_class: str) -> ConcreteState:
-        """为 log 中的 key 解析 concrete definition。
+        """为 log 中的 key 解析 concrete 定义，首次调用时注册并冻结快照。
 
-        首次调用时按 exact → glob → automatic 优先级解析并注册 key；之后同一
-        (metric_class, key) 的所有调用直接返回首次快照，不再升级或回溯——
-        这同时钉住了 "key 首次 log 后 define 不再生效" 的契约（automatic 状态
-        表示该 key 在无定义下被 log 过，后续 define 无法认领）。
+        解析优先级：exact > 最长前缀 glob > automatic。首次调用（log）按命中结果注册 ConcreteState；
+        之后同一 (metric_class, key) 的调用直接返回该快照，不再受后续 define_metric 影响。
+        这意味着一旦log，后续 define_metric 对已出现的 key 不再回溯修改图表定义，遵循 first-writer-wins的原则。
         """
         cache_key = (metric_class, key)
         existing = self._concrete.get(cache_key)

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -146,21 +146,6 @@ def safe_validate_name(name: Optional[str]) -> Optional[str]:
         return None
 
 
-def safe_validate_chart_name(name: Optional[str]) -> Optional[str]:
-    """
-    检查并清洗图表名称，如果出现非法字符或长度超过限制，返回 None。
-
-    :param name: 待检查的图表名称
-    :return: 清洗后的图表名称或 None
-    """
-    if name is None:
-        return None
-    try:
-        return constraints.ta_chart_name.validate_python(name)
-    except ValidationError:
-        return None
-
-
 def safe_validate_x_axis(x_axis: Optional[ScalarXAxisType]) -> Optional[ScalarXAxisType]:
     """
     校验 ``define_metric`` 的 x 轴值，非法时返回 None。
@@ -177,22 +162,7 @@ def safe_validate_x_axis(x_axis: Optional[ScalarXAxisType]) -> Optional[ScalarXA
         return x_axis
     if helper.is_system_key(x_axis):
         return None
-    return safe_validate_key(x_axis)
-
-
-def safe_validate_color(color: Optional[str]) -> Optional[str]:
-    """
-    检查并清洗颜色字符串格式，必须是#开头的十六进制颜色代码
-
-    :param color: 待检查的颜色字符串
-    :return: 清洗后的颜色字符串或 None
-    """
-    if color is None:
-        return None
-    try:
-        return constraints.ta_hex_color.validate_python(color)
-    except ValidationError:
-        return None
+        return safe_validate_key(x_axis)
 
 
 def safe_validate_state(state: FinishType) -> Optional[FinishType]:


### PR DESCRIPTION
## Summary

将随 `define_scalar` 移除（#1733）而失去全部调用方的两个校验函数移入 `swanlab/deprecated/` 并附带 FutureWarning，为 v0.11 删除做准备（#1753）；顺带润色 `resolve_concrete` 的 docstring。

## Changes

- 新增 `swanlab/deprecated/fmt.py`：`safe_validate_chart_name()` / `safe_validate_color()` 迁入，调用时发出 FutureWarning（提示 v0.11 移除），校验逻辑不变
- `swanlab/sdk/internal/run/fmt.py` 删除上述两函数
- `resolver.resolve_concrete` docstring 润色：明确解析优先级（exact > 最长前缀 glob > automatic）、快照冻结与 first-writer-wins 契约

## Testing

- `uv run pytest`：1758 passed，21 skipped
- `uv run ruff check .`：通过
- `uv run basedpyright`：0 errors

## Notes

- 两函数在 main 上即无调用方（唯一引用位于 `define_scalar` 被注释的 TODO 实现中），本 PR 无行为变化
- `swanlab/deprecated/fmt.py` 将于 v0.11 删除（#1753 §3 技术债务）
