### PR TITLE
fix: all custom keys return none

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ import swanlab
 # 初始化一个新的swanlab实验
 swanlab.init(
     project="my-first-ml",
-    config={'learning-rate': 0.003},
+    config={"learning-rate": 0.003},
 )
 
 # 记录指标

--- a/README_EN.md
+++ b/README_EN.md
@@ -318,7 +318,7 @@ import swanlab
 # Initialize a new SwanLab experiment
 swanlab.init(
     project="my-first-ml",
-    config={'learning-rate': 0.003},
+    config={"learning-rate": 0.003},
 )
 
 # Log metrics

--- a/README_JP.md
+++ b/README_JP.md
@@ -298,7 +298,7 @@ import swanlab
 # 新しいSwanLab実験を初期化
 swanlab.init(
     project="my-first-ml",
-    config={'learning-rate': 0.003},
+    config={"learning-rate": 0.003},
 )
 
 # 指標を記録

--- a/README_RU.md
+++ b/README_RU.md
@@ -302,7 +302,7 @@ import swanlab
 # Инициализация нового эксперимента SwanLab
 swanlab.init(
     project="my-first-ml",
-    config={'learning-rate': 0.003},
+    config={"learning-rate": 0.003},
 )
 
 # Запись метрик

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -266,7 +266,7 @@ class BackgroundConsumer(ConsumerProtocol):
             # 3.3 如果用户在本次 event 里显式 log 了 X 值，则不注入
             if x_axis in data or x_axis in candidate_x:
                 continue
-            # 3.4 从 cache 取最近真实 X 值；X 尚无任何真实值时注入默认 0（对齐 wandb 的 step_sync 语义），
+            # 3.4 从 cache 取最近真实 X 值；X 尚无任何真实值时注入默认 0，
             # 使 X 序列从首个绑定 Y 的 step 起出现，而非等到 X 自身首次 log
             cached_x = self._resolver.get_custom_x(x_axis)
             if cached_x is None:

--- a/swanlab/sdk/internal/run/components/consumer/__init__.py
+++ b/swanlab/sdk/internal/run/components/consumer/__init__.py
@@ -266,10 +266,11 @@ class BackgroundConsumer(ConsumerProtocol):
             # 3.3 如果用户在本次 event 里显式 log 了 X 值，则不注入
             if x_axis in data or x_axis in candidate_x:
                 continue
-            # 3.4 从 cache 取最近真实 X 值
+            # 3.4 从 cache 取最近真实 X 值；X 尚无任何真实值时注入默认 0（对齐 wandb 的 step_sync 语义），
+            # 使 X 序列从首个绑定 Y 的 step 起出现，而非等到 X 自身首次 log
             cached_x = self._resolver.get_custom_x(x_axis)
             if cached_x is None:
-                continue
+                cached_x = 0.0
             candidate_x[x_axis] = cached_x
 
         # 4. 把本次 log 的每个 key 变成 record，包括：

--- a/swanlab/sdk/internal/run/fmt.py
+++ b/swanlab/sdk/internal/run/fmt.py
@@ -162,7 +162,7 @@ def safe_validate_x_axis(x_axis: Optional[ScalarXAxisType]) -> Optional[ScalarXA
         return x_axis
     if helper.is_system_key(x_axis):
         return None
-        return safe_validate_key(x_axis)
+    return safe_validate_key(x_axis)
 
 
 def safe_validate_state(state: FinishType) -> Optional[FinishType]:

--- a/tests/unit/sdk/internal/run/components/consumer/test_consumer_step_sync.py
+++ b/tests/unit/sdk/internal/run/components/consumer/test_consumer_step_sync.py
@@ -112,6 +112,36 @@ def test_step_sync_does_not_inject_shared_x_twice_at_same_step(tmp_path: Path):
     assert records["epoch"][0].timestamp == _timestamp(20)
 
 
+def test_step_sync_injects_default_zero_before_first_real_x(tmp_path: Path):
+    """X 从未 log 过时，绑定 Y 触发注入默认 0，X 序列从首个绑定 Y 的 step 出现（对齐 wandb）。"""
+    consumer = _make_consumer(tmp_path)
+    consumer._handle_event(MetricDefineEvent("train/acc", x_axis="epoch"))
+    start = len(consumer._scalar_batch)
+
+    _log(consumer, {"train/acc": 0.9}, step=0, seconds=10)
+
+    records = _records_by_key(consumer, start)
+    assert set(records) == {"train/acc", "epoch"}
+    assert records["epoch"][0].value.number == 0
+    assert records["epoch"][0].step == 0
+    assert records["epoch"][0].timestamp == _timestamp(10)
+
+
+def test_step_sync_default_zero_at_each_y_step_then_forward_fill_after_real_x(tmp_path: Path):
+    """无值窗口内每个 Y event 在各自 step 注入 0；真实 X 到达后恢复取最近真实值。"""
+    consumer = _make_consumer(tmp_path)
+    consumer._handle_event(MetricDefineEvent("train/acc", x_axis="epoch"))
+    consumer._handle_event(MetricDefineEvent("train/loss", x_axis="epoch"))
+
+    _log(consumer, {"train/acc": 0.9}, step=0, seconds=10)
+    _log(consumer, {"train/loss": 0.1}, step=1, seconds=20)
+    _log(consumer, {"epoch": 3}, step=2, seconds=30)
+    _log(consumer, {"train/acc": 0.8}, step=3, seconds=40)
+
+    epoch_records = [r for r in consumer._scalar_batch if r.key == "epoch"]
+    assert [(r.step, r.value.number) for r in epoch_records] == [(0, 0), (1, 0), (2, 3), (3, 3)]
+
+
 def test_real_x_after_injected_x_warns_once_and_updates_next_step_cache(tmp_path: Path, monkeypatch):
     warnings = []
     monkeypatch.setattr(


### PR DESCRIPTION
## 问题

`safe_validate_x_axis` 中 `return safe_validate_key(x_axis)` 错误缩进进 `if` 块，成为 `return None` 之后的死代码：所有自定义 x_axis 一律返回 None，被 `define_metric` 判为非法，custom x_axis / step_sync 全部失效。

## 修复

1. **fmt.py**：修正缩进，非 system key 的 x_axis 正常走 `safe_validate_key` 校验。
2. 【语义对齐】**step_sync 注入语义对齐 wandb**：X 尚无任何真实值时，绑定 Y 触发注入默认 `0`（原实现跳过注入），X 序列从首个绑定 Y 的 step 出现。注入不回写 cache，真实 X 到达后自动恢复 forward-fill。

Y 先于 X 首次 log 的场景，X 序列对照：

| step | 事件 | wandb step_sync | 修改前 | 修改后 |
|---|---|---|---|---|
| 0 | acc（X 无值） | (0, 0) | 无点 | (0, 0) |
| 1 | loss（X 无值） | (1, 0) | 无点 | (1, 0) |
| 2 | 真实 x=3 | (2, 3) | (2, 3) | (2, 3) |
| 3 | acc（forward-fill） | (3, 3) | (3, 3) | (3, 3) |

## 测试

- `tests/unit/sdk/internal/run/components/consumer/test_consumer_step_sync.py` 新增 2 个用例：无值注入默认 0；无值窗口逐 Y 注入 + 真实值到达后 forward-fill
- `uv run pytest tests/unit/sdk/internal/run/ -q` 666 passed

