### PR TITLE
chore: sync __all__ exports and drop dead sync cleanup

### DIFF
--- a/swanlab/sdk/internal/core_python/pkg/builder/__init__.py
+++ b/swanlab/sdk/internal/core_python/pkg/builder/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "build_auto_column",
     "build_resume_column",
     "build_save_record",
+    "build_column_record",
 ]
 
 

--- a/swanlab/sdk/internal/core_python/sync.py
+++ b/swanlab/sdk/internal/core_python/sync.py
@@ -323,7 +323,6 @@ class CoreSyncPython(CoreSyncProtocol):
                     state=finish_record.state,
                     finished_at=finish_record.finished_at,
                 )
-                self._pending_online_finish_record = None
                 return ConfirmSyncFinishResponse(success=True, message="OK")
                 # 如果仅仅是与后端同步出现问题，则换一个让用户安心一些的提示信息
             return ConfirmSyncFinishResponse(

--- a/swanlab/sdk/internal/pkg/adapter/__init__.py
+++ b/swanlab/sdk/internal/pkg/adapter/__init__.py
@@ -15,7 +15,7 @@ from swanlab.proto.swanlab.terminal.v1.log_pb2 import LogLevel
 
 from .bimap import BiMap
 
-__all__ = ["resume", "medium", "state", "level", "policy", "memory_unit", "accelerator_vendor"]
+__all__ = ["resume", "medium", "column", "state", "level", "policy", "memory_unit", "accelerator_vendor"]
 
 
 resume = BiMap(


### PR DESCRIPTION
## Summary

本次是一次小的代码整洁（chore），不涉及任何运行时行为变化：

1. 补齐两处 `__all__` 声明漂移；
2. 删除一处 sync 侧复制残留的死代码。

## Changes

- `swanlab/sdk/internal/pkg/adapter/__init__.py`
  - `__all__` 补充缺失的 `column`（该 `BiMap` 被 `transport/sender.py` 与 `deprecated/sender.py` 引用）。
- `swanlab/sdk/internal/core_python/pkg/builder/__init__.py`
  - `__all__` 补充缺失的 `build_column_record`（被 `core.py` 与 `sync.py` 引用）。
- `swanlab/sdk/internal/core_python/sync.py`
  - 删除 `confirm_sync_finish` 中残留的 `self._pending_online_finish_record = None` 赋值；该属性仅存在于 `CorePython`（core.py），`CoreSyncPython` 从不读取，属复制残留。

## Testing

- `uv run ruff check`（针对 3 个改动文件）：通过
- `uv run pytest tests/unit/sdk/internal/core_python/test_core_sync.py`：19 passed

未运行完整单测套件。

## Notes

- 纯声明与死代码清理，无兼容性影响，无新增对外行为。
